### PR TITLE
Fix Kyma Version display on kubeconfigID-imported clusters

### DIFF
--- a/core/src/luigi-config/kubeconfig-id/constants.js
+++ b/core/src/luigi-config/kubeconfig-id/constants.js
@@ -25,26 +25,6 @@ export const DEFAULT_FEATURES = {
       },
     ]),
   ),
-  KUBECONFIG_ID: {
-    config: {
-      kubeconfigUrl: '/kubeconfig',
-    },
-  },
-  SSO_LOGIN: {
-    isEnabled: false,
-    config: {
-      issuerUrl: 'https://apskyxzcl.accounts400.ondemand.com',
-      scope: 'email',
-      clientId: 'd0316c58-b0fe-45cd-9960-0fea0708355a',
-    },
-  },
-  ADD_CLUSTER_DISABLED: {
-    isEnabled: false,
-    config: {
-      cockpitUrl: 'https://account.staging.hanavlab.ondemand.com/cockpit',
-    },
-  },
-  SHOW_KYMA_VERSION: { isEnabled: false },
 };
 
 export const DEFAULT_HIDDEN_NAMESPACES = [


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- So... for kubeconfigID clusters some additional data were was added - like disabling the Kyma version feature. This configuration overrode the Busola config - along them Kyma version, disabling it.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
