### PR TITLE
Add email to default scopes

### DIFF
--- a/core/src/assets/login.js
+++ b/core/src/assets/login.js
@@ -116,7 +116,7 @@ function onOidcFormSubmit(e) {
   const auth = {
     issuerUrl: document.querySelector('#issuer-url').value,
     clientId: document.querySelector('#client-id').value,
-    scope: 'openid',
+    scope: 'openid email',
     responseType: 'id_token',
   };
   saveInitParams({ cluster, auth });


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- It turns out `openid` scope was ok for IAS, but not enough for auth0-based OIDC.

**Related issue(s)**

