### PR TITLE
Fix Workload creation

### DIFF
--- a/core-ui/src/components/Predefined/Details/Namespace/CreateWorkloadForm/helpers.js
+++ b/core-ui/src/components/Predefined/Details/Namespace/CreateWorkloadForm/helpers.js
@@ -35,26 +35,15 @@ export function formatDeployment(deployment) {
 }
 
 export function formatService(deployment, deploymentUID) {
-  if (!deployment.labels.app) {
-    deployment.labels.app = deployment.name;
-  }
-
   const service = {
     apiVersion: 'v1',
     kind: 'Service',
     metadata: {
       name: deployment.name,
       namespace: deployment.namespace,
-      ownerReferences: [
-        {
-          kind: 'Deployment',
-          apiVersion: 'apps/v1',
-          name: deployment.name,
-          uid: deploymentUID,
-        },
-      ],
     },
     spec: {
+      selector: { app: deployment.name },
       type: 'ClusterIP',
       ports: [
         {

--- a/core-ui/src/components/Predefined/Details/Namespace/CreateWorkloadForm/test/__snapshots__/helpers.test.js.snap
+++ b/core-ui/src/components/Predefined/Details/Namespace/CreateWorkloadForm/test/__snapshots__/helpers.test.js.snap
@@ -57,14 +57,6 @@ Object {
   "metadata": Object {
     "name": "test-name",
     "namespace": "test-namespace",
-    "ownerReferences": Array [
-      Object {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "name": "test-name",
-        "uid": "test-id",
-      },
-    ],
   },
   "spec": Object {
     "ports": Array [
@@ -75,6 +67,9 @@ Object {
         "targetPort": 8080,
       },
     ],
+    "selector": Object {
+      "app": "test-name",
+    },
     "type": "ClusterIP",
   },
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use selector instead of ownerRef during service creation

**Testing**

- Create a workload from namespace details (you can use `nginx:latest` at targetPort `80`). Create apirule for the service (make sure to use `noop`, then enter the apirule `host` in the browser.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
