### PR TITLE
Fix logs

### DIFF
--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-327
+          image: eu.gcr.io/kyma-project/busola-web:PR-331
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
# Why?

The root cause was not finishing the `follow=true` requests:
![image](https://user-images.githubusercontent.com/10504661/128864440-40966082-ca9a-4d10-875e-4aab45e0395a.png)

As you can see above, there are 3 requests (I've switched logs time range twice). They go on and on, finally making the browser sick. The same thing occurred when we navigated out of logs view - the requests were still on.

Here is a screen from my PR:
![image](https://user-images.githubusercontent.com/10504661/128864977-80e0bb55-e51e-4b76-8a4b-95d80984095a.png)

Here I switched logs range twice again, and then navigated out of the view. I dunno why preflights are shown... Anyway, all it was to just call `response.body.getReader::cancel` method.

Also, I've removed the `abortController`, as it turned out it serves nothing.

# Testing

You can drop this talkative `Job` on a cluster and check the pod's logs.
```
kind: Job
apiVersion: batch/v1
metadata:
  name: hell-yeah
  namespace: default
spec:
  parallelism: 1
  completions: 1
  backoffLimit: 6
  template:
    spec:
      containers:
        - name: hello
          image: busybox
          command:
            - /bin/sh
            - '-c'
            - while [ condition ]; do date && sleep 5 ; done
          resources: {}
          terminationMessagePath: /dev/termination-log
          terminationMessagePolicy: File
          imagePullPolicy: IfNotPresent
      restartPolicy: OnFailure
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      securityContext: {}
      schedulerName: default-scheduler
```

