### PR TITLE
Fix scrolling page when mouse is over monaco container

### DIFF
--- a/core-ui/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.js
+++ b/core-ui/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.js
@@ -49,6 +49,11 @@ export function KubeconfigUpload({
           editor.onDidBlurEditorWidget(() => updateKubeconfig(getValue()))
         }
         onChange={(_, value) => updateKubeconfig(value)}
+        options={{
+          scrollbar: {
+            alwaysConsumeMouseWheel: false,
+          },
+        }}
       />
       {error && (
         <MessageStrip type="error" className="fd-margin-top--sm">

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/CodeAndDependencies/Editor.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/CodeAndDependencies/Editor.js
@@ -95,6 +95,11 @@ export default function Editor({
         language={language}
         theme={editorTheme}
         value={controlledValue}
+        options={{
+          scrollbar: {
+            alwaysConsumeMouseWheel: false,
+          },
+        }}
         onChange={handleControlledChange}
       />
     </div>

--- a/core-ui/src/components/Predefined/Details/ConfigMap/ConfigMap.details.js
+++ b/core-ui/src/components/Predefined/Details/ConfigMap/ConfigMap.details.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ControlledBy } from 'react-shared';
 
-import { ReadonlyEditorPanel } from '../../../../shared/components/ReadonlyEditorPanel';
+import { ReadonlyEditorPanel } from 'shared/components/ReadonlyEditorPanel';
 
 export const ConfigMapsDetails = ({ DefaultRenderer, ...otherParams }) => {
   const { t } = useTranslation();

--- a/core-ui/src/components/Predefined/Details/CustomResourceDefinitions/CustomResourceDefinitionVersions.js
+++ b/core-ui/src/components/Predefined/Details/CustomResourceDefinitions/CustomResourceDefinitionVersions.js
@@ -167,6 +167,9 @@ export const CustomResourceDefinitionVersions = resource => {
                     minimap: {
                       enabled: false,
                     },
+                    scrollbar: {
+                      alwaysConsumeMouseWheel: false,
+                    },
                   }}
                 />
               </LayoutPanel.Body>

--- a/core-ui/src/shared/ResourceForm/fields/Editor.js
+++ b/core-ui/src/shared/ResourceForm/fields/Editor.js
@@ -56,8 +56,10 @@ export function Editor({
     minimap: {
       enabled: false,
     },
+    scrollbar: {
+      alwaysConsumeMouseWheel: false,
+    },
   };
-
   return (
     <div className="resource-form__editor">
       <ControlledEditor

--- a/core-ui/src/shared/components/ReadonlyEditorPanel.js
+++ b/core-ui/src/shared/components/ReadonlyEditorPanel.js
@@ -10,6 +10,9 @@ export function ReadonlyEditorPanel({ title, value, editorProps }) {
     minimap: {
       enabled: false,
     },
+    scrollbar: {
+      alwaysConsumeMouseWheel: false,
+    },
   };
 
   return (

--- a/core/src/index.css
+++ b/core/src/index.css
@@ -39,3 +39,7 @@ body.lui-semiCollapsible {
 .lui-side-nav__footer--text p {
   margin: 0;
 }
+
+#app .iframeContainer {
+  overflow: hidden;
+}

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-644
+          image: eu.gcr.io/kyma-project/busola-web:PR-641
           imagePullPolicy: Always
           resources:
             requests:

--- a/shared/components/SideDrawer/SideDrawer.js
+++ b/shared/components/SideDrawer/SideDrawer.js
@@ -38,7 +38,12 @@ export const SideDrawer = ({
           language={'yaml'}
           theme={editorTheme}
           value={textToCopy}
-          options={{ readOnly: true }}
+          options={{
+            readOnly: true,
+            scrollbar: {
+              alwaysConsumeMouseWheel: false,
+            },
+          }}
         />
       </>
     );

--- a/shared/contexts/YamlEditorContext/YamlContent.js
+++ b/shared/contexts/YamlEditorContext/YamlContent.js
@@ -45,7 +45,13 @@ export function YamlContent({
         value={val}
         onChange={(_, text) => setChangedYamlFn(text)}
         editorDidMount={(_, editor) => setEditor(editor)}
-        options={{ minimap: { enabled: false }, readOnly }}
+        options={{
+          minimap: { enabled: false },
+          readOnly,
+          scrollbar: {
+            alwaysConsumeMouseWheel: false,
+          },
+        }}
       />
     </>
   );


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fixes scrolling page when mouse is over a monaco container and removes the scrollbars from the main iframe container to disallow double scrolls.




**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
