### PR TITLE
Fix serviceInstance creation

### DIFF
--- a/resources/web/deployment-service-catalog.yaml
+++ b/resources/web/deployment-service-catalog.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: service-catalog
-          image: eu.gcr.io/kyma-project/busola-service-catalog-ui:166fb4ee
+          image: eu.gcr.io/kyma-project/busola-service-catalog-ui:PR-78
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:

--- a/service-catalog-ui/src/components/ServiceClassDetails/CreateInstanceForm/CreateInstanceForm.js
+++ b/service-catalog-ui/src/components/ServiceClassDetails/CreateInstanceForm/CreateInstanceForm.js
@@ -198,26 +198,14 @@ export default function CreateInstanceForm({
 
     const specSC = {
       serviceClassExternalName: item.spec.externalName,
-      serviceClassRef: {
-        name: item.metadata.name,
-      },
       servicePlanExternalName: currentPlan && currentPlan.spec.externalName,
-      servicePlanRef: {
-        name: currentPlan.metadata.name,
-      },
       parameters: instanceCreateParameters,
     };
 
     const specCSC = {
       clusterServiceClassExternalName: item.spec.externalName,
-      clusterServiceClassRef: {
-        name: item.metadata.name,
-      },
       clusterServicePlanExternalName:
         currentPlan && currentPlan.spec.externalName,
-      clusterServicePlanRef: {
-        name: currentPlan.metadata.name,
-      },
       parameters: instanceCreateParameters,
     };
 


### PR DESCRIPTION


**Description**
Resolves https://github.com/kyma-project/kyma/issues/11009 on Busola side.
In short, `serviceClassRef.name` and `servicePlanRef.name` (and its cluster-wide variants) should not be provided. We should use `serviceClassExternalName` and `servicePlanExternalName` instead (and only!). Addmission hook fills the `ref` fields automatically basing on the `externalName` fields provided.


Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
