### PR TITLE
Handle params from target cluster

### DIFF
--- a/core/src/luigi-config/busola-cluster-params.js
+++ b/core/src/luigi-config/busola-cluster-params.js
@@ -1,6 +1,6 @@
 let params = null;
 
-export async function getClusterParams() {
+export async function getBusolaClusterParams() {
   if (!params) {
     try {
       const cacheBuster = '?cache-buster=' + Date.now();

--- a/core/src/luigi-config/cluster-management.js
+++ b/core/src/luigi-config/cluster-management.js
@@ -102,8 +102,8 @@ export async function saveCARequired() {
       ...cluster.config,
       requiresCA: await checkIfClusterRequiresCA(getAuthData()),
     };
+    await saveClusterParams(cluster);
   }
-  await saveClusterParams(cluster);
 }
 
 export async function getActiveCluster() {
@@ -114,6 +114,7 @@ export async function getActiveCluster() {
   }
   // add target cluster config
   clusters[clusterName].config = merge(
+    {},
     getTargetClusterConfig(),
     clusters[clusterName].config,
   );

--- a/core/src/luigi-config/cluster-management.js
+++ b/core/src/luigi-config/cluster-management.js
@@ -103,10 +103,7 @@ export async function getActiveCluster() {
     getTargetClusterConfig(),
     clusters[clusterName].config,
   );
-  clusters[clusterName] = await mergeParams(
-    clusters[clusterName],
-    'from getactivecluster',
-  );
+  clusters[clusterName] = await mergeParams(clusters[clusterName]);
   return clusters[clusterName];
 }
 
@@ -120,7 +117,7 @@ export function saveActiveClusterName(clusterName) {
 
 // setup params:
 // defaults < config from Busola cluster CM < (config from target cluster CM + init params)
-async function mergeParams(params, f) {
+async function mergeParams(params) {
   const defaultConfig = {
     navigation: {
       disabledNodes: [],

--- a/core/src/luigi-config/cluster-management.js
+++ b/core/src/luigi-config/cluster-management.js
@@ -155,6 +155,12 @@ async function mergeParams(params) {
     ...params.config,
   };
 
+  params.config.features = {
+    ...defaultConfig.features,
+    ...(await getBusolaClusterParams()).config?.features,
+    ...params.config.features,
+  };
+
   // Don't merge hiddenNamespaces, use the defaults only when params are empty
   params.config.hiddenNamespaces =
     params.config?.hiddenNamespaces || DEFAULT_HIDDEN_NAMESPACES;

--- a/core/src/luigi-config/cluster-management.js
+++ b/core/src/luigi-config/cluster-management.js
@@ -118,6 +118,13 @@ export async function getActiveCluster() {
     getTargetClusterConfig(),
     clusters[clusterName].config,
   );
+
+  // merge keys of config.features
+  clusters[clusterName].config.features = {
+    ...clusters[clusterName].config.features,
+    ...getTargetClusterConfig()?.features,
+  };
+
   clusters[clusterName] = await mergeParams(clusters[clusterName]);
   return clusters[clusterName];
 }

--- a/core/src/luigi-config/kubeconfig-id.js
+++ b/core/src/luigi-config/kubeconfig-id.js
@@ -1,4 +1,4 @@
-import { getClusterParams } from './cluster-params';
+import { getBusolaClusterParams } from './busola-cluster-params';
 import { resolveFeatureAvailability } from './features';
 import { DEFAULT_FEATURES, PARAMS_VERSION } from './init-params/constants';
 
@@ -18,7 +18,7 @@ export async function applyKubeconfigIdIfPresent(kubeconfigId, initParams) {
     return;
   }
 
-  const clusterParams = await getClusterParams();
+  const clusterParams = await getBusolaClusterParams();
 
   const kubeconfigIdFeature = {
     ...DEFAULT_FEATURES,

--- a/core/src/luigi-config/luigi-config.js
+++ b/core/src/luigi-config/luigi-config.js
@@ -82,7 +82,7 @@ async function luigiAfterInit() {
 
   const params = await getActiveCluster();
 
-  const kubeconfigUser = params?.currentContext?.user?.user;
+  const kubeconfigUser = params?.currentContext.user.user;
   if (hasNonOidcAuth(kubeconfigUser)) {
     setAuthData(kubeconfigUser);
     await loadTargetClusterConfig(getAuthData());

--- a/core/src/luigi-config/luigi-config.js
+++ b/core/src/luigi-config/luigi-config.js
@@ -23,6 +23,7 @@ import {
 } from './navigation/navigation-data-init';
 import { setTheme, getTheme } from './utils/theme';
 import { readFeatureToggles } from './utils/feature-toggles';
+import { loadTargetClusterConfig } from './utils/target-cluster-config';
 
 export const i18n = i18next.use(i18nextBackend).init({
   lng: localStorage.getItem('busola.language') || 'en',
@@ -56,6 +57,7 @@ async function luigiAfterInit() {
   } else {
     try {
       if (getAuthData() && !hasNonOidcAuth(params.currentContext?.user?.user)) {
+        await loadTargetClusterConfig(getAuthData());
         await addClusterNodes();
       }
     } catch (e) {
@@ -80,9 +82,10 @@ async function luigiAfterInit() {
 
   const params = await getActiveCluster();
 
-  const kubeconfigUser = params?.currentContext.user.user;
+  const kubeconfigUser = params?.currentContext?.user?.user;
   if (hasNonOidcAuth(kubeconfigUser)) {
     setAuthData(kubeconfigUser);
+    await loadTargetClusterConfig(getAuthData());
   }
 
   const luigiConfig = {

--- a/core/src/luigi-config/luigi-config.js
+++ b/core/src/luigi-config/luigi-config.js
@@ -14,6 +14,7 @@ import { saveQueryParamsIfPresent } from './init-params/init-params.js';
 import {
   getActiveCluster,
   handleResetEndpoint,
+  saveCARequired,
   setActiveClusterIfPresentInUrl,
 } from './cluster-management';
 
@@ -57,7 +58,8 @@ async function luigiAfterInit() {
   } else {
     try {
       if (getAuthData() && !hasNonOidcAuth(params.currentContext?.user?.user)) {
-        await loadTargetClusterConfig(getAuthData());
+        await saveCARequired();
+        await loadTargetClusterConfig();
         await addClusterNodes();
       }
     } catch (e) {
@@ -85,7 +87,8 @@ async function luigiAfterInit() {
   const kubeconfigUser = params?.currentContext.user.user;
   if (hasNonOidcAuth(kubeconfigUser)) {
     setAuthData(kubeconfigUser);
-    await loadTargetClusterConfig(getAuthData());
+    await saveCARequired();
+    await loadTargetClusterConfig();
   }
 
   const luigiConfig = {

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -6,7 +6,7 @@ import {
   checkIfClusterRequiresCA,
   fetchObservabilityHost,
 } from './queries';
-import { getClusterParams } from '../cluster-params';
+import { getBusolaClusterParams } from '../busola-cluster-params';
 import { config } from '../config';
 import {
   coreUIViewGroupName,
@@ -233,8 +233,8 @@ async function getObservabilityNodes(authData, enabledFeatures) {
     enabledFeatures.OBSERVABILITY?.config.links;
 
   if (!links) {
-    const defaultObservability = (await getClusterParams()).config.features
-      .OBSERVABILITY;
+    const defaultObservability = (await getBusolaClusterParams()).config
+      .features.OBSERVABILITY;
     links =
       (await resolveFeatureAvailability(defaultObservability)) && //  use the Busola configMap as a fallback
       defaultObservability.config.links;

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -231,8 +231,8 @@ async function getObservabilityNodes(authData, enabledFeatures) {
     enabledFeatures.OBSERVABILITY?.config.links;
 
   if (!links) {
-    let defaultObservability = (await getBusolaClusterParams()).config.features
-      .OBSERVABILITY;
+    const defaultObservability = (await getBusolaClusterParams()).config
+      .features.OBSERVABILITY;
     links =
       (await resolveFeatureAvailability(defaultObservability)) && //  use the Busola configMap as a fallback
       defaultObservability.config.links;

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -3,7 +3,6 @@ import {
   fetchPermissions,
   fetchBusolaInitData,
   fetchNamespaces,
-  checkIfClusterRequiresCA,
   fetchObservabilityHost,
 } from './queries';
 import { getBusolaClusterParams } from '../busola-cluster-params';
@@ -31,7 +30,6 @@ import {
   deleteActiveCluster,
   saveActiveClusterName,
   getCurrentContextNamespace,
-  saveClusterParams,
 } from '../cluster-management';
 import { getFeatureToggle } from '../utils/feature-toggles';
 import { saveLocation } from './previous-location';
@@ -267,15 +265,6 @@ async function getObservabilityNodes(authData, enabledFeatures) {
 
 export async function getNavigationData(authData) {
   const activeCluster = await getActiveCluster();
-
-  if (activeCluster.config.requiresCA === undefined) {
-    activeCluster.config = {
-      ...activeCluster.config,
-      requiresCA: await checkIfClusterRequiresCA(authData),
-    };
-  }
-
-  await saveClusterParams(activeCluster);
 
   const { kubeconfig } = activeCluster;
 

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -233,8 +233,8 @@ async function getObservabilityNodes(authData, enabledFeatures) {
     enabledFeatures.OBSERVABILITY?.config.links;
 
   if (!links) {
-    const defaultObservability = (await getBusolaClusterParams()).config
-      .features.OBSERVABILITY;
+    let defaultObservability = (await getBusolaClusterParams()).config.features
+      .OBSERVABILITY;
     links =
       (await resolveFeatureAvailability(defaultObservability)) && //  use the Busola configMap as a fallback
       defaultObservability.config.links;

--- a/core/src/luigi-config/utils/target-cluster-config.js
+++ b/core/src/luigi-config/utils/target-cluster-config.js
@@ -1,0 +1,23 @@
+import { config } from './../config';
+import { failFastFetch } from './../navigation/queries';
+
+let clusterConfig = null;
+
+export function getTargetClusterConfig() {
+  return clusterConfig;
+}
+
+export async function loadTargetClusterConfig(auth) {
+  try {
+    const res = await failFastFetch(
+      config.backendAddress +
+        '/api/v1/namespaces/kube-public/configmaps/busola-config',
+      auth,
+    );
+    const data = (await res.json()).data.config;
+    clusterConfig = JSON.parse(data);
+    console.log('CONFIG LOADED');
+  } catch (e) {
+    console.warn(e);
+  }
+}

--- a/core/src/luigi-config/utils/target-cluster-config.js
+++ b/core/src/luigi-config/utils/target-cluster-config.js
@@ -1,3 +1,4 @@
+import { getAuthData } from '../auth/auth-storage';
 import { config } from './../config';
 import { failFastFetch } from './../navigation/queries';
 
@@ -7,19 +8,19 @@ export function getTargetClusterConfig() {
   return clusterConfig;
 }
 
-export async function loadTargetClusterConfig(auth) {
+export async function loadTargetClusterConfig() {
   try {
     const res = await failFastFetch(
       config.backendAddress +
         '/api/v1/namespaces/kube-public/configmaps/busola-config',
-      auth,
+      getAuthData(),
     );
     clusterConfig = JSON.parse((await res.json()).data.config);
   } catch (e) {
-    if (e.statusCode === 404) {
-      return {}; // there's no custom config on target cluster
-    } else {
+    if (e.statusCode !== 404) {
+      // don't warn on Not Found, that's fine
       console.warn(e);
     }
+    clusterConfig = {};
   }
 }

--- a/core/src/luigi-config/utils/target-cluster-config.js
+++ b/core/src/luigi-config/utils/target-cluster-config.js
@@ -14,10 +14,12 @@ export async function loadTargetClusterConfig(auth) {
         '/api/v1/namespaces/kube-public/configmaps/busola-config',
       auth,
     );
-    const data = (await res.json()).data.config;
-    clusterConfig = JSON.parse(data);
-    console.log('CONFIG LOADED');
+    clusterConfig = JSON.parse((await res.json()).data.config);
   } catch (e) {
-    console.warn(e);
+    if (e.statusCode === 404) {
+      return {}; // there's no custom config on target cluster
+    } else {
+      console.warn(e);
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,html,css,yaml,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "husky": {

--- a/resources/backend/deployment.yaml
+++ b/resources/backend/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: backend
-          image: eu.gcr.io/kyma-project/busola-backend:PR-318
+          image: eu.gcr.io/kyma-project/busola-backend:PR-324
           imagePullPolicy: Always
           resources:
             limits:

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-322
+          image: eu.gcr.io/kyma-project/busola-web:PR-324
           imagePullPolicy: Always
           resources:
             requests:

--- a/shared/contexts/ThemeContext.js
+++ b/shared/contexts/ThemeContext.js
@@ -30,7 +30,7 @@ const getEditorTheme = theme => {
       return 'hc-black';
     case 'light_dark':
       return window.matchMedia &&
-        window.matchMedia('(prefers-color-scheme: dark)')
+        window.matchMedia('(prefers-color-scheme: dark)').matches
         ? 'vs-dark'
         : 'vs';
     default:

--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -24,6 +24,7 @@
     "invalid-kubeconfig.spec.js",
     "login-enkode.spec.js",
     "other-logins.spec.js",
+    "cluster-configuration.spec.js",
     "run-after.spec.js"
   ]
 }

--- a/tests/tests/cluster-configuration.spec.js
+++ b/tests/tests/cluster-configuration.spec.js
@@ -1,50 +1,51 @@
 /// <reference types="cypress" />
 import 'cypress-file-upload';
 import config from '../config';
-import {
-  generateDefaultParams,
-  generateParamsWithPreselectedNamespace,
-  generateParamsWithNoKubeconfig,
-  generateParamsAndToken,
-  generateParamsWithHiddenNamespacesList,
-  generateParamsWithDisabledFeatures,
-  generateUnsupportedVersionParams,
-  generateWithKubeconfigId,
-} from '../support/enkode';
+import { generateDefaultParams } from '../support/enkode';
 
-context('Cluster configuration', () => {
-  it('Applies config from target cluster', () => {
-    const configMock = {
-      data: {
-        config: JSON.stringify({
-          navigation: {
-            disabledNodes: [],
-            externalNodes: [
+const configMock = {
+  data: {
+    config: JSON.stringify({
+      navigation: {
+        disabledNodes: [],
+        externalNodes: [
+          {
+            category: 'Category from target cluster',
+            icon: 'course-book',
+            children: [
               {
-                category: 'Category from target cluster',
-                icon: 'course-book',
-                children: [
-                  {
-                    label: 'Example label',
-                    link: 'http://test',
-                  },
-                ],
+                label: 'Example label',
+                link: 'http://test',
               },
             ],
           },
-        }),
+        ],
       },
-    };
-    cy.intercept(
-      {
-        method: 'GET',
-        url: '/backend/api/v1/namespaces/kube-public/configmaps/busola-config',
-      },
-      configMock,
-    );
+    }),
+  },
+};
+
+const requestData = {
+  method: 'GET',
+  url: '/backend/api/v1/namespaces/kube-public/configmaps/busola-config',
+};
+
+context('Cluster configuration', () => {
+  it('Applies config from target cluster', () => {
+    cy.intercept(requestData, configMock);
     cy.loginAndSelectCluster();
     cy.url().should('match', /namespaces$/);
 
     cy.contains('Category from target cluster').should('be.visible');
+  });
+
+  it('Init params config override target cluster config', () => {
+    cy.intercept(requestData, configMock);
+    cy.wrap(generateDefaultParams()).then(params => {
+      cy.visit(`${config.clusterAddress}/clusters?init=${params}`);
+    });
+    cy.url().should('match', /namespaces$/);
+
+    cy.contains('Category from target cluster').should('not.exist');
   });
 });

--- a/tests/tests/cluster-configuration.spec.js
+++ b/tests/tests/cluster-configuration.spec.js
@@ -1,0 +1,50 @@
+/// <reference types="cypress" />
+import 'cypress-file-upload';
+import config from '../config';
+import {
+  generateDefaultParams,
+  generateParamsWithPreselectedNamespace,
+  generateParamsWithNoKubeconfig,
+  generateParamsAndToken,
+  generateParamsWithHiddenNamespacesList,
+  generateParamsWithDisabledFeatures,
+  generateUnsupportedVersionParams,
+  generateWithKubeconfigId,
+} from '../support/enkode';
+
+context('Cluster configuration', () => {
+  it('Applies config from target cluster', () => {
+    const configMock = {
+      data: {
+        config: JSON.stringify({
+          navigation: {
+            disabledNodes: [],
+            externalNodes: [
+              {
+                category: 'Category from target cluster',
+                icon: 'course-book',
+                children: [
+                  {
+                    label: 'Example label',
+                    link: 'http://test',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      },
+    };
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/backend/api/v1/namespaces/kube-public/configmaps/busola-config',
+      },
+      configMock,
+    );
+    cy.loginAndSelectCluster();
+    cy.url().should('match', /namespaces$/);
+
+    cy.contains('Category from target cluster').should('be.visible');
+  });
+});


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add possibility to configure Busola by target cluster. The order is as follows: init params *override* configmap from target cluster *overrides* Busola cluster configmap *overrides* default built-in config.
- I've placed the configmap (`busola-config`) in kube-public namespace, [as it seemed to fit here](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#viewing-namespaces).
- Add a test for loading the config.
- Shut up the `lint-staged` warning (that yellow one on `git commit`).
- Fix Monaco editor's theme bug.

Testing:
- `kmain` - configmap with custom `externalLinks`
- `main` - configmap with custom `externalLinks`
- `llama` - no configmap here.


