### PR TITLE
Fix system namespaces filtering

### DIFF
--- a/core/src/assets/login.js
+++ b/core/src/assets/login.js
@@ -4,8 +4,9 @@ function saveInitParams(params) {
   const defaultParams = {
     config: {
       disabledNavigationNodes: '',
-      systemNamespaces:
-        'istio-system knative-eventing knative-serving kube-public kube-system kyma-backup kyma-installer kyma-integration kyma-system natss kube-node-lease kubernetes-dashboard serverless-system',
+      systemNamespaces: 'istio-system knative-eventing knative-serving kube-public kube-system kyma-backup kyma-installer kyma-integration kyma-system natss kube-node-lease kubernetes-dashboard serverless-system'.split(
+        ' '
+      ),
     },
     features: {
       bebEnabled: false,

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-core:PR-71
+          image: eu.gcr.io/kyma-project/busola-core:PR-100
           imagePullPolicy: Always
           resources:
             # limits:


### PR DESCRIPTION
**Description**

To reproduce: create NS with name 'm'. It won't show up on namespace list.

Changes proposed in this pull request:

- In case of link-created init params, we split the system namespaces in initParams.js, but in case of kubeconfig drag-n-drop created init params, they weren't split - and 'm' indeed belongs in long string of 'kyma-syste**m** kube-syste**m**...', causing the bug.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
