### PR TITLE
Fix lists refresh & CM create styles

### DIFF
--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-329
+          image: eu.gcr.io/kyma-project/busola-web:PR-330
           imagePullPolicy: Always
           resources:
             requests:

--- a/shared/components/KeyValueForm/KeyValueForm.js
+++ b/shared/components/KeyValueForm/KeyValueForm.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, FormLabel, FormInput, Icon } from 'fundamental-react';
+import {
+  Button,
+  FormLabel,
+  FormInput,
+  FormTextarea,
+  Icon,
+} from 'fundamental-react';
 import { Tooltip } from '../..';
 import { fromEntries, toEntries, readFromFile } from './helpers';
 import { v4 as uuid } from 'uuid';
@@ -92,7 +98,7 @@ export function KeyValueForm({
                 }}
                 value={entry.key}
               />
-              <textarea
+              <FormTextarea
                 className="value-textarea"
                 name="value"
                 placeholder="Value"

--- a/shared/components/KeyValueForm/KeyValueForm.scss
+++ b/shared/components/KeyValueForm/KeyValueForm.scss
@@ -21,10 +21,7 @@
     }
 
     .value-textarea {
-        resize: none;
-        box-sizing: border-box;
-        height: 36px;
-        margin-top: 4px;
-        padding: 8px;
+        resize: vertical;
+        height: 37px;
     }
 }

--- a/shared/hooks/BackendAPI/useGet.js
+++ b/shared/hooks/BackendAPI/useGet.js
@@ -194,6 +194,7 @@ function handleListDataReceived(filter) {
 
     if (
       !oldData ||
+      newData.items.length !== oldData.length ||
       (lastResourceVersionRef.current !== newData.metadata.resourceVersion &&
         !newData.items.every(
           (item, idx) =>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- We didn't compare lists lengths in `useGet`, so the hook didn't update the list. Fixed!
- I was to check for Function's variables list - it refreshes properly, no work done here.
- Use `FormTextArea` instead of `textarea` in ConfigMap (& Secret) editor, simplifying CSS and making it react to theme changes.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
