### PR TITLE
Backend security fixes

### DIFF
--- a/backend/common.js
+++ b/backend/common.js
@@ -2,11 +2,16 @@ const https = require('https');
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
+const uuid = require('uuid').v4;
 import { handleDockerDesktopSubsitution } from './docker-desktop-substitution';
 import { filters } from './request-filters';
 
 const logger = require('pino-http')({
   autoLogging: process.env.NODE_ENV === 'production', //to disable the automatic "request completed" and "request errored" logging.
+  genReqId: req => {
+    req.id = uuid();
+    return req.id;
+  },
   serializers: {
     req: req => ({
       id: req.id,
@@ -99,9 +104,7 @@ export const handleRequest = async (req, res) => {
 
   function throwInternalServerError(originalError) {
     req.log.warn(originalError);
-    res.statusMessage = 'Bad Gateway';
-    res.statusCode = 502;
-    res.end();
+    res.status(502).send('Request ID: ' + req.id);
   }
 };
 

--- a/backend/common.js
+++ b/backend/common.js
@@ -63,7 +63,7 @@ export const handleRequest = async (req, res) => {
     filters.forEach(filter => filter(req, headersData));
   } catch (e) {
     req.log.error('Filters rejected the request: ' + e.message);
-    res.sendStatus(400);
+    res.status(400).send('Request ID: ' + req.id);
     return;
   }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ import { handleRequest, serveStaticApp, serveMonaco } from './common';
 import { requestLogger } from './utils/other';
 
 const app = express();
+app.disable('x-powered-by');
 app.use(express.raw({ type: '*/*', limit: '100mb' }));
 if (process.env.NODE_ENV === 'development') {
   app.use(cors({ origin: '*' }));

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5566,6 +5566,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "https": "^1.0.0",
-    "pino-http": "^5.7.0"
+    "pino-http": "^5.7.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/core/src/luigi-config/auth/auth.js
+++ b/core/src/luigi-config/auth/auth.js
@@ -17,7 +17,7 @@ export function hasNonOidcAuth(user) {
 
 function updateLuigiAuth(auth) {
   if (!Luigi.getConfig()) {
-    throw Error('Cannot updateLuigiAuth, Luigi config is not set.');
+    throw Error('Cannot updateLuigiAuth, luigi config is not set.');
   }
   Luigi.getConfig().auth = auth;
   Luigi.configChanged();

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -50,12 +50,6 @@ http {
         access_log /dev/stdout combined if=$nonSuccessful;
         server_tokens off;
 
-        add_header 'Cache-Control' 'public, max-age=300';
-        add_header X-Frame-Options 'SAMEORIGIN';
-        add_header X-Content-Type-Options 'nosniff';
-        add_header Strict-Transport-Security 'max-age=31536000';
-        add_header X-XSS-Protection '1; mode=block';
-
         location / {
             limit_except GET {
                 deny all;
@@ -64,6 +58,11 @@ http {
             root   /app/core;
             try_files $uri $uri/ $uri$args $uri$args/ /index.html;
             add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://* wss://*; font-src 'self' data:; frame-ancestors 'self'; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+            add_header 'Cache-Control' 'no-cache, no-store';
+            add_header X-Frame-Options 'SAMEORIGIN';
+            add_header X-Content-Type-Options 'nosniff';
+            add_header Strict-Transport-Security 'max-age=31536000';
+            add_header X-XSS-Protection '1; mode=block';
         }
 
         location /core-ui {
@@ -73,6 +72,11 @@ http {
             root /app;
             try_files $uri $uri/ $uri$args $uri$args/ /core-ui/index.html;
             add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-7fF0zlMDaJyxa8K3gkd0Gnt657Obx/gdAct0hR/pdds=' 'sha256-bjOtDHhqB+wVlyFDAxz9e0RvTn+EEec/Z4mpjUjNvAs=' data: blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' * https://* wss://*; font-src 'self' data:; frame-ancestors https://*; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:;  worker-src 'self' blob: data:;";
+            add_header 'Cache-Control' 'no-cache, no-store';
+            add_header X-Frame-Options 'SAMEORIGIN';
+            add_header X-Content-Type-Options 'nosniff';
+            add_header Strict-Transport-Security 'max-age=31536000';
+            add_header X-XSS-Protection '1; mode=block';
         }
 
         location /service-catalog {
@@ -83,6 +87,11 @@ http {
             try_files $uri $uri/ $uri$args $uri$args/ /service-catalog/index.html;
             add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'sha256-bjOtDHhqB+wVlyFDAxz9e0RvTn+EEec/Z4mpjUjNvAs=' data: blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' * https://* wss://*; font-src 'self' data:; frame-ancestors https://*; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob: data:;";
             # allow unsafe-eval scripts because of "ajv" module - https://github.com/ajv-validator/ajv/issues/406    
+            add_header 'Cache-Control' 'no-cache, no-store';
+            add_header X-Frame-Options 'SAMEORIGIN';
+            add_header X-Content-Type-Options 'nosniff';
+            add_header Strict-Transport-Security 'max-age=31536000';
+            add_header X-XSS-Protection '1; mode=block';   
         }
 
         #error_page  404              /404.html;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -48,7 +48,7 @@ http {
         include      /usr/share/nginx-extended/nginx-*.conf;
         index        index.html index.htm;
         access_log /dev/stdout combined if=$nonSuccessful;
-
+        server_tokens off;
 
         add_header 'Cache-Control' 'public, max-age=300';
         add_header X-Frame-Options 'SAMEORIGIN';

--- a/resources/backend/deployment.yaml
+++ b/resources/backend/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: backend
-          image: eu.gcr.io/kyma-project/busola-backend:PR-409
+          image: eu.gcr.io/kyma-project/busola-backend:PR-414
           imagePullPolicy: Always
           resources:
             limits:

--- a/resources/ingress.yaml
+++ b/resources/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/server-snippet: 'server_tokens off;' # hide nginx version
 spec:
   ingressClassName: nginx
   rules:

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-406
+          image: eu.gcr.io/kyma-project/busola-web:PR-414
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Disable the `X-Powered-By: Express` header.
- Add `Cache-Control`. Funny thing, it looks like none of those headers was actually sent, so I moved 'em to `location` directive. Just copied them, we could use `include` for this, but I don't think it's worth it.
- Add additional data to 50x errors: request id. I'm not proud of modifying original `Request` by adding an `id` prop, so ideas are welcome.
- I've disabled the version (with `server_tokens off` directive).
- A matter of nginx version (and testing it!): we have actually 2 nginxes - one in `web` pod, another one in ingress controller.
	- `web` - just curl the Busola url with http (it should 308 you to https)
	- ingress - curl invalid url, e.g. tets.howdy.hasselhoff.shoot.canary.k8s-hana.ondemand.com. It should return 404.

If yo lazy:
```
curl tets.howdy.hasselhoff.shoot.canary.k8s-hana.ondemand.com (response from ingress, 404)
curl http://backend-security.howdy.hasselhoff.shoot.canary.k8s-hana.ondemand.com (response from `web`, 308 to https).
curl -XPOST https://backend-security.howdy.hasselhoff.shoot.canary.k8s-hana.ondemand.com (response from `web`, 403).
curl -XTRACE https://backend-security.howdy.hasselhoff.shoot.canary.k8s-hana.ondemand.com (response from... something).
```
None of above should contain nginx version.


BTW I had to add some stupid change to force the web job to run - apparently CI doesn't pick up changes in nginx dir.