### PR TITLE
Set restartPolicy in Jobs as read only

### DIFF
--- a/core-ui/src/components/Predefined/Create/Jobs/Jobs.create.js
+++ b/core-ui/src/components/Predefined/Create/Jobs/Jobs.create.js
@@ -76,7 +76,7 @@ function JobsCreate({
         title={t('common.headers.annotations')}
       />
 
-      <JobSpecSection advanced propertyPath="$.spec" />
+      <JobSpecSection advanced propertyPath="$.spec" readOnly={!!initialJob} />
 
       <ContainerSection
         simple

--- a/core-ui/src/components/Predefined/Create/Jobs/SpecSection.js
+++ b/core-ui/src/components/Predefined/Create/Jobs/SpecSection.js
@@ -79,7 +79,7 @@ export const CronJobSpecSection = ({ value, setValue, ...props }) => {
   );
 };
 
-export const JobSpecSection = ({ value, setValue, ...props }) => {
+export const JobSpecSection = ({ value, setValue, readOnly, ...props }) => {
   const { t } = useTranslation();
 
   return (
@@ -107,6 +107,7 @@ export const JobSpecSection = ({ value, setValue, ...props }) => {
         label={t('cron-jobs.create-modal.labels.restart-policy')}
         input={Inputs.Dropdown}
         options={restartPolicyOptions}
+        readOnly={readOnly}
       />
     </ResourceForm.Wrapper>
   );

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-602
+          image: eu.gcr.io/kyma-project/busola-web:PR-613
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**
I found a bug that allowed a user to change the value of the restartPolicy in the Job. After a change and update the error from backend appeared which said that this field is immutable. 

Changes proposed in this pull request:
- set restartPolicy as readOnly after a creation