### PR TITLE
Show error on api rule create/edit error

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleForm.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleForm.js
@@ -177,15 +177,22 @@ export default function ApiRuleForm({
     const data =
       requestType === 'create' ? newApiRule : createPatch(apiRule, newApiRule);
 
-    await sendRequest(
-      injectVariables(API_RULE_URL, {
-        name: formValues.name.current.value,
-        namespace: namespace,
-      }),
-      data,
-    );
-
-    LuigiClient.uxManager().closeCurrentModal();
+    try {
+      await sendRequest(
+        injectVariables(API_RULE_URL, {
+          name: formValues.name.current.value,
+          namespace: namespace,
+        }),
+        data,
+      );
+      LuigiClient.uxManager().closeCurrentModal();
+    } catch (e) {
+      LuigiClient.uxManager().showAlert({
+        text: `Cannot create API Rule: ${e.message}`,
+        type: 'error',
+        closeAfter: 10000,
+      });
+    }
   }
 
   function addAccessStrategy() {

--- a/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleForm.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleForm.js
@@ -22,7 +22,7 @@ import ServicesDropdown from './ServicesDropdown/ServicesDropdown';
 import AccessStrategyForm from './AccessStrategyForm/AccessStrategyForm';
 import { EXCLUDED_SERVICES_LABELS } from 'components/ApiRules/constants';
 import { hasValidMethods } from 'components/ApiRules/accessStrategyTypes';
-import { useGetList } from 'react-shared';
+import { useGetList, useNotification } from 'react-shared';
 import { SERVICES_URL, API_RULE_URL } from '../constants';
 import { formatMessage as injectVariables } from 'components/Lambdas/helpers/misc';
 import { useGetGatewayDomain } from '../hooks/useGetGatewayDomain';
@@ -68,6 +68,7 @@ export default function ApiRuleForm({
     loading: domainLoading,
   } = useGetGatewayDomain();
   const namespace = LuigiClient.getEventData().environmentId;
+  const notification = useNotification();
   const { serviceName, port, openedInModal = false } =
     LuigiClient.getNodeParams() || {};
   const openedInModalBool = openedInModal.toString().toLowerCase() === 'true';
@@ -187,10 +188,8 @@ export default function ApiRuleForm({
       );
       LuigiClient.uxManager().closeCurrentModal();
     } catch (e) {
-      LuigiClient.uxManager().showAlert({
-        text: `Cannot create API Rule: ${e.message}`,
-        type: 'error',
-        closeAfter: 10000,
+      notification.notifyError({
+        content: `Cannot create API Rule: ${e.message}`,
       });
     }
   }

--- a/core-ui/src/index.scss
+++ b/core-ui/src/index.scss
@@ -183,3 +183,8 @@ li {
   clear: both;
   display: table;
 }
+
+// override fd-styles for Safari
+input[type=checkbox] {
+  -webkit-appearance: checkbox !important;
+}

--- a/core-ui/src/shared/components/Secret/SecretData.js
+++ b/core-ui/src/shared/components/Secret/SecretData.js
@@ -8,7 +8,7 @@ const SecretComponent = ({ name, value, showEncoded, isCollapsed }) => (
   <FormItem className="item-wrapper">
     <FormLabel>{name}</FormLabel>
     <div className={isCollapsed ? 'show-more-expand' : 'show-more-collapse'}>
-      {showEncoded ? btoa(value) : value}
+      {showEncoded ? value : atob(value)}
     </div>
   </FormItem>
 );

--- a/core-ui/src/shared/components/Secret/test/SecretData.test.js
+++ b/core-ui/src/shared/components/Secret/test/SecretData.test.js
@@ -4,25 +4,25 @@ import SecretData from '../SecretData';
 
 export const secret = {
   data: {
-    client_id: 'client-id',
-    client_secret: 'client-secret',
+    client_id: btoa('client-id'),
+    client_secret: btoa('client-secret'),
   },
 };
 
 export const empty_secret = {};
 
 describe('SecretData', () => {
-  const expectEncodedState = async ({ findByText, queryByText }) => {
-    expect(await findByText(btoa(secret.data.client_id))).toBeInTheDocument();
+  const expectDecodedState = async ({ findByText, queryByText }) => {
+    expect(await findByText(atob(secret.data.client_id))).toBeInTheDocument();
     expect(
-      await findByText(btoa(secret.data.client_secret)),
+      await findByText(atob(secret.data.client_secret)),
     ).toBeInTheDocument();
 
     expect(queryByText(secret.data.client_id)).not.toBeInTheDocument();
     expect(queryByText(secret.data.client_secret)).not.toBeInTheDocument();
   };
 
-  const expectDecodedState = async ({ findByText, queryByText }) => {
+  const expectEncodedState = async ({ findByText, queryByText }) => {
     expect(await findByText(secret.data.client_id)).toBeInTheDocument();
     expect(await findByText(secret.data.client_secret)).toBeInTheDocument();
 

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - containerPort: 6080
             - containerPort: 8080
         - name: core-ui
-          image: eu.gcr.io/kyma-project/busola-core-ui:PR-80
+          image: eu.gcr.io/kyma-project/busola-core-ui:PR-76
           imagePullPolicy: Always
           resources:
             # limits:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Display error on API Rule create / edit error
- Make sure checkboxes are visible on Safari
- Fix secrets details - they were doubly encoded

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes https://github.com/kyma-project/kyma/issues/10321