### PR TITLE
Fix test.settings to check for created config map

### DIFF
--- a/tests/tests/test.settings.spec.js
+++ b/tests/tests/test.settings.spec.js
@@ -51,6 +51,10 @@ context('Test app settings and preferences', () => {
       .contains('button', 'Create')
       .click();
 
+    cy.getIframeBody()
+      .contains('h3', NAME, { timeout: 5000 })
+      .should('be.visible');
+
     cy.getLeftNav()
       .contains('Config Maps')
       .click();


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fixes cypress test.settings to wait for a created config map before fetching the list.


<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
