### PR TITLE
Rework npx release

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To build and run the Busola for `npx` mode:
 - Run `npm run build` in `/shared`.
 - Run `npm run build:npx` in `/core`, `/core-ui` and `/backend`.
 - Export a kubeconfig in your terminal.
-- Run `node backend-npx.js` in `/backend` to start the app.
+- Run `node index-npx.js` in `/backend` to start the app.
 
 ## Development
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "APIserver proxy for Busola",
   "main": "backend.index.js",
-  "bin": "backend-npx.js",
+  "bin": "index-npx.js",
   "scripts": {
     "start:kyma": "npm run watch",
     "start:npx": "NODE_ENV=npx nodemon --exec babel-node index-npx.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
   "license": "Apache-2.0",
+  "name": "@kyma-project/busola",
+  "version": "0.0.1-rc.4",
   "scripts": {
     "bootstrap": "npm install && npm run install:libraries && npm run build:libraries && npm run install:apps && npm run append-hosts && npm run generate-cluster-config",
     "bootstrap:ci": "npm ci && npm run ci:libraries && npm run build:libraries",

--- a/scripts/npx-release.sh
+++ b/scripts/npx-release.sh
@@ -1,0 +1,13 @@
+
+# make a backup of backend package.json
+cp ../backend/package.json ../backend/package-org.json
+
+# get values from current root package.json and set them into target package.json
+NAME=$(jq -r '.name' ../package.json)
+VERSION=$(jq -r '.version' ../package.json)
+echo $(jq ". |= . + {\"version\": \"$VERSION\", \"name\": \"$NAME\"}" ../backend/package.json) > ../backend/package.json
+
+npm publish ../backend
+
+# restore backend package.json
+mv ../backend/package-org.json ../backend/package.json


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- It turns out we can't `npm publish` from the root folder - all the libraries from the root package.json would be installed. Instead, I've added a script `scripts/npx-release.sh`, which copies valid name and version from root package.json into backend one, runs `npm publish` from there and rollbacks unnecessary changes.
- Remove mysterious `localhost` file.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
