### PR TITLE
Add status pods to RS details

### DIFF
--- a/core-ui/src/components/Predefined/Details/Replicaset.details.js
+++ b/core-ui/src/components/Predefined/Details/Replicaset.details.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getComponentForList } from 'shared/getComponents';
+import { StatusBadge } from 'react-shared';
 
 export const ReplicasetsDetails = DefaultRenderer => ({ ...otherParams }) => {
   const customColumns = [
@@ -8,16 +9,16 @@ export const ReplicasetsDetails = DefaultRenderer => ({ ...otherParams }) => {
       value: resource => {
         const containers = resource.spec.template.spec.containers || [];
         return (
-          <>
+          <React.Fragment key="limits">
             {containers.map(c => (
-              <>
+              <React.Fragment key={c.name}>
                 CPU: {c.resources?.limits?.cpu}
                 <br />
                 Memory: {c.resources?.limits?.memory}
                 <br />
-              </>
+              </React.Fragment>
             ))}
-          </>
+          </React.Fragment>
         );
       },
     },
@@ -26,16 +27,28 @@ export const ReplicasetsDetails = DefaultRenderer => ({ ...otherParams }) => {
       value: resource => {
         const containers = resource.spec.template.spec.containers || [];
         return (
-          <>
+          <React.Fragment key="requests">
             {containers.map(c => (
-              <>
+              <React.Fragment key={c.name}>
                 CPU: {c.resources?.requests?.cpu}
                 <br />
                 Memory: {c.resources?.requests?.memory}
                 <br />
-              </>
+              </React.Fragment>
             ))}
-          </>
+          </React.Fragment>
+        );
+      },
+    },
+    {
+      header: 'Ready Replicas',
+      value: ({ status: { replicas, readyReplicas } }) => {
+        const type = (readyReplicas || 0) < replicas ? 'warning' : 'success';
+        const content = `${readyReplicas || 0} / ${replicas}`;
+        return (
+          <StatusBadge key="replicas" type={type}>
+            {content}
+          </StatusBadge>
         );
       },
     },


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add ready pods display to ReplicaSet details
- Resolve `key` issues

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
