### PR TITLE
Auto-fill OIDC data when available in the kubeconfig

### DIFF
--- a/core-ui/src/components/Clusters/components/AuthForm.js
+++ b/core-ui/src/components/Clusters/components/AuthForm.js
@@ -15,7 +15,7 @@ export function AuthForm({ setAuthValid, auth, setAuth }) {
     }
   }, [formRef, auth, setAuthValid]);
 
-  const oidcForm = (
+  const OIDCform = _ => (
     <>
       <TextFormItem
         inputKey="issuer-url"
@@ -79,7 +79,7 @@ export function AuthForm({ setAuthValid, auth, setAuth }) {
           OIDC provider
         </FormRadioItem>
       </FormRadioGroup>
-      {auth.type === AUTH_FORM_OIDC ? oidcForm : tokenForm}
+      {auth.type === AUTH_FORM_OIDC ? <OIDCform /> : tokenForm}
     </form>
   );
 }

--- a/core-ui/src/components/Clusters/components/AuthForm.js
+++ b/core-ui/src/components/Clusters/components/AuthForm.js
@@ -6,6 +6,35 @@ export const AUTH_FORM_TOKEN = 'Token';
 export const AUTH_FORM_OIDC = 'OIDC';
 export const DEFAULT_SCOPE_VALUE = 'openid ';
 
+const OIDCform = ({ auth, setAuth }) => {
+  return (
+    <>
+      <TextFormItem
+        inputKey="issuer-url"
+        required
+        type="url"
+        label="Issuer URL"
+        onChange={e => setAuth({ ...auth, issuerUrl: e.target.value })}
+        inputProps={{ value: auth.issuerUrl || '' }}
+      />
+      <TextFormItem
+        inputKey="client-id"
+        required
+        label="Client ID"
+        onChange={e => setAuth({ ...auth, clientId: e.target.value })}
+        inputProps={{ value: auth.clientId || '' }}
+      />
+      <TextFormItem
+        inputKey="scope"
+        required
+        label="Scopes"
+        onChange={e => setAuth({ ...auth, scope: e.target.value })}
+        inputProps={{ value: auth.scope || DEFAULT_SCOPE_VALUE }}
+      />
+    </>
+  );
+};
+
 export function AuthForm({ setAuthValid, auth, setAuth }) {
   const formRef = React.useRef();
 
@@ -14,33 +43,6 @@ export function AuthForm({ setAuthValid, auth, setAuth }) {
       setAuthValid(formRef.current?.checkValidity());
     }
   }, [formRef, auth, setAuthValid]);
-
-  const OIDCform = _ => (
-    <>
-      <TextFormItem
-        inputKey="issuer-url"
-        required
-        type="url"
-        label="Issuer URL"
-        onChange={e => setAuth({ ...auth, issuerUrl: e.target.value })}
-        defaultValue={auth.issuerUrl}
-      />
-      <TextFormItem
-        inputKey="client-id"
-        required
-        label="Client ID"
-        onChange={e => setAuth({ ...auth, clientId: e.target.value })}
-        defaultValue={auth.clientId}
-      />
-      <TextFormItem
-        inputKey="scope"
-        required
-        label="Scopes"
-        onChange={e => setAuth({ ...auth, scope: e.target.value })}
-        defaultValue={auth.scope || DEFAULT_SCOPE_VALUE}
-      />
-    </>
-  );
 
   const tokenForm = (
     <TextFormItem
@@ -79,7 +81,11 @@ export function AuthForm({ setAuthValid, auth, setAuth }) {
           OIDC provider
         </FormRadioItem>
       </FormRadioGroup>
-      {auth.type === AUTH_FORM_OIDC ? <OIDCform /> : tokenForm}
+      {auth.type === AUTH_FORM_OIDC ? (
+        <OIDCform auth={auth} setAuth={setAuth} />
+      ) : (
+        tokenForm
+      )}
     </form>
   );
 }

--- a/core-ui/src/components/Clusters/components/ClusterConfiguration.js
+++ b/core-ui/src/components/Clusters/components/ClusterConfiguration.js
@@ -48,10 +48,12 @@ export function ClusterConfiguration({
   React.useEffect(() => {
     if (Object.keys(auth).length > 1) return; // Some properties were already predefined for the auth. Filling them again would cause an infinite loop.
     fillAuthFromKubeconfig();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth, kubeconfig, setAuth]);
 
   React.useEffect(() => {
     fillAuthFromKubeconfig();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contextName]);
 
   function fillAuthFromKubeconfig() {

--- a/core-ui/src/components/Clusters/components/ClusterConfiguration.js
+++ b/core-ui/src/components/Clusters/components/ClusterConfiguration.js
@@ -1,9 +1,31 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNotification } from 'react-shared';
 import { AuthForm, AUTH_FORM_OIDC } from './AuthForm';
 import { ContextChooser } from './ContextChooser/ContextChooser';
 import { getContext, hasKubeconfigAuth, addCluster } from '../shared';
 import { Button, Icon } from 'fundamental-react';
+
+const OIDC_PARAM_NAMES = new Map([
+  ['--oidc-issuer-url', 'issuerUrl'],
+  ['--oidc-client-id', 'clientId'],
+  ['--oidc-extra-scope', 'scope'],
+]);
+
+async function tryParseOIDCparams({ exec: commandData }) {
+  if (!commandData || !commandData.args) throw new Error('No args provided');
+  let output = {};
+
+  commandData.args.forEach(arg => {
+    const [argKey, argValue] = arg.split('=');
+    if (!OIDC_PARAM_NAMES.has(argKey)) return;
+
+    const outputKey = OIDC_PARAM_NAMES.get(argKey);
+    if (output[outputKey]) output[outputKey] += ' ' + argValue;
+    else output[outputKey] = argValue;
+  });
+
+  return output;
+}
 
 export function ClusterConfiguration({
   kubeconfig,
@@ -22,15 +44,40 @@ export function ClusterConfiguration({
     setContextName(kubeconfig['current-context']);
   }, [kubeconfig]);
 
+  React.useEffect(() => {
+    if (Object.keys(auth).length > 1) return; // Some properties were already predefined for the auth. Filling them again would cause an infinite loop.
+    fillAuthFromKubeconfig();
+  }, [auth, kubeconfig, setAuth]);
+
+  useEffect(() => {
+    fillAuthFromKubeconfig();
+  }, [contextName]);
+
+  function fillAuthFromKubeconfig() {
+    if (auth.type !== AUTH_FORM_OIDC || !kubeconfig || !contextName) return;
+    const { context } = kubeconfig.contexts.find(c => c.name === contextName);
+    const user = kubeconfig.users.find(u => u.name === context.user);
+    tryParseOIDCparams(user.user)
+      .then(parsedParams => {
+        setAuth({
+          ...auth,
+          ...parsedParams,
+        });
+      })
+      .catch(e => console.debug('Failed to parse predefined OIDC args', e));
+  }
+
   const addAuthToParams = params => {
     const { type: authType, token, ...oidcConfig } = auth;
     if (authType === AUTH_FORM_OIDC) {
       // just add OIDC params to configuration
+
       params.config.auth = oidcConfig;
     } else {
       // add token to current context's user
       const { context } = kubeconfig.contexts.find(c => c.name === contextName);
       const user = params.kubeconfig.users.find(u => u.name === context.user);
+
       if (user) {
         user.user = { token };
       } else {

--- a/core-ui/src/components/Clusters/components/ClusterConfiguration.js
+++ b/core-ui/src/components/Clusters/components/ClusterConfiguration.js
@@ -38,7 +38,8 @@ export function ClusterConfiguration({
   const [contextName, setContextName] = React.useState(null);
   const notification = useNotification();
 
-  const requireAuth = kubeconfig && !hasKubeconfigAuth(kubeconfig, contextName);
+  const requireAuth =
+    kubeconfig && contextName && !hasKubeconfigAuth(kubeconfig, contextName);
 
   React.useEffect(() => {
     setContextName(kubeconfig['current-context']);
@@ -57,6 +58,7 @@ export function ClusterConfiguration({
     if (auth.type !== AUTH_FORM_OIDC || !kubeconfig || !contextName) return;
     const { context } = kubeconfig.contexts.find(c => c.name === contextName);
     const user = kubeconfig.users.find(u => u.name === context.user);
+
     try {
       const parsedParams = parseOIDCparams(user?.user);
       setAuth({
@@ -64,7 +66,10 @@ export function ClusterConfiguration({
         ...parsedParams,
       });
     } catch (e) {
-      console.debug('Failed to parse predefined OIDC args', e);
+      console.debug(
+        '[INFO] Tried to parse predefined OIDC args and failed due to',
+        e,
+      );
     }
   }
 

--- a/core-ui/src/components/Clusters/components/ClusterConfiguration.js
+++ b/core-ui/src/components/Clusters/components/ClusterConfiguration.js
@@ -11,7 +11,7 @@ const OIDC_PARAM_NAMES = new Map([
   ['--oidc-extra-scope', 'scope'],
 ]);
 
-function parseOIDCparams({ exec: commandData }) {
+export function parseOIDCparams({ exec: commandData }) {
   if (!commandData || !commandData.args) throw new Error('No args provided');
   let output = {};
 

--- a/core-ui/src/components/Clusters/components/test/ClusterConfiguration.test.js
+++ b/core-ui/src/components/Clusters/components/test/ClusterConfiguration.test.js
@@ -48,9 +48,9 @@ const TWO_USERS_KUBECONFIG = {
             '--oidc-issuer-url=https://coastguard.gov.us',
             '--oidc-client-id=hasselhoff',
             '--oidc-client-secret=otherSecret',
-            '--oidc-extra-scope=blondies',
-            '--oidc-extra-scope=rescue',
-            '--oidc-extra-scope=muscles',
+            '--oidc-extra-scope=peach',
+            '--oidc-extra-scope=melon',
+            '--oidc-extra-scope=plum',
             '--grant-type=auto',
           ],
         },
@@ -85,7 +85,7 @@ describe('ClusterConfiguration', () => {
         auth: {
           clientId: 'hasselhoff',
           issuerUrl: 'https://coastguard.gov.us',
-          scope: 'blondies rescue muscles',
+          scope: 'peach melon plum',
         },
       }),
       expect.anything(),
@@ -107,7 +107,7 @@ describe('ClusterConfiguration', () => {
         auth: {
           clientId: 'hasselhoff',
           issuerUrl: 'https://coastguard.gov.us',
-          scope: 'blondies rescue muscles',
+          scope: 'peach melon plum',
         },
       }),
       expect.anything(),
@@ -121,14 +121,14 @@ describe('ClusterConfiguration', () => {
           args: [
             '--oidc-issuer-url=https://coastguard.gov.us',
             '--oidc-client-id=hasselhoff',
-            '--oidc-extra-scope=blondies',
+            '--oidc-extra-scope=peach',
           ],
         },
       };
       expect(parseOIDCparams(input)).toMatchObject({
         clientId: 'hasselhoff',
         issuerUrl: 'https://coastguard.gov.us',
-        scope: 'blondies',
+        scope: 'peach',
       });
     });
 
@@ -136,14 +136,14 @@ describe('ClusterConfiguration', () => {
       const input = {
         exec: {
           args: [
-            '--oidc-extra-scope=blondies',
-            '--oidc-extra-scope=brunettes',
-            '--oidc-extra-scope=redheads',
+            '--oidc-extra-scope=peach',
+            '--oidc-extra-scope=melon',
+            '--oidc-extra-scope=plum',
           ],
         },
       };
       expect(parseOIDCparams(input)).toMatchObject({
-        scope: 'blondies brunettes redheads',
+        scope: 'peach melon plum',
       });
     });
 

--- a/core-ui/src/components/Clusters/components/test/ClusterConfiguration.test.js
+++ b/core-ui/src/components/Clusters/components/test/ClusterConfiguration.test.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AUTH_FORM_OIDC, AuthForm } from '../AuthForm';
+import { parseOIDCparams, ClusterConfiguration } from '../ClusterConfiguration';
+
+// const mockAuthForm = jest.fn().mockReturnValue('mocked AuthForm');
+jest.mock('../AuthForm', () => ({
+  AuthForm: jest.fn().mockReturnValue('test2'),
+}));
+
+const TWO_USERS_KUBECONFIG = {
+  kind: 'Config',
+  apiVersion: 'v1',
+  clusters: [
+    {
+      name: 'garden-hasselhoff',
+      cluster: {},
+    },
+  ],
+  contexts: [
+    {
+      context: {
+        cluster: 'garden-hasselhoff',
+        user: 'oidc-login',
+        namespace: 'garden-hasselhoff',
+      },
+      name: 'garden-hasselhoff',
+    },
+    {
+      context: {
+        cluster: 'garden-hasselhoff',
+        user: 'david-h',
+        namespace: 'garden-hasselhoff',
+      },
+      name: 'exclusive-david-h-context',
+    },
+  ],
+  'current-context': 'garden-hasselhoff',
+  users: [
+    {
+      name: 'oidc-login',
+      user: {
+        exec: {
+          apiVersion: 'client.authentication.k8s.io/v1beta1',
+          command: 'kubectl',
+          args: [
+            'oidc-login',
+            'get-token',
+            '--oidc-issuer-url=https://identity.cia.gov',
+            '--oidc-client-id=kube-kubectl',
+            '--oidc-client-secret=testsecret',
+            '--oidc-extra-scope=email',
+            '--oidc-extra-scope=profile',
+            '--oidc-extra-scope=groups',
+            '--grant-type=auto',
+          ],
+        },
+      },
+    },
+    {
+      name: 'david-h',
+      user: {
+        exec: {
+          apiVersion: 'client.authentication.k8s.io/v1beta1',
+          command: 'kubectl',
+          args: [
+            'oidc-login',
+            'get-token',
+            '--oidc-issuer-url=https://coastguard.gov.us',
+            '--oidc-client-id=hasselhoff',
+            '--oidc-client-secret=otherSecret',
+            '--oidc-extra-scope=blondies',
+            '--oidc-extra-scope=rescue',
+            '--oidc-extra-scope=muscles',
+            '--grant-type=auto',
+          ],
+        },
+      },
+    },
+  ],
+  preferences: {},
+};
+
+describe('ClusterConfiguration', () => {
+  beforeEach(() => {});
+
+  it('Renders AuthForm with issuerUrl, clientId and scope with the values from kubeconfig', () => {
+    render(
+      <ClusterConfiguration
+        kubeconfig={TWO_USERS_KUBECONFIG}
+        auth={{ type: AUTH_FORM_OIDC }}
+      />,
+    );
+
+    expect(AuthForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: {
+          clientId: 'kube-kubectl',
+          issuerUrl: 'https://identity.cia.gov',
+          scope: 'email profile groups',
+        },
+      }),
+      expect.anything(),
+    );
+  });
+});

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - containerPort: 6080
             - containerPort: 8080
         - name: core-ui
-          image: eu.gcr.io/kyma-project/busola-core-ui:PR-234
+          image: eu.gcr.io/kyma-project/busola-core-ui:PR-240
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- auto-fill the input fields on the "OIDC login" form reveal
- re-fill the inputs on context change
- add unit tests 🎆 

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
