### PR TITLE
Add status and url to Service Brokers list

### DIFF
--- a/core-ui/src/components/Predefined/List/ServiceBrokers.list.js
+++ b/core-ui/src/components/Predefined/List/ServiceBrokers.list.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { StatusBadge } from 'react-shared';
+
+export const ServiceBrokersList = DefaultRenderer => ({ ...otherParams }) => {
+  const customColumns = [
+    {
+      header: 'Url',
+      value: ({ spec }) => spec.url,
+    },
+    {
+      header: 'Status',
+      value: ({ status }) => (
+        <StatusBadge autoResolveType>{status.lastConditionState}</StatusBadge>
+      ),
+    },
+  ];
+
+  return <DefaultRenderer customColumns={customColumns} {...otherParams} />;
+};

--- a/core-ui/src/components/Predefined/List/index.js
+++ b/core-ui/src/components/Predefined/List/index.js
@@ -11,3 +11,4 @@ export * from './AddonsConfigurations.list.js';
 export * from './ReplicaSets.list.js';
 export * from './Services.list.js';
 export * from './OAuth2Clients.list.js';
+export * from './ServiceBrokers.list.js';


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- As in title. I decided not to style url as link, because it's a internal address anyway.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
