### PR TITLE
Hide drawer on namespace change

### DIFF
--- a/resources/web/deployment-service-catalog.yaml
+++ b/resources/web/deployment-service-catalog.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: service-catalog
-          image: eu.gcr.io/kyma-project/busola-service-catalog-ui:PR-144
+          image: eu.gcr.io/kyma-project/busola-service-catalog-ui:PR-156
           imagePullPolicy: Always
           resources: {}
           ports:

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - containerPort: 6080
             - containerPort: 8080
         - name: core-ui
-          image: eu.gcr.io/kyma-project/busola-core-ui:PR-152
+          image: eu.gcr.io/kyma-project/busola-core-ui:PR-156
           imagePullPolicy: Always
           resources:
             requests:

--- a/shared/components/ResourceDetails/ResourceDetails.js
+++ b/shared/components/ResourceDetails/ResourceDetails.js
@@ -108,7 +108,7 @@ function Resource({
   readOnly,
 }) {
   useWindowTitle(windowTitle || prettifyNamePlural(null, resourceType));
-  const { setEditedJson: setEditedSpec } = useYamlEditor();
+  const { setEditedYaml: setEditedSpec } = useYamlEditor();
   const notification = useNotification();
 
   const prettifiedResourceName = prettifyNameSingular(undefined, resourceType);

--- a/shared/components/ResourceDetails/ResourceDetails.js
+++ b/shared/components/ResourceDetails/ResourceDetails.js
@@ -108,7 +108,7 @@ function Resource({
   readOnly,
 }) {
   useWindowTitle(windowTitle || prettifyNamePlural(null, resourceType));
-  const setEditedSpec = useYamlEditor();
+  const { setEditedJson: setEditedSpec } = useYamlEditor();
   const notification = useNotification();
 
   const prettifiedResourceName = prettifyNameSingular(undefined, resourceType);

--- a/shared/components/ResourcesList/ResourcesList.js
+++ b/shared/components/ResourcesList/ResourcesList.js
@@ -89,7 +89,7 @@ function Resources({
   readOnly,
 }) {
   useWindowTitle(windowTitle || prettifyNamePlural(resourceName, resourceType));
-  const { setEditedJson: setEditedSpec, closeEditor } = useYamlEditor();
+  const { setEditedYaml: setEditedSpec, closeEditor } = useYamlEditor();
   const notification = useNotification();
   const updateResourceMutation = useUpdate(resourceUrl);
   const deleteResourceMutation = useDelete(resourceUrl);

--- a/shared/components/ResourcesList/ResourcesList.js
+++ b/shared/components/ResourcesList/ResourcesList.js
@@ -89,13 +89,15 @@ function Resources({
   readOnly,
 }) {
   useWindowTitle(windowTitle || prettifyNamePlural(resourceName, resourceType));
-  const setEditedSpec = useYamlEditor();
+  const { setEditedJson: setEditedSpec, closeEditor } = useYamlEditor();
   const notification = useNotification();
   const updateResourceMutation = useUpdate(resourceUrl);
   const deleteResourceMutation = useDelete(resourceUrl);
   const { loading = true, error, data: resources, silentRefetch } = useGetList(
     filter,
   )(resourceUrl, { pollingInterval: 3000 });
+
+  React.useEffect(() => closeEditor(), [namespace]);
 
   const prettifiedResourceName = prettifyNameSingular(
     resourceName,

--- a/shared/contexts/YamlEditorContext.js
+++ b/shared/contexts/YamlEditorContext.js
@@ -15,7 +15,7 @@ import copyToCliboard from 'copy-to-clipboard';
 import { saveAs } from 'file-saver';
 
 export const YamlEditorContext = createContext({
-  setEditedJson: _ => {},
+  setEditedYaml: _ => {},
 });
 
 const isValidYaml = yaml => {
@@ -92,7 +92,7 @@ export const YamlEditorProvider = ({ children }) => {
     LuigiClient.uxManager().setDirtyStatus(!!changedYaml);
   }, [changedYaml]);
 
-  function setEditedJson(newJson, onSaveHandler) {
+  function setEditedYaml(newJson, onSaveHandler) {
     onSaveFn.current = onSaveHandler;
     setJson(newJson);
   }
@@ -139,7 +139,7 @@ export const YamlEditorProvider = ({ children }) => {
   );
 
   return (
-    <YamlEditorContext.Provider value={{ setEditedJson, closeEditor }}>
+    <YamlEditorContext.Provider value={{ setEditedYaml, closeEditor }}>
       {drawerComponent}
       {children}
     </YamlEditorContext.Provider>

--- a/shared/contexts/YamlEditorContext.js
+++ b/shared/contexts/YamlEditorContext.js
@@ -28,14 +28,14 @@ const isValidYaml = yaml => {
   }
 };
 
-const YamlContent = ({ json, setChangedYamlFn }) => {
-  const [val, setVal] = useState(jsyaml.safeDump(json));
+const YamlContent = ({ yaml, setChangedYamlFn }) => {
+  const [val, setVal] = useState(jsyaml.safeDump(yaml));
 
   useEffect(() => {
-    const converted = jsyaml.safeDump(json);
+    const converted = jsyaml.safeDump(yaml);
     setChangedYamlFn(null);
     setVal(converted);
-  }, [json]);
+  }, [yaml]);
 
   return (
     <>
@@ -74,27 +74,27 @@ const YamlContent = ({ json, setChangedYamlFn }) => {
 };
 
 export const YamlEditorProvider = ({ children }) => {
-  const [json, setJson] = useState(null);
+  const [yaml, setYaml] = useState(null);
   const [isOpen, setOpen] = useState(false);
   const [changedYaml, setChangedYaml] = useState(null);
   const onSaveFn = useRef(_ => {});
 
   useEffect(() => {
     LuigiClient.uxManager().setDirtyStatus(false);
-    json && setOpen(true);
-  }, [json]);
+    yaml && setOpen(true);
+  }, [yaml]);
 
   useEffect(() => {
-    if (!isOpen) setJson(null);
+    if (!isOpen) setYaml(null);
   }, [isOpen]);
 
   useEffect(() => {
     LuigiClient.uxManager().setDirtyStatus(!!changedYaml);
   }, [changedYaml]);
 
-  function setEditedYaml(newJson, onSaveHandler) {
+  function setEditedYaml(newYaml, onSaveHandler) {
     onSaveFn.current = onSaveHandler;
-    setJson(newJson);
+    setYaml(newYaml);
   }
 
   function closeEditor() {
@@ -134,7 +134,7 @@ export const YamlEditorProvider = ({ children }) => {
       bottomContent={bottomContent}
       hideDefaultButton={true}
     >
-      <YamlContent json={json} setChangedYamlFn={setChangedYaml} />
+      <YamlContent yaml={yaml} setChangedYamlFn={setChangedYaml} />
     </SideDrawer>
   );
 

--- a/shared/contexts/YamlEditorContext.js
+++ b/shared/contexts/YamlEditorContext.js
@@ -97,10 +97,14 @@ export const YamlEditorProvider = ({ children }) => {
     setJson(newJson);
   }
 
+  function closeEditor() {
+    setOpen(false);
+  }
+
   async function handleSaveClick() {
     try {
       await onSaveFn.current(changedYaml);
-      setOpen(false);
+      closeEditor();
     } catch (_) {}
   }
 
@@ -135,7 +139,7 @@ export const YamlEditorProvider = ({ children }) => {
   );
 
   return (
-    <YamlEditorContext.Provider value={setEditedJson}>
+    <YamlEditorContext.Provider value={{ setEditedJson, closeEditor }}>
       {drawerComponent}
       {children}
     </YamlEditorContext.Provider>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- As in title. Also, rename `json` occurences to `yaml`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
