### PR TITLE
Add error tolerancy for useGet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV CI true
 COPY . /app
 
 RUN make resolve
-RUN make lint
+RUN make validate
 RUN make pull-licenses
 
 RUN cd /app/core && make test && make build

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -18,7 +18,7 @@ ENV CI true
 COPY . /app
 
 RUN make resolve
-RUN make lint
+RUN make validate
 RUN make pull-licenses
 
 RUN cd /app/core && make test && make build-docker

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-698
+          image: eu.gcr.io/kyma-project/busola-web:PR-711
           imagePullPolicy: Always
           resources:
             requests:

--- a/shared/components/KeyValueForm/test/KeyValueForm.test.js
+++ b/shared/components/KeyValueForm/test/KeyValueForm.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, fireEvent, wait } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { KeyValueForm } from '../KeyValueForm';
 import * as helpers from '../helpers';
+import wait from 'waait';
 
 describe('KeyValueForm', () => {
   it('Adds and removes entries, showing proper warnings', () => {

--- a/shared/components/StatusBadge/test/StatusBadge.test.js
+++ b/shared/components/StatusBadge/test/StatusBadge.test.js
@@ -31,7 +31,7 @@ describe('StatusBadge', () => {
 
   it('renders status text with DEFAULT_STATUSES_PATH', () => {
     const DEFAULT_STATUSES_PATH =
-      'common.statuses.initial,common.statuses.initial,fallback';
+      'common.statuses.initialcommon.statuses.initial';
     const { queryByRole } = render(
       <StatusBadge i18n={{ a: 'a' }}>Initial</StatusBadge>,
     );
@@ -43,7 +43,7 @@ describe('StatusBadge', () => {
   it('renders status text with RESOURCE_STATUSES_PATH', () => {
     const RESOURCE_KIND = 'resource';
     const RESOURCE_STATUSES_PATH =
-      'resource.statuses.initial,common.statuses.initial,fallback';
+      'resource.statuses.initialcommon.statuses.initial';
     const { queryByRole } = render(
       <StatusBadge i18n={{ a: 'a' }} resourceKind={RESOURCE_KIND}>
         Initial

--- a/shared/hooks/BackendAPI/tests/useGet.test.js
+++ b/shared/hooks/BackendAPI/tests/useGet.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useGet } from './../useGet';
+import { MicrofrontendContext, ConfigContext } from '../../..';
+import wait from 'waait';
+import { act } from 'react-dom/test-utils';
+
+const mockUseFetch = jest.fn();
+jest.mock('./../useFetch', () => ({
+  useFetch: () => mockUseFetch,
+}));
+
+function Testbed({ setGetResult }) {
+  const getResult = useGet('/', { pollingInterval: 100 });
+  setGetResult(getResult.loading, getResult.error, getResult.data);
+  return null;
+}
+
+function MockContext({ children }) {
+  return (
+    <ConfigContext.Provider value={{ fromConfig: key => key }}>
+      <MicrofrontendContext.Provider
+        value={{ authData: { token: 'test-token' }, cluster: {}, config: {} }}
+      >
+        {children}
+      </MicrofrontendContext.Provider>
+    </ConfigContext.Provider>
+  );
+}
+
+describe('useGet', () => {
+  it('Tolerancy', async () => {
+    const mock = jest.fn();
+
+    mockUseFetch
+      .mockImplementationOnce(
+        () =>
+          Promise.resolve({ json: () => Promise.resolve({ metadata: {} }) }), // loading call
+      )
+      .mockImplementationOnce(
+        () =>
+          Promise.resolve({ json: () => Promise.resolve({ metadata: {} }) }), // first valid call
+      )
+      .mockImplementation(() => {
+        throw new Error('2'); // failing calls
+      });
+    render(
+      <MockContext>
+        <Testbed setGetResult={mock} />
+      </MockContext>,
+    );
+    await act(async () => {
+      // first call - loading
+      expect(mock).toHaveBeenCalledWith(true, null, null);
+      await wait(150);
+      // first call - valid data
+      expect(mock).toHaveBeenCalledWith(false, null, expect.any(Object));
+      // second call - error, but still show data (1/2)
+      await wait(100);
+      expect(mock).toHaveBeenCalledWith(false, null, expect.any(Object));
+      // third call - error, but still show data (2/2)
+      await wait(100);
+      expect(mock).toHaveBeenCalledWith(false, null, expect.any(Object));
+      // fourth call - error, start displaying error
+      await wait(100);
+      expect(mock).toHaveBeenCalledWith(
+        false,
+        expect.any(Error),
+        expect.any(Object),
+      );
+    });
+  });
+});

--- a/shared/hooks/BackendAPI/useGet.js
+++ b/shared/hooks/BackendAPI/useGet.js
@@ -2,6 +2,9 @@ import React from 'react';
 import { useMicrofrontendContext } from '../../contexts/MicrofrontendContext';
 import { useFetch } from './useFetch';
 
+const ERROR_TOLERANCY = 2;
+const fails = [0, 0, 1];
+
 const useGetHook = processDataFn =>
   function(path, { pollingInterval, onDataReceived, skip } = {}) {
     const lastAuthData = React.useRef(null);
@@ -12,6 +15,8 @@ const useGetHook = processDataFn =>
     const { authData } = useMicrofrontendContext();
     const fetch = useFetch();
     const abortController = React.useRef(new AbortController());
+    const b = React.useRef(0);
+    const errorTolerancyCounter = React.useRef(0);
 
     const refetch = (isSilent, currentData) => async () => {
       if (skip || !authData || abortController.current.signal.aborted) return;
@@ -21,12 +26,25 @@ const useGetHook = processDataFn =>
 
       function processError(error) {
         if (!abortController.current.signal.aborted) {
-          console.error(error);
-          setError(error);
+          errorTolerancyCounter.current++;
+          console.log(
+            'error caught, tolerancy is up',
+            errorTolerancyCounter.current,
+          );
+          if (errorTolerancyCounter.current > ERROR_TOLERANCY) {
+            console.error(error);
+            setError(error);
+          }
         }
       }
 
       try {
+        const isBAD = !!fails[b.current % fails.length];
+        console.log(b.current, 'should fail? ->', isBAD);
+        b.current++;
+        if (isBAD) {
+          throw Error('oh no');
+        }
         const response = await fetch({
           relativeUrl: path,
           abortController: abortController.current,
@@ -36,6 +54,8 @@ const useGetHook = processDataFn =>
         if (abortController.current.signal.aborted) return;
         if (typeof onDataReceived === 'function') onDataReceived(payload.items);
         if (error) setTimeout(_ => setError(null)); // bring back the data and clear the error once the connection started working again
+        console.log('success, tolerancy reset');
+        errorTolerancyCounter.current = 0;
         setTimeout(_ =>
           processDataFn(payload, currentData, setData, lastResourceVersion),
         );

--- a/shared/hooks/BackendAPI/useGet.js
+++ b/shared/hooks/BackendAPI/useGet.js
@@ -26,7 +26,7 @@ const useGetHook = processDataFn =>
       function processError(error) {
         if (!abortController.current.signal.aborted) {
           errorTolerancyCounter.current++;
-          if (errorTolerancyCounter.current > ERROR_TOLERANCY) {
+          if (errorTolerancyCounter.current > ERROR_TOLERANCY || !data) {
             console.error(error);
             setError(error);
           }

--- a/shared/hooks/BackendAPI/useGet.js
+++ b/shared/hooks/BackendAPI/useGet.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useMicrofrontendContext } from '../../contexts/MicrofrontendContext';
 import { useFetch } from './useFetch';
 
+// allow <n> consecutive requests to fail before displaying error
 const ERROR_TOLERANCY = 2;
 
 const useGetHook = processDataFn =>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Allow up to 2 consecutive requests to fail until displaying an error
- Fix `shared` tests
- Enable `shared` tests on CI

**Related issue(s)**

Closes #694 
