### PR TITLE
Rework navigation contexts

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleFormHeader/ApiRuleFormHeader.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleFormHeader/ApiRuleFormHeader.js
@@ -22,7 +22,7 @@ const ApiRuleFormHeader = ({
         className="link"
         onClick={() =>
           LuigiClient.linkManager()
-            .fromContext('namespaces')
+            .fromContext('namespace')
             .navigate(`services/details/${serviceName}`)
         }
       >

--- a/core-ui/src/components/ApiRules/ApiRulesList/ApiRulesList.js
+++ b/core-ui/src/components/ApiRules/ApiRulesList/ApiRulesList.js
@@ -27,7 +27,7 @@ function editApiRuleModal(
 ) {
   if (!inSubView) {
     LuigiClient.linkManager()
-      .fromContext('namespaces')
+      .fromContext('namespace')
       .navigate(`apirules/edit/${apiRule.metadata.name}`);
     return;
   }
@@ -37,7 +37,7 @@ function editApiRuleModal(
   });
 
   LuigiClient.linkManager()
-    .fromContext('namespaces')
+    .fromContext('namespace')
     .withParams({
       serviceName: apiRule.spec.service.name,
       port: apiRule.spec.service.port,

--- a/core-ui/src/components/ApiRules/ApiRulesList/components.js
+++ b/core-ui/src/components/ApiRules/ApiRulesList/components.js
@@ -14,7 +14,6 @@ function goToApiRuleDetails(apiRule) {
 }
 
 function navigateToService(apiRule) {
-  console.log(apiRule);
   LuigiClient.linkManager()
     .fromContext('namespace')
     .navigate(`services/details/${apiRule.spec.service.name}`);

--- a/core-ui/src/components/ApiRules/ApiRulesList/components.js
+++ b/core-ui/src/components/ApiRules/ApiRulesList/components.js
@@ -9,13 +9,14 @@ import { getApiRuleUrl } from 'components/ApiRules/helpers';
 
 function goToApiRuleDetails(apiRule) {
   LuigiClient.linkManager()
-    .fromContext('namespaces')
+    .fromContext('namespace')
     .navigate(`apirules/details/${apiRule.metadata.name}`);
 }
 
 function navigateToService(apiRule) {
+  console.log(apiRule);
   LuigiClient.linkManager()
-    .fromContext('namespaces')
+    .fromContext('namespace')
     .navigate(`services/details/${apiRule.spec.service.name}`);
 }
 

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Configuration/ServiceBindings/ServiceBindings.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Configuration/ServiceBindings/ServiceBindings.js
@@ -66,7 +66,7 @@ export default function ServiceBindings({
       data-test-id="service-instance-name"
       onClick={() =>
         LuigiClient.linkManager()
-          .fromContext('namespaces')
+          .fromContext('namespace')
           .navigate(`instances/details/${serviceBinding.spec.instanceRef.name}`)
       }
     >

--- a/core-ui/src/components/Lambdas/hooks/useCreateLambda.js
+++ b/core-ui/src/components/Lambdas/hooks/useCreateLambda.js
@@ -49,7 +49,7 @@ export const useCreateLambda = ({ redirect = true }) => {
 
       if (redirect) {
         LuigiClient.linkManager()
-          .fromContext('namespaces')
+          .fromContext('namespace')
           .navigate(`functions/details/${name}`);
       }
     } catch (err) {

--- a/core-ui/src/components/Predefined/Details/ApiRules.details.js
+++ b/core-ui/src/components/Predefined/Details/ApiRules.details.js
@@ -45,7 +45,7 @@ export const ApiRulesDetails = ({ DefaultRenderer, ...otherParams }) => {
         option="transparent"
         onClick={() =>
           LuigiClient.linkManager()
-            .fromContext('namespaces')
+            .fromContext('namespace')
             .withParams({
               serviceName: apirule.spec.service.name,
               port: apirule.spec.service.port,

--- a/core-ui/src/components/Predefined/Details/Application/ApplicationServices.js
+++ b/core-ui/src/components/Predefined/Details/Application/ApplicationServices.js
@@ -14,6 +14,7 @@ export default function ApplicationServices({ spec: applicationSpec }) {
 
   return (
     <GenericList
+      key="application-services"
       title="Provided Services & Events"
       textSearchProperties={['displayName']}
       entries={entries}

--- a/core-ui/src/components/Predefined/Details/Application/NamespaceBindings.js
+++ b/core-ui/src/components/Predefined/Details/Application/NamespaceBindings.js
@@ -58,6 +58,7 @@ export default function NamespaceBindings(application) {
 
   return (
     <GenericList
+      key="application-bindings"
       extraHeaderContent={
         <CreateBindingModal
           application={application}

--- a/core-ui/src/components/Predefined/Details/ConfigMap/ConfigMap.details.js
+++ b/core-ui/src/components/Predefined/Details/ConfigMap/ConfigMap.details.js
@@ -15,7 +15,7 @@ export const ConfigMapsDetails = ({ DefaultRenderer, ...otherParams }) => {
   const ConfigMapEditor = resource => {
     const { data } = resource;
     return Object.keys(data || {}).map(key => (
-      <LayoutPanel className="fd-has-margin-m">
+      <LayoutPanel key={key} className="fd-has-margin-m">
         <LayoutPanel.Header>
           <LayoutPanel.Head title={key} />
         </LayoutPanel.Header>

--- a/core-ui/src/components/Predefined/Details/Namespace/CreateWorkloadForm/CreateWorkloadForm.js
+++ b/core-ui/src/components/Predefined/Details/Namespace/CreateWorkloadForm/CreateWorkloadForm.js
@@ -51,8 +51,8 @@ export default function CreateWorkloadForm({
       }
       notification.notifySuccess({ title: 'Succesfully created Deployment' });
       LuigiClient.linkManager()
-        .fromContext('namespaces')
-        .navigate('/deployments');
+        .fromContext('namespace')
+        .navigate(`/deployments/details/${deployment.name}`);
     } catch (e) {
       console.error(e);
       notification.notifyError({

--- a/core-ui/src/components/Predefined/Details/Namespace/NamespaceWorkloads/NamespaceWorkloads.js
+++ b/core-ui/src/components/Predefined/Details/Namespace/NamespaceWorkloads/NamespaceWorkloads.js
@@ -28,7 +28,6 @@ const ResourceCircle = ({ data, loading, error, title, color }) => {
     .split(' ')
     .join('')
     .toLowerCase();
-
   return (
     <CircleProgress
       onClick={navigateTo(navigationPath)}

--- a/core-ui/src/components/Predefined/Details/Namespace/NamespaceWorkloads/NamespaceWorkloads.js
+++ b/core-ui/src/components/Predefined/Details/Namespace/NamespaceWorkloads/NamespaceWorkloads.js
@@ -14,7 +14,7 @@ NamespaceWorkloads.propTypes = { namespace: PropTypes.string.isRequired };
 
 const navigateTo = path => () => {
   LuigiClient.linkManager()
-    .fromContext('namespaces')
+    .fromContext('namespace')
     .navigate(path);
 };
 
@@ -28,6 +28,7 @@ const ResourceCircle = ({ data, loading, error, title, color }) => {
     .split(' ')
     .join('')
     .toLowerCase();
+
   return (
     <CircleProgress
       onClick={navigateTo(navigationPath)}

--- a/core-ui/src/components/Predefined/Details/OAuth2Clients/OAuthClientSpecPanel.js
+++ b/core-ui/src/components/Predefined/Details/OAuth2Clients/OAuthClientSpecPanel.js
@@ -14,6 +14,7 @@ const Tokens = ({ tokens }) => (
         key={scope}
         style={{ marginTop: '4px' }}
         className="y-fd-token y-fd-token--no-button y-fd-token--gap"
+        readOnly={true}
       >
         {scope}
       </Token>

--- a/core-ui/src/components/Predefined/Details/Pod/ContainersLogs.js
+++ b/core-ui/src/components/Predefined/Details/Pod/ContainersLogs.js
@@ -14,12 +14,12 @@ function Logs({ params }) {
     {
       name: 'Pods',
       path: '/',
-      fromAbsolutePath: false,
+      fromContext: 'pods',
     },
     {
       name: params.podName,
-      path: `/details/${params.podName}`,
-      fromAbsolutePath: false,
+      path: '/',
+      fromContext: 'pod',
     },
     { name: '' },
   ];

--- a/core-ui/src/components/Predefined/Details/Pod/Pod.details.js
+++ b/core-ui/src/components/Predefined/Details/Pod/Pod.details.js
@@ -22,7 +22,7 @@ function goToSecretDetails(resourceKind, name) {
   const preperedResourceKind = toSnakeCase(resourceKind);
 
   LuigiClient.linkManager()
-    .fromContext('namespaces')
+    .fromContext('namespace')
     .navigate(`${preperedResourceKind}s/details/${name}`);
 }
 
@@ -66,10 +66,15 @@ export const PodsDetails = ({ DefaultRenderer, ...otherParams }) => {
   };
 
   const Containers = resource => (
-    <ContainersData type="Containers" containers={resource.spec.containers} />
+    <ContainersData
+      key="containers"
+      type="Containers"
+      containers={resource.spec.containers}
+    />
   );
   const InitContainers = resource => (
     <ContainersData
+      key="init-containers"
       type="Init containers"
       containers={resource.spec.initContainers}
     />

--- a/core-ui/src/components/Predefined/Details/RoleBindings/RoleBindings.js
+++ b/core-ui/src/components/Predefined/Details/RoleBindings/RoleBindings.js
@@ -4,7 +4,7 @@ import { LayoutPanel } from 'fundamental-react';
 import './RoleBindings.scss';
 
 export const RoleBindings = resource => (
-  <>
+  <React.Fragment key="role-bindings">
     <div className="fd-margin--md">
       <LayoutPanel key={`roleRef`}>
         <LayoutPanel.Header>
@@ -44,5 +44,5 @@ export const RoleBindings = resource => (
         </LayoutPanel>
       ))}
     </div>
-  </>
+  </React.Fragment>
 );

--- a/core-ui/src/components/Predefined/Details/Roles/Rules.js
+++ b/core-ui/src/components/Predefined/Details/Roles/Rules.js
@@ -5,6 +5,7 @@ import './Rules.scss';
 
 export const Rules = resource => (
   <div
+    key="rules"
     style={{
       display: 'grid',
       gridTemplateColumns:

--- a/core-ui/src/components/Predefined/List/ApiRules.list.js
+++ b/core-ui/src/components/Predefined/List/ApiRules.list.js
@@ -17,7 +17,7 @@ export const ApiRulesList = ({ DefaultRenderer, ...otherParams }) => {
       option="transparent"
       onClick={() =>
         LuigiClient.linkManager()
-          .fromContext('namespaces')
+          .fromContext('namespace')
           .withParams({
             serviceName: otherParams.serviceName,
             port: otherParams.port,

--- a/core-ui/src/components/Predefined/List/Function/Functions.list.js
+++ b/core-ui/src/components/Predefined/List/Function/Functions.list.js
@@ -14,7 +14,7 @@ export const FunctionsList = ({ DefaultRenderer, ...otherParams }) => {
 
   function goToGitRepositories() {
     LuigiClient.linkManager()
-      .fromContext('namespaces')
+      .fromContext('namespace')
       .navigate(`gitrepositories`);
   }
 

--- a/core-ui/src/components/Predefined/List/GitRepository/GitRepositories.list.js
+++ b/core-ui/src/components/Predefined/List/GitRepository/GitRepositories.list.js
@@ -30,7 +30,7 @@ export const GitRepositoriesList = ({ DefaultRenderer, ...otherParams }) => {
             className="link"
             onClick={() =>
               LuigiClient.linkManager()
-                .fromContext('namespaces')
+                .fromContext('namespace')
                 .navigate(`secrets/details/${secretName}`)
             }
           >

--- a/core/src/luigi-config/navigation/static-navigation-model.js
+++ b/core/src/luigi-config/navigation/static-navigation-model.js
@@ -100,7 +100,7 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
                 toSearchParamsString({
                   resourceApiPath: '/api/v1',
                 }),
-                navigationContext: 'pod',
+              navigationContext: 'pod',
               children: [
                 {
                   navigationContext: 'containers',

--- a/core/src/luigi-config/navigation/static-navigation-model.js
+++ b/core/src/luigi-config/navigation/static-navigation-model.js
@@ -100,8 +100,10 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
                 toSearchParamsString({
                   resourceApiPath: '/api/v1',
                 }),
+                navigationContext: 'pod',
               children: [
                 {
+                  navigationContext: 'containers',
                   pathSegment: 'containers',
                   children: [
                     {
@@ -114,6 +116,7 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
                 },
                 {
                   pathSegment: 'initContainers',
+                  navigationContext: 'init-containers',
                   children: [
                     {
                       pathSegment: ':containerName',
@@ -272,7 +275,6 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
         }),
       keepSelectedForChildren: true,
       viewGroup: coreUIViewGroupName,
-      navigationContext: 'services',
       children: [
         {
           pathSegment: 'details',
@@ -433,7 +435,7 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
     {
       category: 'Configuration',
       pathSegment: 'addons',
-      navigationContext: 'addons',
+      navigationContext: 'addonsconfigurations',
       label: 'Addons',
       viewUrl:
         config.coreUIModuleUrl +
@@ -468,7 +470,7 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
     {
       category: 'Configuration',
       pathSegment: 'config-maps',
-      navigationContext: 'config-maps',
+      navigationContext: 'configmaps',
       label: 'Config Maps',
       viewUrl:
         config.coreUIModuleUrl +
@@ -565,7 +567,7 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
     {
       category: 'Configuration',
       pathSegment: 'role-bindings',
-      navigationContext: 'role-bindings',
+      navigationContext: 'rolebindings',
       label: 'Role Bindings',
       viewUrl:
         config.coreUIModuleUrl +
@@ -678,6 +680,7 @@ export function getStaticRootNodes(
       viewGroup: coreUIViewGroupName,
       children: [
         {
+          navigationContext: 'namespace',
           pathSegment: ':namespaceId',
           context: {
             namespaceId: ':namespaceId',
@@ -739,14 +742,13 @@ export function getStaticRootNodes(
     },
     {
       pathSegment: 'preferences',
-      navigationContext: 'settings',
       viewUrl: config.coreUIModuleUrl + '/preferences',
       viewGroup: coreUIViewGroupName,
       hideFromNav: true,
     },
     {
       pathSegment: 'addons-config',
-      navigationContext: 'addons-config',
+      navigationContext: 'clusteraddonsconfigurations',
       label: 'Cluster Addons',
       category: {
         label: 'Integration',
@@ -787,7 +789,7 @@ export function getStaticRootNodes(
     //ADMINISTRATION CATEGORY
     {
       pathSegment: 'cluster-roles',
-      navigationContext: 'cluster-roles',
+      navigationContext: 'clusterroles',
       label: 'Cluster Roles',
       category: {
         label: 'Administration',
@@ -832,7 +834,7 @@ export function getStaticRootNodes(
     },
     {
       pathSegment: 'cluster-role-bindings',
-      navigationContext: 'cluster-role-bindings',
+      navigationContext: 'clusterrolebindings',
       label: 'Cluster Role Bindings',
       category: {
         label: 'Administration',

--- a/core/src/luigi-config/navigation/static-navigation-model.js
+++ b/core/src/luigi-config/navigation/static-navigation-model.js
@@ -21,7 +21,7 @@ export function getStaticChildrenNodesForNamespace(apiGroups, modules) {
       label: 'Overview',
       viewUrl:
         config.coreUIModuleUrl +
-        '/namespaces/:namespaceId?' +
+        '/Namespaces/:namespaceId?' +
         toSearchParamsString({
           resourceApiPath: '/api/v1',
         }),

--- a/resources/web/deployment-service-catalog.yaml
+++ b/resources/web/deployment-service-catalog.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: service-catalog
-          image: eu.gcr.io/kyma-project/busola-service-catalog-ui:PR-134
+          image: eu.gcr.io/kyma-project/busola-service-catalog-ui:PR-139
           imagePullPolicy: Always
           resources: {}
           ports:

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-core:PR-134
+          image: eu.gcr.io/kyma-project/busola-core:PR-139
           imagePullPolicy: Always
           resources:
             requests:
@@ -31,7 +31,7 @@ spec:
             - containerPort: 6080
             - containerPort: 8080
         - name: core-ui
-          image: eu.gcr.io/kyma-project/busola-core-ui:PR-134
+          image: eu.gcr.io/kyma-project/busola-core-ui:PR-139
           imagePullPolicy: Always
           resources:
             requests:

--- a/service-catalog-ui/src/components/ServiceClassDetails/CreateInstanceForm/CreateInstanceForm.js
+++ b/service-catalog-ui/src/components/ServiceClassDetails/CreateInstanceForm/CreateInstanceForm.js
@@ -168,7 +168,7 @@ export default function CreateInstanceForm({
       });
 
       LuigiClient.linkManager()
-        .fromContext('namespaces')
+        .fromContext('namespace')
         .navigate(`instances/details/${name}`);
     } catch (err) {
       notificationManager.notifyError({

--- a/service-catalog-ui/src/components/ServiceClassDetails/ServiceClassInstancesTable/ServiceClassInstancesTable.js
+++ b/service-catalog-ui/src/components/ServiceClassDetails/ServiceClassInstancesTable/ServiceClassInstancesTable.js
@@ -13,7 +13,7 @@ const ServiceClassInstancesTable = ({ instanceList }) => {
 
   function goToServiceInstanceDetails(instanceName) {
     LuigiClient.linkManager()
-      .fromContext('namespaces')
+      .fromContext('namespace')
       .navigate(`instances/details/${instanceName}`);
   }
 

--- a/service-catalog-ui/src/components/ServiceInstanceDetails/ServiceInstanceHeader/ServiceInstanceHeader.js
+++ b/service-catalog-ui/src/components/ServiceInstanceDetails/ServiceInstanceHeader/ServiceInstanceHeader.js
@@ -51,7 +51,7 @@ const ServiceInstanceHeader = ({ serviceInstance, servicePlan }) => {
       });
 
       LuigiClient.linkManager()
-        .fromContext('namespaces')
+        .fromContext('namespace')
         .withParams({
           selectedTab: preselectTabOnList,
         })

--- a/service-catalog-ui/src/components/ServiceInstanceDetails/ServiceInstanceInfo/ServiceInstanceInfo.js
+++ b/service-catalog-ui/src/components/ServiceInstanceDetails/ServiceInstanceInfo/ServiceInstanceInfo.js
@@ -13,9 +13,9 @@ const ServiceInstanceInfo = ({
   servicePlan,
 }) => {
   const goToServiceClassDetails = name => {
-    const target = `catalog/details/${name}`;
+    const target = `catalog/${serviceClass.kind}/${name}`;
     LuigiClient.linkManager()
-      .fromContext('namespaces')
+      .fromContext('namespace')
       .withParams({
         resourceType: serviceClass.kind,
       })

--- a/service-catalog-ui/src/components/ServiceInstanceList/ServiceInstanceTable/ServiceInstanceRowRenderer.js
+++ b/service-catalog-ui/src/components/ServiceInstanceList/ServiceInstanceTable/ServiceInstanceRowRenderer.js
@@ -16,7 +16,7 @@ import { ServiceInstanceStatus } from './../../../shared/ServiceInstanceStatus.j
 
 const goToServiceInstanceDetails = name => {
   LuigiClient.linkManager()
-    .fromContext('namespaces')
+    .fromContext('namespace')
     .navigate(`instances/details/${name}`);
 };
 
@@ -56,7 +56,7 @@ const ServiceClassName = ({ instance }) => {
           classRef
             ? () =>
                 LuigiClient.linkManager()
-                  .fromContext('namespaces')
+                  .fromContext('namespace')
                   .withParams({
                     resourceType,
                   })

--- a/service-catalog-ui/src/components/ServiceInstanceList/ServiceInstanceTable/ServiceInstanceTable.js
+++ b/service-catalog-ui/src/components/ServiceInstanceList/ServiceInstanceTable/ServiceInstanceTable.js
@@ -13,7 +13,7 @@ const ServiceInstanceTable = ({
 }) => {
   function goToServiceCatalog() {
     LuigiClient.linkManager()
-      .fromContext('namespaces')
+      .fromContext('namespace')
       .withParams({ selectedTab: type })
       .navigate('catalog');
   }

--- a/shared/components/ResourceDetails/ResourceDetails.js
+++ b/shared/components/ResourceDetails/ResourceDetails.js
@@ -121,7 +121,6 @@ function Resource({
     },
     { name: '' },
   ];
-
   const actions = readOnly ? null : (
     <>
       {headerActions}

--- a/shared/components/ResourceDetails/ResourceDetails.js
+++ b/shared/components/ResourceDetails/ResourceDetails.js
@@ -117,10 +117,11 @@ function Resource({
     {
       name: resourceType,
       path: '/',
-      fromAbsolutePath: resourceType === 'namespaces',
+      fromContext: resourceType.toLowerCase(),
     },
     { name: '' },
   ];
+
   const actions = readOnly ? null : (
     <>
       {headerActions}

--- a/shared/components/StringInput/StringInput.js
+++ b/shared/components/StringInput/StringInput.js
@@ -7,6 +7,7 @@ export const SingleString = ({ text, onClick }) => (
     title="Click to remove"
     className="label-selector__label"
     onClick={onClick}
+    buttonLabel=""
   >
     {text}
   </Token>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use `navigationContext`:
	- `${resource}`s on list
	- `${resource} on :details
	- I used the `resourceType` as a values on lists, as we use it in generic resource details.
- Fix some `key` warnings
- Fix catalog service class navigation
- Fix namespace details lowercase breadcrumb

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
