### PR TITLE
Add grego952 as a documentation CODEOWNER in Busola

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 * @akucharska @dariadomagala @qbalukom @valentinvieriu @Wawrzyn321 @Sawthis
 
 # Owners of all .md files in the repository
-*.md @mmitoraj @klaudiagrz @alexandra-simeonova @majakurcius @NHingerl
+*.md @mmitoraj @klaudiagrz @alexandra-simeonova @majakurcius @NHingerl @grego952
 
-core/src/i18n/ @mmitoraj @klaudiagrz @alexandra-simeonova @majakurcius @NHingerl
+core/src/i18n/ @mmitoraj @klaudiagrz @alexandra-simeonova @majakurcius @NHingerl @grego952
 
 tests/ @akucharska @dariadomagala @qbalukom @valentinvieriu @Wawrzyn321 @Sawthis


### PR DESCRIPTION
**Description**

As @grego952 has been working with Kyma for over 3 months as a Technical Writer and has gained expertise in this domain, he should be added to the documentation CODEOWNERS.

Changes proposed in this pull request:

- Add @grego952 to Busola documentation CODEOWNERS

**Related issue**
[#13077 ](https://github.com/kyma-project/kyma/issues/13077)
