### PR TITLE
Job workloads

### DIFF
--- a/core-ui/src/components/Predefined/Details/CronJobs/CronJob.details.js
+++ b/core-ui/src/components/Predefined/Details/CronJobs/CronJob.details.js
@@ -4,6 +4,9 @@ import { CronJobConcurrencyPolicy } from './CronJobConcurrencyPolicy';
 import { CronJobJobs } from './CronJobJobs.js';
 import { CronJobLastScheduleTime } from '../../../../shared/components/CronJob/CronJobLastScheduleTime';
 import { useTranslation } from 'react-i18next';
+import LuigiClient from '@luigi-project/client';
+import { navigateToFixedPathResourceDetails } from 'react-shared';
+import { Link } from 'fundamental-react';
 
 export const CronJobsDetails = ({ DefaultRenderer, ...otherParams }) => {
   const { t } = useTranslation();
@@ -30,10 +33,21 @@ export const CronJobsDetails = ({ DefaultRenderer, ...otherParams }) => {
     },
     {
       header: t('cron-jobs.last-job-execution'),
-      value: resource =>
-        resource.status.active
-          ? resource.status.active[resource.status.active.length - 1].name
-          : t('cron-jobs.not-scheduled-yet'),
+      value: resource => {
+        if (!resource.status.active) {
+          return t('cron-jobs.not-scheduled-yet');
+        }
+
+        const jobName =
+          resource.status.active[resource.status.active.length - 1].name;
+        return (
+          <Link
+            onClick={() => navigateToFixedPathResourceDetails('jobs', jobName)}
+          >
+            {jobName}
+          </Link>
+        );
+      },
     },
   ];
 

--- a/core-ui/src/components/Predefined/Details/CronJobs/CronJob.details.js
+++ b/core-ui/src/components/Predefined/Details/CronJobs/CronJob.details.js
@@ -4,7 +4,6 @@ import { CronJobConcurrencyPolicy } from './CronJobConcurrencyPolicy';
 import { CronJobJobs } from './CronJobJobs.js';
 import { CronJobLastScheduleTime } from '../../../../shared/components/CronJob/CronJobLastScheduleTime';
 import { useTranslation } from 'react-i18next';
-import LuigiClient from '@luigi-project/client';
 import { navigateToFixedPathResourceDetails } from 'react-shared';
 import { Link } from 'fundamental-react';
 

--- a/core-ui/src/components/Predefined/Details/CronJobs/CronJobJobs.js
+++ b/core-ui/src/components/Predefined/Details/CronJobs/CronJobJobs.js
@@ -15,7 +15,7 @@ export function CronJobJobs(cronJob) {
       name="jobsList"
       key="cron-job-jobs"
       params={{
-        hasDetailsView: false,
+        hasDetailsView: true,
         fixedPath: true,
         resourceUrl: jobsUrl,
         resourceType: 'jobs',

--- a/core-ui/src/components/Predefined/Details/Job/Job.details.js
+++ b/core-ui/src/components/Predefined/Details/Job/Job.details.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ResourcePods } from './ResourcePods.js';
+import { ResourcePods } from '../ResourcePods.js';
 
 export function JobsDetails({ DefaultRenderer, ...otherParams }) {
   const customColumns = [

--- a/core-ui/src/components/Predefined/Details/Job/Job.details.js
+++ b/core-ui/src/components/Predefined/Details/Job/Job.details.js
@@ -1,12 +1,16 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { ResourcePods } from '../ResourcePods.js';
+import { JobCompletions } from './JobCompletions';
 
 export function JobsDetails({ DefaultRenderer, ...otherParams }) {
+  const { t } = useTranslation();
+
   const customColumns = [
     {
-      header: 'Status',
-      value: job => 'abc',
+      header: t('jobs.completions'),
+      value: job => <JobCompletions job={job} />,
     },
   ];
 

--- a/core-ui/src/components/Predefined/Details/Job/Job.details.js
+++ b/core-ui/src/components/Predefined/Details/Job/Job.details.js
@@ -2,11 +2,19 @@ import React from 'react';
 
 import { ResourcePods } from './ResourcePods.js';
 
-export const DeploymentsDetails = ({ DefaultRenderer, ...otherParams }) => {
+export function JobsDetails({ DefaultRenderer, ...otherParams }) {
+  const customColumns = [
+    {
+      header: 'Status',
+      value: job => 'abc',
+    },
+  ];
+
   return (
     <DefaultRenderer
+      customColumns={customColumns}
       customComponents={[ResourcePods]}
       {...otherParams}
     ></DefaultRenderer>
   );
-};
+}

--- a/core-ui/src/components/Predefined/Details/Job/Job.details.js
+++ b/core-ui/src/components/Predefined/Details/Job/Job.details.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ReadableCreationTimestamp } from 'react-shared';
 
-import { ResourcePods } from '../ResourcePods.js';
+import { ResourcePods } from '../ResourcePods';
 import { JobCompletions } from './JobCompletions';
 import { JobConditions } from './JobConditions';
 

--- a/core-ui/src/components/Predefined/Details/Job/Job.details.js
+++ b/core-ui/src/components/Predefined/Details/Job/Job.details.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ReadableCreationTimestamp } from 'react-shared';
+
 import { ResourcePods } from '../ResourcePods.js';
 import { JobCompletions } from './JobCompletions';
+import { JobConditions } from './JobConditions';
 
 export function JobsDetails({ DefaultRenderer, ...otherParams }) {
   const { t } = useTranslation();
@@ -10,14 +13,40 @@ export function JobsDetails({ DefaultRenderer, ...otherParams }) {
   const customColumns = [
     {
       header: t('jobs.completions'),
-      value: job => <JobCompletions job={job} />,
+      value: job => <JobCompletions key="completions" job={job} />,
+    },
+    {
+      header: t('jobs.start-time'),
+      value: job =>
+        job.status.startTime ? (
+          <ReadableCreationTimestamp
+            key="start"
+            timestamp={job.status.startTime}
+          />
+        ) : (
+          '-'
+        ),
+    },
+    {
+      header: t('jobs.completion-time'),
+      value: job =>
+        job.status.completionTime ? (
+          <ReadableCreationTimestamp
+            key="completion"
+            timestamp={job.status.completionTime}
+          />
+        ) : (
+          '-'
+        ),
     },
   ];
+
+  const customComponents = [JobConditions, ResourcePods];
 
   return (
     <DefaultRenderer
       customColumns={customColumns}
-      customComponents={[ResourcePods]}
+      customComponents={customComponents}
       {...otherParams}
     ></DefaultRenderer>
   );

--- a/core-ui/src/components/Predefined/Details/Job/JobCompletions.js
+++ b/core-ui/src/components/Predefined/Details/Job/JobCompletions.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { StatusBadge } from 'react-shared';
+
+export function JobCompletions({ job }) {
+  const succeeded = job.status.succeeded || 0;
+  const completions = job.spec.completions;
+  const statusType = succeeded === completions ? 'success' : 'info';
+  return (
+    <StatusBadge
+      type={statusType}
+    >{`${succeeded} / ${completions}`}</StatusBadge>
+  );
+}

--- a/core-ui/src/components/Predefined/Details/Job/JobConditions.js
+++ b/core-ui/src/components/Predefined/Details/Job/JobConditions.js
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { GenericList, ReadableCreationTimestamp } from 'react-shared';
 
 export function JobConditions(job) {
-  console.log('job', job);
   const { t } = useTranslation();
 
   if (!job.status.conditions) {

--- a/core-ui/src/components/Predefined/Details/Job/JobConditions.js
+++ b/core-ui/src/components/Predefined/Details/Job/JobConditions.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { GenericList, ReadableCreationTimestamp } from 'react-shared';
+
+export function JobConditions(job) {
+  console.log('job', job);
+  const { t } = useTranslation();
+
+  if (!job.status.conditions) {
+    return <></>;
+  }
+
+  const headerRenderer = () => [
+    t('jobs.conditions.type'),
+    t('jobs.conditions.status'),
+    t('jobs.conditions.last-probe'),
+    t('jobs.conditions.last-transition'),
+  ];
+  const rowRenderer = condition => {
+    return [
+      condition.type,
+      condition.status,
+      <ReadableCreationTimestamp timestamp={condition.lastProbeTime} />,
+      <ReadableCreationTimestamp timestamp={condition.lastTransitionTime} />,
+    ];
+  };
+
+  return (
+    <GenericList
+      key="conditions"
+      title={t('jobs.conditions.title')}
+      showSearchField={false}
+      headerRenderer={headerRenderer}
+      rowRenderer={rowRenderer}
+      entries={job.status.conditions}
+    />
+  );
+}

--- a/core-ui/src/components/Predefined/Details/Job/JobConditions.js
+++ b/core-ui/src/components/Predefined/Details/Job/JobConditions.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { GenericList, ReadableCreationTimestamp } from 'react-shared';
+import {
+  GenericList,
+  ReadableCreationTimestamp,
+  StatusBadge,
+} from 'react-shared';
 
 export function JobConditions(job) {
   const { t } = useTranslation();
-
-  if (!job.status.conditions) {
-    return <></>;
-  }
 
   const headerRenderer = () => [
     t('jobs.conditions.type'),
@@ -16,9 +16,20 @@ export function JobConditions(job) {
     t('jobs.conditions.last-probe'),
     t('jobs.conditions.last-transition'),
   ];
+  const conditionTypeStatus = type => {
+    if (type === 'Complete') {
+      return 'success';
+    } else if (type === 'Failed') {
+      return 'error';
+    } else {
+      return 'info';
+    }
+  };
   const rowRenderer = condition => {
     return [
-      condition.type,
+      <StatusBadge type={conditionTypeStatus(condition.type)}>
+        {condition.type}
+      </StatusBadge>,
       condition.status,
       <ReadableCreationTimestamp timestamp={condition.lastProbeTime} />,
       <ReadableCreationTimestamp timestamp={condition.lastTransitionTime} />,
@@ -32,7 +43,7 @@ export function JobConditions(job) {
       showSearchField={false}
       headerRenderer={headerRenderer}
       rowRenderer={rowRenderer}
-      entries={job.status.conditions}
+      entries={job.status.conditions || []}
     />
   );
 }

--- a/core-ui/src/components/Predefined/Details/Replicaset.details.js
+++ b/core-ui/src/components/Predefined/Details/Replicaset.details.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { ComponentForList } from 'shared/getComponents';
 import { StatusBadge } from 'react-shared';
 
+import { ResourcePods } from './ResourcePods';
+
 export const ReplicasetsDetails = ({ DefaultRenderer, ...otherParams }) => {
   const customColumns = [
     {
@@ -54,30 +56,11 @@ export const ReplicasetsDetails = ({ DefaultRenderer, ...otherParams }) => {
     },
   ];
 
-  const PodsList = (
-    <ComponentForList
-      name="podsList"
-      params={{
-        hasDetailsView: true,
-        fixedPath: true,
-        resourceUrl: `/api/v1/namespaces/${otherParams.namespace}/pods`,
-        resourceType: 'pods',
-        namespace: otherParams.namespace,
-        isCompact: true,
-        showTitle: true,
-        filter: pod =>
-          !!pod.metadata.ownerReferences.find(
-            ref =>
-              ref.kind === 'ReplicaSet' &&
-              ref.name === otherParams.resourceName,
-          ),
-      }}
-    />
-  );
-
   return (
-    <DefaultRenderer customColumns={customColumns} {...otherParams}>
-      {PodsList}
-    </DefaultRenderer>
+    <DefaultRenderer
+      customColumns={customColumns}
+      customComponents={[ResourcePods]}
+      {...otherParams}
+    ></DefaultRenderer>
   );
 };

--- a/core-ui/src/components/Predefined/Details/Replicaset.details.js
+++ b/core-ui/src/components/Predefined/Details/Replicaset.details.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ComponentForList } from 'shared/getComponents';
 import { StatusBadge } from 'react-shared';
 
 import { ResourcePods } from './ResourcePods';

--- a/core-ui/src/components/Predefined/Details/ResourcePods.js
+++ b/core-ui/src/components/Predefined/Details/ResourcePods.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentForList } from 'shared/getComponents';
 
-export function DeploymentPods(resource) {
+export function ResourcePods(resource) {
   if (!resource) return null;
   const labelSelectors = Object.entries(resource.spec.selector.matchLabels)
     .map(([key, value]) => `${key}=${value}`)

--- a/core-ui/src/components/Predefined/Details/index.js
+++ b/core-ui/src/components/Predefined/Details/index.js
@@ -13,3 +13,4 @@ export * from './OAuth2Clients/OAuth2Clients.details';
 export * from './ConfigMap/ConfigMap.details.js';
 export * from './AddonsConfiguration.details';
 export * from './CustomResourceDefinitions/CustomResourceDefinitions.details.js';
+export * from './Job/Job.details';

--- a/core-ui/src/components/Predefined/List/Jobs.list.js
+++ b/core-ui/src/components/Predefined/List/Jobs.list.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { StatusBadge } from 'react-shared';
 import { useTranslation } from 'react-i18next';
 
 import { JobCompletions } from '../Details/Job/JobCompletions';
@@ -11,22 +10,6 @@ export const JobsList = ({ DefaultRenderer, ...otherParams }) => {
     {
       header: t('jobs.completions'),
       value: job => <JobCompletions job={job} />,
-    },
-    {
-      header: t('jobs.conditions'),
-      value: job => {
-        const statusType = status =>
-          status === 'Complete' ? 'success' : 'error';
-        return (
-          <>
-            {job.status.conditions?.map((condition, i) => (
-              <StatusBadge key={i} type={statusType(condition.type)}>
-                {condition.type}
-              </StatusBadge>
-            ))}
-          </>
-        );
-      },
     },
   ];
 

--- a/core-ui/src/components/Predefined/List/Jobs.list.js
+++ b/core-ui/src/components/Predefined/List/Jobs.list.js
@@ -1,25 +1,19 @@
 import React from 'react';
-import { Button } from 'fundamental-react';
 import { StatusBadge } from 'react-shared';
+import { useTranslation } from 'react-i18next';
+
+import { JobCompletions } from '../Details/Job/JobCompletions';
 
 export const JobsList = ({ DefaultRenderer, ...otherParams }) => {
+  const { t } = useTranslation();
+
   const customColumns = [
     {
-      header: 'Runs',
-      value: job => {
-        console.log('job', job);
-        const succeeded = job.status.succeeded || 0;
-        const completions = job.spec.completions;
-        const statusType = succeeded === completions ? 'success' : 'info';
-        return (
-          <StatusBadge
-            type={statusType}
-          >{`${succeeded} / ${completions}`}</StatusBadge>
-        );
-      },
+      header: t('jobs.completions'),
+      value: job => <JobCompletions job={job} />,
     },
     {
-      header: 'Conditions',
+      header: t('jobs.conditions'),
       value: job => {
         const statusType = status =>
           status === 'Complete' ? 'success' : 'error';

--- a/core-ui/src/components/Predefined/List/Jobs.list.js
+++ b/core-ui/src/components/Predefined/List/Jobs.list.js
@@ -1,0 +1,18 @@
+import React from 'react';
+// import { PodStatus } from '../../Details/Pod/PodStatus';
+// import PodRestarts from './PodRestarts';
+
+export const JobsList = ({ DefaultRenderer, ...otherParams }) => {
+  // const customColumns = [
+  // {
+  // header: 'Status',
+  // value: pod => <PodStatus pod={pod} />,
+  // },
+  // {
+  // header: 'Restarts',
+  // value: pod => <PodRestarts statuses={pod.status.containerStatuses} />,
+  // },
+  // ];
+
+  return <DefaultRenderer {...otherParams} />;
+};

--- a/core-ui/src/components/Predefined/List/Jobs.list.js
+++ b/core-ui/src/components/Predefined/List/Jobs.list.js
@@ -1,18 +1,40 @@
 import React from 'react';
-// import { PodStatus } from '../../Details/Pod/PodStatus';
-// import PodRestarts from './PodRestarts';
+import { Button } from 'fundamental-react';
+import { StatusBadge } from 'react-shared';
 
 export const JobsList = ({ DefaultRenderer, ...otherParams }) => {
-  // const customColumns = [
-  // {
-  // header: 'Status',
-  // value: pod => <PodStatus pod={pod} />,
-  // },
-  // {
-  // header: 'Restarts',
-  // value: pod => <PodRestarts statuses={pod.status.containerStatuses} />,
-  // },
-  // ];
+  const customColumns = [
+    {
+      header: 'Runs',
+      value: job => {
+        console.log('job', job);
+        const succeeded = job.status.succeeded || 0;
+        const completions = job.spec.completions;
+        const statusType = succeeded === completions ? 'success' : 'info';
+        return (
+          <StatusBadge
+            type={statusType}
+          >{`${succeeded} / ${completions}`}</StatusBadge>
+        );
+      },
+    },
+    {
+      header: 'Conditions',
+      value: job => {
+        const statusType = status =>
+          status === 'Complete' ? 'success' : 'error';
+        return (
+          <>
+            {job.status.conditions?.map((condition, i) => (
+              <StatusBadge key={i} type={statusType(condition.type)}>
+                {condition.type}
+              </StatusBadge>
+            ))}
+          </>
+        );
+      },
+    },
+  ];
 
-  return <DefaultRenderer {...otherParams} />;
+  return <DefaultRenderer customColumns={customColumns} {...otherParams} />;
 };

--- a/core-ui/src/components/Predefined/List/index.js
+++ b/core-ui/src/components/Predefined/List/index.js
@@ -16,3 +16,4 @@ export * from './LimitRanges.list';
 export * from './ResourceQuotas.list';
 export * from './Events.list';
 export * from './CustomResourceDefinitions.list';
+export * from './Jobs.list.js';

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -18,6 +18,10 @@ pods:
   title: Pods
 deployments:
   title: Deployments
+jobs:
+  title: Jobs
+  completions: Completions
+  conditions: Conditions
 service-catalog:
   title: Service Management
   catalog:

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -18,16 +18,24 @@ pods:
   title: Pods
 deployments:
   title: Deployments
-jobs:
-  title: Jobs
-  completions: Completions
-  conditions: Conditions
 service-catalog:
   title: Service Management
   catalog:
     title: Service Catalog
     services:
       description: Enrich your experience with additional services that are installed outside the cluster.
+jobs:
+  title: Jobs
+  completions: Completions
+  start-time: Start Time
+  completion-time: Completion Time
+  conditions:
+    title: Conditions
+    type: Type
+    status: Status
+    last-probe: Last Probe
+    last-transition: Last Transition
+
 cron-jobs:
   title: Cron Jobs
   schedule: Schedule

--- a/core/src/luigi-config/navigation/static-navigation-model.js
+++ b/core/src/luigi-config/navigation/static-navigation-model.js
@@ -250,6 +250,40 @@ export function getStaticChildrenNodesForNamespace(
         },
       ],
     },
+    {
+      category: 'Workloads',
+      resourceType: 'jobs',
+      pathSegment: 'jobs',
+      label: i18next.t('jobs.title'),
+      viewUrl:
+        config.coreUIModuleUrl +
+        '/namespaces/:namespaceId/jobs?' +
+        toSearchParamsString({
+          resourceApiPath: '/apis/batch/v1',
+          hasDetailsView: true,
+        }),
+      viewGroup: coreUIViewGroupName,
+      keepSelectedForChildren: true,
+
+      navigationContext: 'jobs',
+      children: [
+        {
+          pathSegment: 'details',
+          children: [
+            {
+              pathSegment: ':jobName',
+              resourceType: 'jobs',
+              viewUrl:
+                config.coreUIModuleUrl +
+                '/namespaces/:namespaceId/jobs/:jobName?' +
+                toSearchParamsString({
+                  resourceApiPath: '/apis/batch/v1',
+                }),
+            },
+          ],
+        },
+      ],
+    },
 
     //DISCOVERY AND NETWORK CATEGORY
     {

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-317
+          image: eu.gcr.io/kyma-project/busola-web:PR-319
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- add job list and details
- create a common `ResourcePods` component for pod lists
- **important** use the `ResourcePods` for replica sets - not 100% sure if the results are correct, as the original fetched everything and filtered manually (but since replica sets have all the necessary references, and I didn't notice any differences, I assume it's correct)