### PR TITLE
Remove application module from subscription section requirements

### DIFF
--- a/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetails.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetails.js
@@ -27,7 +27,6 @@ export default function LambdaDetails({ lambda, backendModules = [] }) {
   ) : null;
 
   const eventSubscriptions = backendModulesExist(backendModules, [
-    BACKEND_MODULES.APPLICATION,
     BACKEND_MODULES.EVENTING,
   ]) ? (
     <EventSubscriptionsWrapper lambda={lambda} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyma-project/busola",
-  "version": "0.0.1-rc.7",
+  "version": "0.0.1-rc.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "license": "Apache-2.0",
   "name": "@kyma-project/busola",
-  "version": "0.0.1-rc.7",
+  "version": "0.0.1-rc.8",
   "scripts": {
     "bootstrap": "npm install && npm run install:libraries && npm run build:libraries && npm run install:apps",
     "bootstrap:ci": "npm ci && npm run ci:libraries && npm run build:libraries",

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - containerPort: 6080
             - containerPort: 8080
         - name: core-ui
-          image: eu.gcr.io/kyma-project/busola-core-ui:PR-104
+          image: eu.gcr.io/kyma-project/busola-core-ui:PR-106
           imagePullPolicy: Always
           resources:
             # limits:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Turns out `application` backendmodule isn't required for displaying subscription section on lambda details - remove it!
- Bump NPX for rc.8

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
