### PR TITLE
Migrate discovery and network, namespaces, integration views to new translatable labels

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleStatus/ApiRuleStatus.js
+++ b/core-ui/src/components/ApiRules/ApiRuleStatus/ApiRuleStatus.js
@@ -30,12 +30,14 @@ export default function ApiRuleStatus({ apiRule }) {
   }
 
   const { code, desc } = apiRule.status.APIRuleStatus;
+
   return (
     <StatusBadge
       i18n={i18n}
       resourceKind="api-rules"
       type={resolveAPIRuleStatus(code)}
       additionalContent={desc}
+      noTooltip={code === 'OK'}
     >
       {code}
     </StatusBadge>

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/CodeAndDependencies/CodeAndDependencies.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/CodeAndDependencies/CodeAndDependencies.js
@@ -120,6 +120,7 @@ export default function CodeAndDependencies({ lambda }) {
   const button = (
     <Button
       glyph="save"
+      compact
       option={disabled ? 'transparent' : 'emphasized'}
       typeAttr="button"
       disabled={disabled}

--- a/core-ui/src/components/Lambdas/components/TabsWithActions/TabsWithActions.scss
+++ b/core-ui/src/components/Lambdas/components/TabsWithActions/TabsWithActions.scss
@@ -11,7 +11,8 @@
     border-radius: 4px;
   }
 
-  .monaco-editor, .monaco-diff-editor {
+  .monaco-editor,
+  .monaco-diff-editor {
     border-radius: 4px;
 
     > div {
@@ -20,6 +21,7 @@
   }
 
   .fd-panel-tabs__actions {
+    display: flex;
     position: absolute;
     top: 0;
     right: 0;

--- a/core-ui/src/components/Predefined/Create/AddonsConfigurations/AddonsConfigurations.js
+++ b/core-ui/src/components/Predefined/Create/AddonsConfigurations/AddonsConfigurations.js
@@ -114,6 +114,7 @@ export const AddonsConfigurations = ({
             id={`${resourceType}-name`}
             kind={resourceType}
             i18n={i18n}
+            value={name}
           />
         </div>
 

--- a/core-ui/src/components/Predefined/Details/AddonsConfiguration.details.js
+++ b/core-ui/src/components/Predefined/Details/AddonsConfiguration.details.js
@@ -9,12 +9,16 @@ const RepositoryUrls = addon => {
     t('addons.headers.url'),
     t('common.headers.status'),
   ];
+
   const rowRenderer = repo => [
     repo.url,
     <StatusBadge
+      resourceKind="addons"
       ariaLabel={t('addons.addons-status')}
-      tooltipContent={repo.message}
+      additionalContent={repo.message}
       autoResolveType
+      i18n={i18n}
+      noTooltip={repo.status === 'Ready'}
     >
       {repo.status}
     </StatusBadge>,

--- a/core-ui/src/components/Predefined/Details/Application/ApplicationStatus.js
+++ b/core-ui/src/components/Predefined/Details/Application/ApplicationStatus.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { StatusBadge } from 'react-shared';
 
 const isStatusOk = application => {
@@ -17,7 +18,19 @@ const getStatusType = application => {
 };
 
 export function ApplicationStatus({ application }) {
+  const { i18n } = useTranslation();
   const status = getStatus(application);
   const statusType = getStatusType(application);
-  return <StatusBadge type={statusType}>{status}</StatusBadge>;
+  const statusDescription = application.status?.installationStatus?.description;
+  console.log(statusDescription);
+  return (
+    <StatusBadge
+      additionalContent={statusDescription}
+      i18n={i18n}
+      type={statusType}
+      resourceKind="applications"
+    >
+      {status}
+    </StatusBadge>
+  );
 }

--- a/core-ui/src/components/Predefined/Details/Namespace/NamespaceStatus.js
+++ b/core-ui/src/components/Predefined/Details/Namespace/NamespaceStatus.js
@@ -1,7 +1,10 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { StatusBadge } from 'react-shared';
 
 export function NamespaceStatus({ namespaceStatus }) {
+  const { i18n } = useTranslation();
+
   const badgeType = status => {
     switch (status) {
       case 'Active':
@@ -14,7 +17,11 @@ export function NamespaceStatus({ namespaceStatus }) {
   };
 
   return (
-    <StatusBadge type={badgeType(namespaceStatus.phase)}>
+    <StatusBadge
+      resourceKind="namespaces"
+      type={badgeType(namespaceStatus.phase)}
+      i18n={i18n}
+    >
       {namespaceStatus.phase}
     </StatusBadge>
   );

--- a/core-ui/src/components/Predefined/List/AddonsConfigurations.list.js
+++ b/core-ui/src/components/Predefined/List/AddonsConfigurations.list.js
@@ -10,12 +10,14 @@ export const GenericAddonsConfigurationsList = ({
   DefaultRenderer,
   ...otherParams
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const statusColumn = {
     header: t('common.headers.status'),
     value: addon => (
-      <StatusBadge autoResolveType>{addon.status?.phase}</StatusBadge>
+      <StatusBadge resourceKind="addons" noTooltip autoResolveType i18n={i18n}>
+        {addon.status?.phase}
+      </StatusBadge>
     ),
   };
 

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -1102,13 +1102,18 @@ namespaces:
       error: 'Error while loading {{title}} data due to: {{message}}'
       pods: $t(pods.title)
       title: Healthy Resources
+  statuses:
+    active: Active
+    terminating: Terminating
   title: Namespaces
   tooltips:
+    active: The Namespace is available for use in the system.
     container-memory-limit: Define memory constraints for individual containers in your Namespace.
     create: Select this option to disable Istio to mediate all communication between the Pods in your Namespace.
     healthy-resources: '{{value}}/{{total}} {{resourceType}} are healthy.'
     memory-examples: 'Use plain value in bytes (128974848) or equivalent suffixes (e.g.: 129e6, 129M, 123Mi).'
     no-resources: There are no {{resourceType}} in this Namespace.
+    terminating: The Namespace is undergoing graceful termination.
     total-memory-limit: Define constraints that limit total memory consumption in your Namespace.
     usage-of-memory-limits: This Namespace uses {{valueText}} of {{maxText}} its memory limits.
     usage-of-memory-requests: This Namespace uses {{valueText}} of {{maxText}} its memory requests.

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -1123,7 +1123,7 @@ namespaces:
     healthy-resources: '{{value}}/{{total}} {{resourceType}} are healthy.'
     memory-examples: 'Use plain value in bytes (128974848) or equivalent suffixes (e.g.: 129e6, 129M, 123Mi).'
     no-resources: There are no {{resourceType}} in this Namespace.
-    terminating: The Namespace is undergoing graceful termination.
+    terminating: The Namespace is being terminated.
     total-memory-limit: Define constraints that limit total memory consumption in your Namespace.
     usage-of-memory-limits: This Namespace uses {{valueText}} of {{maxText}} its memory limits.
     usage-of-memory-requests: This Namespace uses {{valueText}} of {{maxText}} its memory requests.

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -1118,7 +1118,7 @@ namespaces:
     terminating: Terminating
   title: Namespaces
   tooltips:
-    active: The Namespace is available for the use.
+    active: The Namespace is available for use.
     container-memory-limit: Define memory constraints for individual containers in your Namespace.
     create: Select this option to disable Istio to mediate all communication between the Pods in your Namespace.
     healthy-resources: '{{value}}/{{total}} {{resourceType}} are healthy.'

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -8,6 +8,9 @@ addons:
   messages:
     created: Addons Configuration {{name}} created.
   repository-urls: Repository URLs
+  statuses:
+    failed: Failed
+    ready: Ready
   title: Addons
   urls: URLs
 api-rules:
@@ -123,6 +126,10 @@ applications:
     description: Specify a description for your Application.
     name: Specify a name for your Application.
     namespace: Choose Namespace.
+  statuses:
+    deployed: Deployed
+    error: Error
+    provisioning: Provisioning
   subtitle:
     bound-to: Services and events bound to '{{namespace}}'.
     connect-app: Connect Application
@@ -132,6 +139,8 @@ applications:
     namespace-bindings: Namespace Bindings
     provided-services: Provided Services and events
   title: Applications
+  tooltips:
+    provisioning: The Application is being provisioned asynchronously.
 brokers:
   description: <0>Service Broker</0> provides a set of managed services that a third party offers and maintains.
   headers:

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -1117,7 +1117,7 @@ namespaces:
     terminating: Terminating
   title: Namespaces
   tooltips:
-    active: The Namespace is available for use in the system.
+    active: The Namespace is available for the use.
     container-memory-limit: Define memory constraints for individual containers in your Namespace.
     create: Select this option to disable Istio to mediate all communication between the Pods in your Namespace.
     healthy-resources: '{{value}}/{{total}} {{resourceType}} are healthy.'

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -78,7 +78,6 @@ api-rules:
     ns-no-services: No Services in this Namespace.
     placeholder: Choose the service to expose.
   statuses:
-    error: Error
     ok: OK
     skipped: Skipped
   title: API Rules
@@ -419,6 +418,8 @@ common:
     secret-ref-name: Select name
     secret-ref-namespace: Select Namespace
   protected-resource: This resource is protected.
+  statuses:
+    error: Error
   tooltips:
     copy-to-clipboard: Copy to clipboard
     download: Download

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -279,6 +279,7 @@ clusters:
       no-metrics: No metrics available for this node.
     title-all-clusters: Clusters Overview
     title-current-cluster: Cluster Overview
+    title-no-clusters-available: No clusters available
     version: Version
   statuses:
     inmemory: In Memory

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -62,7 +62,18 @@ async function createAppSwitcher() {
     testId: 'clusters-overview',
   };
 
-  return { items: [...clusterNodes, clusterOverviewNode] };
+  const noClustersNode = {
+    title: i18next.t('clusters.overview.title-no-clusters-available'),
+    subTitle: i18next.t('clusters.overview.title-no-clusters-available'),
+    link: '#',
+  };
+
+  return {
+    items:
+      [...clusterNodes, clusterOverviewNode].length > 1
+        ? [...clusterNodes, clusterOverviewNode]
+        : [clusterOverviewNode, noClustersNode],
+  };
 }
 
 export async function reloadNavigation() {

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-629
+          image: eu.gcr.io/kyma-project/busola-web:PR-647
           imagePullPolicy: Always
           resources:
             requests:

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-647
+          image: eu.gcr.io/kyma-project/busola-web:PR-670
           imagePullPolicy: Always
           resources:
             requests:

--- a/shared/components/StatusBadge/StatusBadge.js
+++ b/shared/components/StatusBadge/StatusBadge.js
@@ -123,18 +123,15 @@ export const StatusBadge = ({
     </ObjectStatus>
   );
 
-  let content = translate(
+  const content = translate(
     i18n,
     [tooltipVariableName, commonTooltipVariableName, i18nFullVariableName],
     fallbackValue,
   );
-  if (additionalContent) {
-    content = `${content} ${additionalContent}`;
-  }
   const statusElement = noTooltip ? (
     badgeElement
   ) : (
-    <Tooltip content={content} {...tooltipProps}>
+    <Tooltip content={additionalContent || content} {...tooltipProps}>
       {badgeElement}
     </Tooltip>
   );

--- a/shared/hooks/useProtectedResources.js
+++ b/shared/hooks/useProtectedResources.js
@@ -21,7 +21,7 @@ export function useProtectedResources(i18n) {
 
   const getEntryProtection = entry => {
     return protectedResourceRules.filter(rule =>
-      Object.entries(rule.match).every(
+      Object.entries(rule?.match || {}).every(
         ([pattern, value]) => jp.value(entry, pattern) === value,
       ),
     );


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- `StatusBadge`: don't prepend status text to tooltip message if `additionalContent` is set.
- Namespaces: tooltips stolen from [sources](https://raw.githubusercontent.com/kubernetes/api/master/core/v1/types.go) (`NamespacePhase`)
- Services: no statuses here
- Applications: seeing from types.go file (`components/application-operator/pkg/apis/applicationconnector/v1alpha1/types.go`, `release-1.25` branch), status is just a string.
- Addons & ClusterAddons: 2 statuses, one for `AddonStatus` (either `Ready` or `Failed`, no tooltip), one for `RepositoryStatus` (of type `string`, tooltip when status is not `Ready`)
(`kyma1.25/installation/resources/crds/service-catalog-addons/addonsconfigurations.addons.crd.yaml`)
- API Rules: they were already done, just disable tooltip for "OK" status
- ALSO fix #664 
- ALSO fix #667 

**Related issue(s)**

Closes #657 
Closes #664 
Closes #667 