### PR TITLE
Sync clusters between tabs

### DIFF
--- a/core/src/luigi-config/communication.js
+++ b/core/src/luigi-config/communication.js
@@ -1,6 +1,6 @@
 import i18next from 'i18next';
 import { NODE_PARAM_PREFIX } from './luigi-config';
-import { communicationEntries as clusterCommunicationCommunicationEntries } from './cluster-management/cluster-management';
+import { communicationEntries as clusterManagementCommunicationEntries } from './cluster-management/cluster-management';
 import { reloadNavigation } from './navigation/navigation-data-init';
 import { setFeatureToggle } from './utils/feature-toggles';
 import { setTheme } from './utils/theme';
@@ -78,7 +78,7 @@ export const communication = {
       });
     },
     ...pageSizeCommunicationEntry,
-    ...clusterCommunicationCommunicationEntries,
+    ...clusterManagementCommunicationEntries,
   },
 };
 

--- a/core/src/luigi-config/communication.js
+++ b/core/src/luigi-config/communication.js
@@ -1,15 +1,7 @@
 import i18next from 'i18next';
 import { NODE_PARAM_PREFIX } from './luigi-config';
-import {
-  saveClusterParams,
-  deleteCluster,
-  saveActiveClusterName,
-  getActiveClusterName,
-  setCluster,
-} from './cluster-management/cluster-management';
-import { clearAuthData } from './auth/auth-storage';
+import { communicationEntries as clusterCommunicationCommunicationEntries } from './cluster-management/cluster-management';
 import { reloadNavigation } from './navigation/navigation-data-init';
-import { reloadAuth } from './auth/auth';
 import { setFeatureToggle } from './utils/feature-toggles';
 import { setTheme } from './utils/theme';
 import { setSSOAuthData } from './auth/sso';
@@ -69,24 +61,6 @@ export const communication = {
       }
       location.reload();
     },
-    'busola.addCluster': async ({ params }) => {
-      await saveClusterParams(params);
-      setCluster(params.currentContext.cluster.name);
-    },
-    'busola.deleteCluster': async ({ clusterName }) => {
-      await deleteCluster(clusterName);
-
-      const activeClusterName = getActiveClusterName();
-      if (activeClusterName === clusterName) {
-        await reloadAuth();
-        clearAuthData();
-        saveActiveClusterName(null);
-      }
-      await reloadNavigation();
-    },
-    'busola.setCluster': ({ clusterName }) => {
-      setCluster(clusterName);
-    },
     'busola.showMessage': ({ message, title, type }) => {
       Luigi.customMessages().sendToAll({
         id: 'busola.showMessage',
@@ -104,6 +78,7 @@ export const communication = {
       });
     },
     ...pageSizeCommunicationEntry,
+    ...clusterCommunicationCommunicationEntries,
   },
 };
 

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-621
+          image: eu.gcr.io/kyma-project/busola-web:PR-624
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Move cluster management message handling to its own file
- Use [BroadcastChannel API](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) to sync clusters between browser tabs

There won't be a test for that, as in Cypress [there will never be support for multiple browser tabs](https://docs.cypress.io/guides/references/trade-offs#Permanent-trade-offs-1).
