### PR TITLE
Warn on missing translation key

### DIFF
--- a/core-ui/src/components/Clusters/views/ClusterOverview/ClusterOverviewHeader.js
+++ b/core-ui/src/components/Clusters/views/ClusterOverview/ClusterOverviewHeader.js
@@ -18,7 +18,7 @@ export function ClusterOverviewHeader() {
   } = useGet('/version');
 
   function formatClusterVersion() {
-    if (versionLoading) return t('common.loading');
+    if (versionLoading) return t('common.headers.loading');
     if (versionError) return getErrorMessage(versionError);
     return version.gitVersion;
   }

--- a/core-ui/src/index.js
+++ b/core-ui/src/index.js
@@ -16,11 +16,17 @@ i18next
   .use(initReactI18next)
   .use(i18nextBackend)
   .init({
-    lng: false,
+    lng: 'en',
     fallbackLng: false,
     backend: {
       loadPath: '/i18n/{{lng}}.yaml',
       parse: data => yaml.load(data),
+    },
+    saveMissing: true,
+    missingKeyHandler: (_lngs, _ns, key) => {
+      if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+        console.warn(key);
+      }
     },
   });
 

--- a/core/src/luigi-config/luigi-config.js
+++ b/core/src/luigi-config/luigi-config.js
@@ -34,6 +34,10 @@ export const i18n = i18next.use(i18nextBackend).init({
     loadPath: '/i18n/{{lng}}.yaml',
     parse: data => yaml.load(data),
   },
+  saveMissing: true,
+  missingKeyHandler: (_lngs, _ns, key) => {
+    console.warn(key);
+  },
 });
 
 export const NODE_PARAM_PREFIX = `~`;

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-368
+          image: eu.gcr.io/kyma-project/busola-web:PR-369
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- I've added a handler in `core` and `core-ui`.
	- I've also changed the default language in `core-ui` - it was `undefined` at start (before proper one came from `MicrofrontendContext`), causing some false positive warnings.
	- There's no detection of "dev vs prod" in `core`, as we always build into `production`... There won't be many changes anyways.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
