### PR TITLE
Logout fixes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1013,10 +1013,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-      "dev": true,
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@babel/runtime": "^7.13.10",
     "@kubernetes/client-node": "^0.12.3",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/core/src/luigi-config/auth.js
+++ b/core/src/luigi-config/auth.js
@@ -56,6 +56,7 @@ export const createAuth = async (authParams) => {
 
     events: {
       onLogout: () => {
+        clearInitParams();
         console.log('onLogout');
       },
       onAuthExpired: () => {

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -20,7 +20,7 @@ import {
 import { groups } from '../auth';
 import { getInitParams, clearInitParams } from '../init-params';
 
-const customLogoutFn =() => {
+const customLogoutFn = () => {
   clearInitParams();
   window.location = '/logout.html';
 };

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -20,13 +20,10 @@ import {
 import { groups } from '../auth';
 import { getInitParams, clearInitParams } from '../init-params';
 
-const params = getInitParams();
-const customLogoutFn =
-  !!params?.auth ||
-  (() => {
-    clearInitParams();
-    window.location = '/logout.html';
-  });
+const customLogoutFn =() => {
+  clearInitParams();
+  window.location = '/logout.html';
+};
 
 export let resolveNavigationNodes;
 export let navigation = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyma-project/busola",
-  "version": "0.0.1-rc.5",
+  "version": "0.0.1-rc.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "license": "Apache-2.0",
   "name": "@kyma-project/busola",
-  "version": "0.0.1-rc.5",
+  "version": "0.0.1-rc.7",
   "scripts": {
     "bootstrap": "npm install && npm run install:libraries && npm run build:libraries && npm run install:apps",
     "bootstrap:ci": "npm ci && npm run ci:libraries && npm run build:libraries",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove init params on logout
- Add @babel/runtime to backend, as npx mode requires it (this happened after adding `json-url` to backend)
```
npx @kyma-project/busola@0.0.1-rc.6
Cannot find module '@babel/runtime/helpers/interopRequireDefault'
Require stack:
- /Users/i515358/.npm/_npx/44792/lib/node_modules/@kyma-project/busola/node_modules/json-url/dist/node/index.js
- /Users/i515358/.npm/_npx/44792/lib/node_modules/@kyma-project/busola/index-npx.js
```
- Release new npx mode version


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
