### PR TITLE
Automated tests for Replica sets

### DIFF
--- a/core-ui/src/components/Predefined/Create/ReplicaSets/ReplicaSets.create.js
+++ b/core-ui/src/components/Predefined/Create/ReplicaSets/ReplicaSets.create.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as jp from 'jsonpath';
+import * as _ from 'lodash';
 
 import { ResourceForm } from 'shared/ResourceForm/ResourceForm';
 import * as Inputs from 'shared/ResourceForm/components/Inputs';
@@ -12,7 +13,9 @@ import {
   AdvancedContainersView,
 } from 'shared/components/Deployment/ContainersViews';
 
-export function ReplicaSetsCreate({
+function ReplicaSetsCreate({
+  resourceUrl,
+  resource: initialReplicaSet,
   formElementRef,
   namespace,
   onChange,
@@ -21,7 +24,7 @@ export function ReplicaSetsCreate({
   const { t } = useTranslation();
 
   const [replicaset, setReplicaSet] = useState(
-    createReplicaSetTemplate(namespace),
+    _.cloneDeep(initialReplicaSet) || createReplicaSetTemplate(namespace),
   );
 
   useEffect(() => {
@@ -49,12 +52,14 @@ export function ReplicaSetsCreate({
       setResource={setReplicaSet}
       onChange={onChange}
       formElementRef={formElementRef}
-      createUrl={`/apis/apps/v1/namespaces/${namespace}/replicasets/`}
+      createUrl={resourceUrl}
+      initialResource={initialReplicaSet}
     >
       <ResourceForm.K8sNameField
         propertyPath="$.metadata.name"
         kind={t('replica-sets.name_singular')}
         setValue={handleNameChange}
+        readOnly={!!initialReplicaSet}
       />
       <ResourceForm.KeyValueField
         advanced
@@ -109,3 +114,5 @@ export function ReplicaSetsCreate({
     </ResourceForm>
   );
 }
+ReplicaSetsCreate.allowEdit = true;
+export { ReplicaSetsCreate };

--- a/core-ui/src/shared/components/Deployment/ContainersViews.js
+++ b/core-ui/src/shared/components/Deployment/ContainersViews.js
@@ -107,7 +107,7 @@ export function AdvancedContainersView({
               setOpen(true);
             }}
           >
-            Add Container
+            {t('deployments.create-modal.advanced.add-container')}
           </Button>
         )}
       >

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -557,6 +557,7 @@ daemon-sets:
 deployments:
   create-modal:
     advanced:
+      add-container: Add Container
       container-header: Container {{name}}
       containers: Containers
       cpu-limits: CPU Limits

--- a/core/src/luigi-config/communication.js
+++ b/core/src/luigi-config/communication.js
@@ -32,7 +32,6 @@ export const communication = {
     },
     'busola.dontConfirmDelete': ({ value }) => {
       setFeatureToggle('dontConfirmDelete', value);
-      Luigi.configChanged();
     },
     'busola.refreshNavigation': () => {
       Luigi.configChanged('navigation.nodes');

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-570
+          image: eu.gcr.io/kyma-project/busola-web:PR-582
           imagePullPolicy: Always
           resources:
             requests:

--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -16,9 +16,25 @@
   "experimentalInteractiveRunEvents": true,
   "testFiles": [
     "run-before.spec.js",
-
+    "create-a-deployment.spec.js",
+    "create-an-api-rule.spec.js",
+    "download-a-kubeconfig.spec.js",
+    "in-cluster-eventing.spec.js",
+    "test-cluster-overview.spec.js",
+    "smoke-tests.spec.js",
+    "test-jobs.spec.js",
     "test-replica-sets.spec.js",
-
+    "test-crds.spec.js",
+    "test-cron-jobs.spec.js",
+    "test-git-repositories.spec.js",
+    "test-gateways.spec.js",
+    "test-oauth2.spec.js",
+    "test-dns-providers.spec.js",
+    "invalid-kubeconfig.spec.js",
+    "login-kubeconfigID.spec.js",
+    "other-logins.spec.js",
+    "cluster-configuration.spec.js",
+    "add-cluster-disabled.spec.js",
     "run-after.spec.js"
   ]
 }

--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -22,6 +22,7 @@
     "test-cluster-overview.spec.js",
     "smoke-tests.spec.js",
     "test-crds.spec.js",
+    "test-replica-sets.spec.js",
     "invalid-kubeconfig.spec.js",
     "login-kubeconfigID.spec.js",
     "other-logins.spec.js",

--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -16,20 +16,9 @@
   "experimentalInteractiveRunEvents": true,
   "testFiles": [
     "run-before.spec.js",
-    "create-a-deployment.spec.js",
-    "download-a-kubeconfig.spec.js",
-    "in-cluster-eventing.spec.js",
-    "test-cluster-overview.spec.js",
-    "smoke-tests.spec.js",
-    "test-crds.spec.js",
+
     "test-replica-sets.spec.js",
-    "test-git-repositories.spec.js",
-    "test-oauth2.spec.js",
-    "invalid-kubeconfig.spec.js",
-    "login-kubeconfigID.spec.js",
-    "other-logins.spec.js",
-    "cluster-configuration.spec.js",
-    "add-cluster-disabled.spec.js",
+
     "run-after.spec.js"
   ]
 }

--- a/tests/tests/test-replica-sets.spec.js
+++ b/tests/tests/test-replica-sets.spec.js
@@ -2,7 +2,11 @@
 import 'cypress-file-upload';
 
 const REPLICA_SET_NAME = 'test-replica-set';
+const REPLICAS_AMOUNT = 2;
 const DOCKER_IMAGE_TAG = 'bitnami/nginx';
+
+const EDITED_REPLICAS_AMOUNT = 1;
+const EDITED_DOCKER_IMAGE_TAG = 'test-replica-set-image';
 context('Create a Replica Set', () => {
   before(() => {
     cy.loginAndSelectCluster();
@@ -33,19 +37,19 @@ context('Create a Replica Set', () => {
       .clear()
       .type(REPLICA_SET_NAME);
 
-    const replicasAmount = 1;
     cy.getIframeBody()
       .find('[placeholder="Replicas"]')
       .clear()
-      .type(replicasAmount)
-      .should('have.value', replicasAmount);
+      .type(REPLICAS_AMOUNT)
+      .should('have.value', REPLICAS_AMOUNT);
 
     cy.getIframeBody()
       .find(
         '[placeholder="Enter the Docker image tag, for example, bitnami/nginx."]',
       )
       .clear()
-      .type(DOCKER_IMAGE_TAG);
+      .type(DOCKER_IMAGE_TAG)
+      .should('have.value', DOCKER_IMAGE_TAG);
 
     cy.getIframeBody()
       .find('[role="document"]')
@@ -53,19 +57,75 @@ context('Create a Replica Set', () => {
       .click();
   });
 
-  it('Checks details view', () => {
+  it('Checks the details view', () => {
     cy.getIframeBody()
       .contains(`${REPLICA_SET_NAME}-`)
       .click();
 
-    cy.getIframeBody('Containers')
-      .parent()
-      .getIframeBody()
-      .contains(REPLICA_SET_NAME);
+    cy.getIframeBody().contains(`Name:${REPLICA_SET_NAME}`);
 
-    cy.getIframeBody('Containers')
-      .parent()
-      .getIframeBody()
-      .contains(DOCKER_IMAGE_TAG);
+    cy.getIframeBody().contains(`Image:${DOCKER_IMAGE_TAG}`);
+  });
+
+  it('Checks the list view', () => {
+    cy.getLeftNav()
+      .contains('Replica Sets')
+      .click();
+
+    cy.getIframeBody()
+      .contains(REPLICA_SET_NAME)
+      .click();
+
+    cy.getIframeBody().contains(REPLICA_SET_NAME);
+  });
+
+  it('Edits the Docker image and Replicas amount in the Replica set', () => {
+    cy.getIframeBody()
+      .contains('Edit')
+      .click();
+
+    cy.getIframeBody()
+      .contains('Advanced')
+      .click();
+
+    cy.getIframeBody()
+      .find(
+        '[placeholder="Enter the Docker image tag, for example, bitnami/nginx."]',
+      )
+      .clear()
+      .type(EDITED_DOCKER_IMAGE_TAG)
+      .should('have.value', EDITED_DOCKER_IMAGE_TAG);
+
+    cy.getIframeBody()
+      .find('[placeholder="Replicas"]')
+      .clear()
+      .type(EDITED_REPLICAS_AMOUNT)
+      .should('have.value', EDITED_REPLICAS_AMOUNT);
+
+    cy.getIframeBody()
+      .find('[role="document"]')
+      .contains('button', 'Update')
+      .click();
+
+    cy.reload();
+  });
+
+  it('Checks the new Docker image', () => {
+    cy.getIframeBody()
+      .contains('Replica Sets')
+      .click();
+
+    cy.getIframeBody().contains(EDITED_DOCKER_IMAGE_TAG);
+  });
+
+  it('Checks the new amout of Replicas', () => {
+    cy.getIframeBody()
+      .contains(REPLICA_SET_NAME)
+      .click();
+
+    cy.getIframeBody().contains(
+      `${EDITED_REPLICAS_AMOUNT} / ${EDITED_REPLICAS_AMOUNT}`,
+      { timeout: 12000 },
+    );
   });
 });

--- a/tests/tests/test-replica-sets.spec.js
+++ b/tests/tests/test-replica-sets.spec.js
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+import 'cypress-file-upload';
+
+const REPLICA_SET_NAME = 'test-replica-set';
+
+context('Create a Replica Set', () => {
+  before(() => {
+    cy.loginAndSelectCluster();
+    cy.goToNamespaceDetails();
+  });
+
+  it('Navigates to Replica Sets', () => {
+    cy.getLeftNav()
+      .contains('Workloads')
+      .click();
+
+    cy.getLeftNav()
+      .contains('Replica Sets')
+      .click();
+  });
+
+  it('Creates a Replica Set', () => {
+    cy.getIframeBody()
+      .contains('Create Replica Set')
+      .click();
+
+    cy.getIframeBody()
+      .contains('Advanced')
+      .click();
+
+    cy.getIframeBody()
+      .find('[placeholder="Replica Set Name"]')
+      .clear()
+      .type(REPLICA_SET_NAME);
+
+    const replicasAmount = 1;
+    cy.getIframeBody()
+      .find('[placeholder="Replicas"]')
+      .clear()
+      .type(replicasAmount)
+      .should('have.value', replicasAmount);
+
+    cy.getIframeBody()
+      .find(
+        '[placeholder="Enter the Docker image tag, for example, bitnami/nginx."]',
+      )
+      .clear()
+      .type('bitnami/nginx');
+
+    cy.getIframeBody()
+      .find('[role="document"]')
+      .contains('button', 'Create')
+      .click();
+  });
+
+  it('Checks details view', () => {
+    cy.getIframeBody()
+      .contains(REPLICA_SET_NAME)
+      .click();
+
+    cy.getIframeBody()
+      .contains(REPLICA_SET_NAME)
+      .should('be.visible');
+
+    cy.getIframeBody()
+      .contains('Containers')
+      .parent()
+      .contains(REPLICA_SET_NAME)
+      .should('be.visible');
+  });
+});

--- a/tests/tests/test-replica-sets.spec.js
+++ b/tests/tests/test-replica-sets.spec.js
@@ -2,7 +2,7 @@
 import 'cypress-file-upload';
 
 const REPLICA_SET_NAME = 'test-replica-set';
-
+const DOCKER_IMAGE_TAG = 'bitnami/nginx';
 context('Create a Replica Set', () => {
   before(() => {
     cy.loginAndSelectCluster();
@@ -45,7 +45,7 @@ context('Create a Replica Set', () => {
         '[placeholder="Enter the Docker image tag, for example, bitnami/nginx."]',
       )
       .clear()
-      .type('bitnami/nginx');
+      .type(DOCKER_IMAGE_TAG);
 
     cy.getIframeBody()
       .find('[role="document"]')
@@ -55,17 +55,17 @@ context('Create a Replica Set', () => {
 
   it('Checks details view', () => {
     cy.getIframeBody()
-      .contains(REPLICA_SET_NAME)
+      .contains(`${REPLICA_SET_NAME}-`)
       .click();
 
-    cy.getIframeBody()
-      .contains(REPLICA_SET_NAME)
-      .should('be.visible');
-
-    cy.getIframeBody()
-      .contains('Containers')
+    cy.getIframeBody('Containers')
       .parent()
-      .contains(REPLICA_SET_NAME)
-      .should('be.visible');
+      .getIframeBody()
+      .contains(REPLICA_SET_NAME);
+
+    cy.getIframeBody('Containers')
+      .parent()
+      .getIframeBody()
+      .contains(DOCKER_IMAGE_TAG);
   });
 });


### PR DESCRIPTION
**Description**
Adding automated tests for Replica sets.

Changes proposed in this pull request:
- Added test for creating Replica set
- Added tests that check details and list views
- Added test that modifies a resource and checks new values
- Modified Replica Set to use Edit button
- Added translation
- Fix bug: After deleting a pod in Cypress, there was a redirect to the Cluster Overview page

Related issue:  #555 
