### PR TITLE
Fix APIRule status bug

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleStatus/ApiRuleStatus.js
+++ b/core-ui/src/components/ApiRules/ApiRuleStatus/ApiRuleStatus.js
@@ -22,7 +22,7 @@ const resolveAPIRuleStatus = statusCode => {
 };
 
 export default function ApiRuleStatus({ apiRule }) {
-  if (!apiRule.status.APIRuleStatus) {
+  if (!apiRule.status?.APIRuleStatus) {
     return null;
   }
 

--- a/core-ui/src/components/ApiRules/ApiRuleStatus/test/ApiRuleStatus.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleStatus/test/ApiRuleStatus.test.js
@@ -1,23 +1,36 @@
-// import React from 'react';
-// import { render } from '@testing-library/react';
+import React from 'react';
+import { render } from '@testing-library/react';
 
-// import ApiRuleStatus from '../ApiRuleStatus';
+import ApiRuleStatus from '../ApiRuleStatus';
 
 describe('ApiRuleStatus', () => {
-  test.todo('ApiRuleStatus');
-  //   it('Renders with minimal props', () => {
-  //     const apiRule = {
-  //       status: {
-  //         apiRuleStatus: {
-  //           code: 'OK',
-  //           desc: '',
-  //         },
-  //       },
-  //     };
-  //     const { queryByRole } = render(<ApiRuleStatus apiRule={apiRule} />);
+  it('Renders nothing if status is none', () => {
+    const apiRule = { status: null };
+    const { queryByRole } = render(<ApiRuleStatus apiRule={apiRule} />);
+    expect(queryByRole('status')).not.toBeInTheDocument();
+  });
 
-  //     const statusText = queryByRole('status');
-  //     expect(statusText).toBeInTheDocument();
-  //     expect(statusText).toHaveTextContent('OK');
-  //   });
+  it('Renders nothing if status.APIRuleStatus is none', () => {
+    const apiRule = {
+      status: { APIRuleStatus: null },
+    };
+    const { queryByRole } = render(<ApiRuleStatus apiRule={apiRule} />);
+    expect(queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('Renders with minimal props', () => {
+    const apiRule = {
+      status: {
+        APIRuleStatus: {
+          code: 'OK',
+          desc: '',
+        },
+      },
+    };
+    const { queryByRole } = render(<ApiRuleStatus apiRule={apiRule} />);
+
+    const statusText = queryByRole('status');
+    expect(statusText).toBeInTheDocument();
+    expect(statusText).toHaveTextContent('OK');
+  });
 });


### PR DESCRIPTION
**Description**

Well, despite creating like 20 apirules I didn't manage to reproduce this bug, but I have seen it myself before, so I decided to just add a bonus check for them, to be safe.
![image](https://user-images.githubusercontent.com/10504661/111759169-9cfcfa80-889d-11eb-875f-9d23acfd7774.png)


Changes proposed in this pull request:

- Add a check for `apiRule.status`
- Add more test cases for APIRule status

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
