### PR TITLE
Store configuration in sessionStorage in Docker

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -43,6 +43,9 @@ COPY --from=builder /app/backend/certs.pem /app/certs.pem
 COPY --from=builder /app/backend/package* /app/
 RUN npm ci --only=production
 
+# use sessionStorage as default
+RUN sed -i 's/"defaultStorage": "localStorage",/"defaultStorage": "sessionStorage",/g' core/assets/config/config.json 
+
 EXPOSE 3001
 ENV NODE_ENV=production ADDRESS=0.0.0.0 IS_DOCKER=true
 CMD ["node", "backend-production.js"]

--- a/core/src/luigi-config/cluster-management/cluster-management.js
+++ b/core/src/luigi-config/cluster-management/cluster-management.js
@@ -158,7 +158,7 @@ async function mergeParams(params) {
     },
     hiddenNamespaces: DEFAULT_HIDDEN_NAMESPACES,
     features: DEFAULT_FEATURES,
-    storage: 'localStorage',
+    storage: await clusterStorage.getDefaultStorage(),
   };
 
   params.config = {
@@ -207,9 +207,7 @@ export async function deleteActiveCluster() {
 }
 
 export async function saveClusters(clusters) {
-  const defaultStorage =
-    (await getBusolaClusterParams()).config.storage || 'localStorage';
-  clusterStorage.save(clusters, defaultStorage);
+  await clusterStorage.save(clusters);
 }
 
 export function handleResetEndpoint() {

--- a/core/src/luigi-config/init-params/init-params.js
+++ b/core/src/luigi-config/init-params/init-params.js
@@ -11,6 +11,7 @@ import {
 import * as constants from './constants';
 import { hasNonOidcAuth } from '../auth/auth';
 import { applyKubeconfigIdIfPresent } from './../kubeconfig-id';
+import { getDefaultStorage } from '../cluster-management/clusters-storage';
 
 const getEncoder = async () => {
   const createEncoder = (await import('json-url')).default;
@@ -78,7 +79,7 @@ async function setupFromParams() {
         ...constants.DEFAULT_FEATURES,
         ...(decoded.config?.features || {}),
       },
-      storage: 'localStorage',
+      storage: await getDefaultStorage(),
     },
     currentContext: {
       cluster: decoded.kubeconfig.clusters[0],

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-342
+          image: eu.gcr.io/kyma-project/busola-web:PR-347
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace `defaultStorage` for Docker builds
- Propagate storage to other scripts

Testing:

- You can check out Docker image: `docker run -p 3001:3001 wawrzyn321/busola-local-347`

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
