### PR TITLE
Fix eventing tests

### DIFF
--- a/tests/support/views/functions-view.js
+++ b/tests/support/views/functions-view.js
@@ -60,7 +60,7 @@ Cypress.Commands.add(
     cy.readFile(dependenciesPath).then(body => {
       cy.getIframeBody()
         .find('textarea[aria-roledescription="editor"]')
-        .filter(':visible'
+        .filter(':visible')
         // cy.clear sometimes fails, removing only the first character - use this as a workaround
         .type('{selectall}{backspace}{selectall}{backspace}')
         .paste({


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Soooo... it turns out it was our fault. Or rather, Cypress's fault.
I've inspected the logs of a function from the failed test (there was 500 error there) and noticed that function's code is almost doubled - it's not an uncommon problem: https://stackoverflow.com/questions/57378083/cy-clear-not-clearing-input-field-properly-cypress/61101054 

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
