### PR TITLE
Handle kubeconfig ID param

### DIFF
--- a/core/src/luigi-config/init-params/constants.js
+++ b/core/src/luigi-config/init-params/constants.js
@@ -27,7 +27,7 @@ export const DEFAULT_FEATURES = {
     lazy: false,
     selectors: [],
     config: {
-      kubeconfigUrl: 'http://localhost:3030',
+      kubeconfigUrl: 'https://kyma-env-broker.cp.dev.kyma.cloud.sap/kubeconfig',
     },
   },
 };

--- a/core/src/luigi-config/init-params/constants.js
+++ b/core/src/luigi-config/init-params/constants.js
@@ -8,19 +8,29 @@ const DEFAULT_MODULES = {
   SERVERLESS: 'serverless.kyma-project.io',
 };
 
-export const DEFAULT_FEATURES = Object.fromEntries(
-  Object.entries(DEFAULT_MODULES).map(([key, value]) => [
-    key,
-    {
-      selectors: [
-        {
-          type: 'apiGroup',
-          apiGroup: value,
-        },
-      ],
+export const DEFAULT_FEATURES = {
+  ...Object.fromEntries(
+    Object.entries(DEFAULT_MODULES).map(([key, value]) => [
+      key,
+      {
+        selectors: [
+          {
+            type: 'apiGroup',
+            apiGroup: value,
+          },
+        ],
+      },
+    ]),
+  ),
+  KUBECONFIG_ID: {
+    isEnabled: true,
+    lazy: false,
+    selectors: [],
+    config: {
+      kubeconfigUrl: 'http://localhost:3030',
     },
-  ]),
-);
+  },
+};
 
 export const DEFAULT_HIDDEN_NAMESPACES = [
   'istio-system',

--- a/core/src/luigi-config/init-params/constants.js
+++ b/core/src/luigi-config/init-params/constants.js
@@ -23,9 +23,6 @@ export const DEFAULT_FEATURES = {
     ]),
   ),
   KUBECONFIG_ID: {
-    isEnabled: true,
-    lazy: false,
-    selectors: [],
     config: {
       kubeconfigUrl: 'https://kyma-env-broker.cp.dev.kyma.cloud.sap/kubeconfig',
     },

--- a/core/src/luigi-config/init-params/init-params.js
+++ b/core/src/luigi-config/init-params/init-params.js
@@ -19,7 +19,7 @@ function hasExactlyOneContext(kubeconfig) {
   return kubeconfig?.contexts?.length === 1;
 }
 
-export async function saveInitParamsIfPresent() {
+export async function saveQueryParamsIfPresent() {
   try {
     await setupFromParams();
   } catch (e) {
@@ -91,6 +91,7 @@ async function setupFromParams() {
   const targetLocation =
     `/cluster/${encodeURIComponent(clusterName)}/namespaces` +
     (preselectedNamespace ? `/${preselectedNamespace}/details` : '');
+
   saveLocation(targetLocation);
 }
 

--- a/core/src/luigi-config/init-params/init-params.js
+++ b/core/src/luigi-config/init-params/init-params.js
@@ -23,7 +23,9 @@ export async function saveInitParamsIfPresent() {
   try {
     await setupFromParams();
   } catch (e) {
-    alert('Error loading init params, configuration not changed.');
+    alert(
+      `Error loading init params, configuration not changed (Error: ${e.message}).`,
+    );
     console.warn(e);
   }
 }

--- a/core/src/luigi-config/kubeconfig-id.js
+++ b/core/src/luigi-config/kubeconfig-id.js
@@ -27,12 +27,9 @@ export async function applyKubeconfigIdIfPresent(kubeconfigId, initParams) {
     return;
   }
 
-  console.log(kubeconfigIdFeature.config.kubeconfigUrl, kubeconfigId);
   const url = join(kubeconfigIdFeature.config.kubeconfigUrl, kubeconfigId);
   const responseText = await fetch(url).then(res => res.text());
   const payload = jsyaml.load(responseText);
-
-  console.log(payload);
 
   if (payload.Error) {
     throw Error(payload.Error);

--- a/core/src/luigi-config/kubeconfig-id.js
+++ b/core/src/luigi-config/kubeconfig-id.js
@@ -1,0 +1,40 @@
+import { getClusterParams } from './cluster-params';
+import { resolveFeatureAvailability } from './features';
+import { DEFAULT_FEATURES, PARAMS_VERSION } from './init-params/constants';
+
+export async function applyKubeconfigIdIfPresent(kubeconfigId, initParams) {
+  if (!kubeconfigId) {
+    return;
+  }
+
+  const clusterParams = await getClusterParams();
+
+  const feature = {
+    ...DEFAULT_FEATURES,
+    ...clusterParams.config?.features,
+    ...initParams.config?.features,
+  }['KUBECONFIG_ID'];
+
+  if (!(await resolveFeatureAvailability(feature))) {
+    return;
+  }
+
+  if (!feature.config.kubeconfigUrl.endsWith('/')) {
+    feature.config.kubeconfigUrl += '/';
+  }
+
+  try {
+    const response = await fetch(feature.config.kubeconfigUrl + kubeconfigId);
+
+    initParams.kubeconfig = await response.json();
+    if (!initParams.config?.version) {
+      initParams.config = {
+        ...initParams.config,
+        version: PARAMS_VERSION,
+      };
+    }
+  } catch (e) {
+    alert('Cannot reach kubeconfig ID service.');
+    throw e;
+  }
+}

--- a/core/src/luigi-config/luigi-config.js
+++ b/core/src/luigi-config/luigi-config.js
@@ -6,7 +6,7 @@ import { getAuthData, setAuthData } from './auth/auth-storage';
 import { communication } from './communication';
 import { createSettings } from './settings';
 import { createAuth, hasNonOidcAuth } from './auth/auth.js';
-import { saveInitParamsIfPresent } from './init-params/init-params.js';
+import { saveQueryParamsIfPresent } from './init-params/init-params.js';
 import {
   getActiveCluster,
   setActiveClusterIfPresentInUrl,
@@ -57,7 +57,7 @@ async function luigiAfterInit() {
 (async () => {
   await setActiveClusterIfPresentInUrl();
 
-  await saveInitParamsIfPresent();
+  await saveQueryParamsIfPresent();
 
   const params = await getActiveCluster();
 

--- a/core/src/luigi-config/navigation/previous-location.js
+++ b/core/src/luigi-config/navigation/previous-location.js
@@ -5,9 +5,12 @@ export const saveLocation = location => {
 };
 
 export const saveCurrentLocation = () => {
-  const hasInitParams = [
-    ...(window.location.searchParams?.keys() || []),
-  ].includes('init');
+  const searchParams = [
+    ...(new URL(window.location).searchParams?.keys() || []),
+  ];
+  const hasInitParams =
+    searchParams.includes('init') || searchParams.includes('kubeconfigID');
+
   if (
     !window.location.hash &&
     !hasInitParams &&

--- a/core/src/luigi-config/navigation/previous-location.js
+++ b/core/src/luigi-config/navigation/previous-location.js
@@ -4,17 +4,18 @@ export const saveLocation = location => {
   localStorage.setItem(PREVIOUS_LOCATION_KEY, location);
 };
 
-export const saveCurrentLocation = () => {
+function hasQueryParams() {
   const searchParams = [
     ...(new URL(window.location).searchParams?.keys() || []),
   ];
-  const hasInitParams =
-    searchParams.includes('init') || searchParams.includes('kubeconfigID');
+  return searchParams.includes('init') || searchParams.includes('kubeconfigID');
+}
 
+export const saveCurrentLocation = () => {
   if (
     !window.location.hash &&
-    !hasInitParams &&
-    window.location.pathname !== '/'
+    window.location.pathname !== '/' &&
+    !hasQueryParams()
   ) {
     const location = window.location.pathname;
     const params = window.location.search;

--- a/resources/backend/deployment.yaml
+++ b/resources/backend/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: backend
-          image: eu.gcr.io/kyma-project/busola-backend:PR-231
+          image: eu.gcr.io/kyma-project/busola-backend:PR-263
           imagePullPolicy: Always
           resources:
             limits:

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-262
+          image: eu.gcr.io/kyma-project/busola-web:PR-263
           imagePullPolicy: Always
           resources:
             requests:

--- a/tests/support/enkode.js
+++ b/tests/support/enkode.js
@@ -187,3 +187,22 @@ export async function generateUnsupportedVersionParams() {
   };
   return await encoder.compress(params);
 }
+
+export async function generateWithKubeconfigId(kubeconfigIdAddress) {
+  const kubeconfig = await loadKubeconfig();
+  const params = {
+    kubeconfig: null,
+    config: {
+      ...DEFAULT_CONFIG,
+      features: {
+        KUBECONFIG_ID: {
+          selectors: [],
+          config: {
+            kubeconfigUrl: kubeconfigIdAddress,
+          },
+        },
+      },
+    },
+  };
+  return { params: await encoder.compress(params), kubeconfig };
+}

--- a/tests/tests/login-enkode.spec.js
+++ b/tests/tests/login-enkode.spec.js
@@ -208,7 +208,6 @@ context('Login - enkode link', () => {
     const kubeconfigIdAddress = 'http://localhost:3030';
     cy.wrap(generateWithKubeconfigId(kubeconfigIdAddress)).then(
       ({ params, kubeconfig }) => {
-        console.log(params, kubeconfig);
         cy.intercept(
           {
             method: 'GET',
@@ -218,6 +217,43 @@ context('Login - enkode link', () => {
         );
         cy.visit(`${config.clusterAddress}?init=${params}&kubeconfigID=tests`);
         cy.url().should('match', /namespaces$/);
+      },
+    );
+  });
+
+  it('Enkode + kubeconfigID: valid kubeconfig ID', () => {
+    const kubeconfigIdAddress = 'http://localhost:3030';
+    cy.wrap(generateWithKubeconfigId(kubeconfigIdAddress)).then(
+      ({ params, kubeconfig }) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: kubeconfigIdAddress + '/*',
+          },
+          kubeconfig,
+        );
+        cy.visit(`${config.clusterAddress}?init=${params}&kubeconfigID=tests`);
+        cy.url().should('match', /namespaces$/);
+      },
+    );
+  });
+
+  it.only('Enkode + kubeconfigID: invalid kubeconfig ID', () => {
+    const kubeconfigIdAddress = 'http://localhost:3030';
+    cy.wrap(generateWithKubeconfigId(kubeconfigIdAddress)).then(
+      ({ params }) => {
+        cy.intercept(
+          {
+            method: 'GET',
+            url: kubeconfigIdAddress + '/*',
+          },
+          { Error: 'not found' },
+        );
+        cy.visit(`${config.clusterAddress}?init=${params}&kubeconfigID=tests`);
+
+        Cypress.on('window:alert', alertContent =>
+          expect(alertContent).to.include('Error: not found'),
+        );
       },
     );
   });

--- a/tests/tests/login-enkode.spec.js
+++ b/tests/tests/login-enkode.spec.js
@@ -204,23 +204,6 @@ context('Login - enkode link', () => {
     });
   });
 
-  it('Enkode + kubeconfigID', () => {
-    const kubeconfigIdAddress = 'http://localhost:3030';
-    cy.wrap(generateWithKubeconfigId(kubeconfigIdAddress)).then(
-      ({ params, kubeconfig }) => {
-        cy.intercept(
-          {
-            method: 'GET',
-            url: kubeconfigIdAddress + '/*',
-          },
-          kubeconfig,
-        );
-        cy.visit(`${config.clusterAddress}?init=${params}&kubeconfigID=tests`);
-        cy.url().should('match', /namespaces$/);
-      },
-    );
-  });
-
   it('Enkode + kubeconfigID: valid kubeconfig ID', () => {
     const kubeconfigIdAddress = 'http://localhost:3030';
     cy.wrap(generateWithKubeconfigId(kubeconfigIdAddress)).then(
@@ -238,7 +221,7 @@ context('Login - enkode link', () => {
     );
   });
 
-  it.only('Enkode + kubeconfigID: invalid kubeconfig ID', () => {
+  it('Enkode + kubeconfigID: invalid kubeconfig ID', () => {
     const kubeconfigIdAddress = 'http://localhost:3030';
     cy.wrap(generateWithKubeconfigId(kubeconfigIdAddress)).then(
       ({ params }) => {

--- a/tests/tests/login-enkode.spec.js
+++ b/tests/tests/login-enkode.spec.js
@@ -9,6 +9,7 @@ import {
   generateParamsWithHiddenNamespacesList,
   generateParamsWithDisabledFeatures,
   generateUnsupportedVersionParams,
+  generateWithKubeconfigId,
 } from '../support/enkode';
 
 const SYSTEM_NAMESPACE = 'kyma-system';
@@ -201,5 +202,23 @@ context('Login - enkode link', () => {
     cy.wrap(generateUnsupportedVersionParams()).then(params => {
       cy.visit(`${config.clusterAddress}?init=${params}`);
     });
+  });
+
+  it('Enkode + kubeconfigID', () => {
+    const kubeconfigIdAddress = 'http://localhost:3030';
+    cy.wrap(generateWithKubeconfigId(kubeconfigIdAddress)).then(
+      ({ params, kubeconfig }) => {
+        console.log(params, kubeconfig);
+        cy.intercept(
+          {
+            method: 'GET',
+            url: kubeconfigIdAddress + '/*',
+          },
+          kubeconfig,
+        );
+        cy.visit(`${config.clusterAddress}?init=${params}&kubeconfigID=tests`);
+        cy.url().should('match', /namespaces$/);
+      },
+    );
   });
 });


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Handle kk-id during app bootstrap
- Add test case

Testing:

- So, we by default we can't login to kk-id cluster - `kymatest` authenticates them, and we have no access here to add `callbackUrl`. BUT if we change the local port from 4200 to 8000, then it will work!
- This means we can't really test it on our cluster.
- Another way would be to run a simple backend:
```
const express = require("express");
const cors = require("cors");

const port = 3030;

const app = express();
app.use(cors());

const kk = {/* drop a oidc kubeconfig here */};

app.get("/*", (req, res) => {
  res.send(kk);
});

app.listen(port, () => {
  console.log(`Example app listening at http://localhost:${port}`);
});
```
and make the `kubeconfigId` (can be easily changed via [pr-enkode](http://pr.enkode.surge.sh/) to this mini-backend address.

**Related issue(s)**

[Connected #1599](https://github.tools.sap/kyma/backlog/issues/1599)
