### PR TITLE
Option to login through OIDC during tests

### DIFF
--- a/core-ui/src/components/Clusters/views/EditCluster/EditCluster.js
+++ b/core-ui/src/components/Clusters/views/EditCluster/EditCluster.js
@@ -60,10 +60,21 @@ function ClustersEdit(props) {
     />
   );
 
-  //OIDC data
-  const [issuerUrl, setIssuerUrl] = useState('');
-  const [clientId, setClientId] = useState('');
-  const [scopes, setScopes] = useState('');
+  const findInitialValue = id => {
+    if (resource.kubeconfig?.users?.[0]?.user?.exec?.args) {
+      const elementWithId = resource.kubeconfig?.users?.[0]?.user?.exec?.args.find(
+        el => el.includes(id),
+      );
+      const regex = new RegExp(`${id}=(?<value>.*)`);
+      return regex.exec(elementWithId)?.groups?.value || '';
+    }
+    return '';
+  };
+  const [issuerUrl, setIssuerUrl] = useState(
+    findInitialValue('oidc-issuer-url'),
+  );
+  const [clientId, setClientId] = useState(findInitialValue('oidc-client-id'));
+  const [scopes, setScopes] = useState(findInitialValue('oidc-extra-scope'));
   const createOIDC = (type = '', val = '') => {
     const config = { issuerUrl, clientId, scopes, [type]: val };
     const exec = {

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-932
+          image: eu.gcr.io/kyma-project/busola-web:PR-917
           imagePullPolicy: Always
           resources:
             requests:

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,3 +55,11 @@ To open the `tests runner`, pointing to a `local Busola` instance, use this comm
 ```bash
 npm run start:local
 ```
+
+### Login via OIDC to a cluster (optional)
+
+If a cluster requires an OIDC authentication, include these additional arguments while lunching tests, for example:
+
+```bash
+CYPRESS_OIDC_PASS={YOUR_PASSWORD} CYPRESS_OIDC_USER={YOUR_USERNAME} npm start
+```

--- a/tests/support/login-commands.js
+++ b/tests/support/login-commands.js
@@ -1,6 +1,11 @@
 import config from '../config';
+import { loadKubeconfig } from '../support/loadKubeconfigFile';
 
-Cypress.Commands.add('loginAndSelectCluster', params => {
+const NO_VALUE = 'NO_VALUE'; // must be something, OIDC server doesn't accept empty strings
+const USERNAME = Cypress.env('OIDC_USER');
+const PASSWORD = Cypress.env('OIDC_PASS');
+
+Cypress.Commands.add('loginAndSelectCluster', function(params) {
   const defaults = {
     fileName: 'kubeconfig.yaml',
     expectedLocation: /overview$/,
@@ -8,34 +13,117 @@ Cypress.Commands.add('loginAndSelectCluster', params => {
   };
   const { fileName, expectedLocation, storage } = { ...defaults, ...params };
 
-  cy.visit(`${config.clusterAddress}/clusters`)
-    .getIframeBody()
-    .contains('Connect cluster')
-    .click();
+  cy.wrap(loadKubeconfig()).then(kubeconfig => {
+    // conditionally log in to OIDC
+    if (kubeconfig.users?.[0]?.user?.exec?.args) {
+      // obtaining OIDC URL
+      const URLelement = kubeconfig.users[0].user.exec.args.find(el =>
+        el.includes('oidc-issuer-url'),
+      );
+      // if you experience an error with URL address during tests, please note kubeconfig should
+      // only specify scheme and domain, i.e, https://apskyxzcl.accounts400.ondemand.com
+      const OICD_URL = /oidc-issuer-url=(?<url>(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,}))/.exec(
+        URLelement,
+      )?.groups?.url;
 
-  cy.getIframeBody()
-    .contains('Drag file here')
-    .attachFile(fileName, { subjectType: 'drag-n-drop' });
+      // validating the input
+      if (!(OICD_URL && USERNAME && PASSWORD)) {
+        cy.log(
+          'Either OIDC url, username or password is missing. URL is obained from kubeconfig "--oidc-issuer-url". Credentials are provided through Cypress env.',
+        );
+      }
+      cy.wrap(OICD_URL && USERNAME && PASSWORD).should('be.ok');
 
-  cy.getIframeBody()
-    .contains('Next')
-    .click();
+      cy.request(OICD_URL).then(res => {
+        const cookies = res.headers?.['set-cookie'];
 
-  if (storage) {
-    cy.getIframeBody()
-      .contains(storage)
+        const xsrfCookie = cookies?.find(el => el.includes('XSRF'));
+        const xsrfToken = xsrfCookie
+          ? /XSRF_COOKIE="?(?<token>.*?)"?;/.exec(xsrfCookie)?.groups?.token
+          : NO_VALUE;
+
+        const jSessionIdCookie = cookies?.find(el => el.includes('JSESSIONID'));
+        const jSessionIdToken = jSessionIdCookie
+          ? /JSESSIONID="?(?<token>.*?)"?;/.exec(jSessionIdCookie)?.groups
+              ?.token
+          : NO_VALUE;
+
+        const body = res.body;
+        const spId =
+          /spid=['"](?<spid>.*?)['"]/.exec(body)?.groups?.spid || NO_VALUE;
+        const authenticityToken =
+          /authenticity_token.{1,10}value="(?<auth>.*?)"/.exec(body)?.groups
+            ?.auth || NO_VALUE;
+
+        cy.log('Sending OIDC auth request');
+        // if a response has status different than 2xx or 3xx, test will fail
+        cy.request({
+          log: true,
+          url: `${OICD_URL}/saml2/idp/sso`,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Cookie: `JSESSIONID=${jSessionIdToken}; XSRF_COOKIE="${xsrfToken}"`,
+          },
+          body: {
+            utf8: '✓',
+            authenticity_token: authenticityToken,
+            xsrfProtection: xsrfToken,
+            method: 'GET',
+            idpSSOEndpoint: `${OICD_URL}/saml2/idp/sso`,
+            sp: 'sp.accounts.sap.com',
+            RelayState: `${OICD_URL}/ui/protected/profilemanagement`,
+            targetUrl: '',
+            sourceUrl: '',
+            org: '',
+            spId: spId,
+            spName: 'sp.accounts.sap.com',
+            mobileSSOToken: '',
+            tfaToken: '',
+            css: '',
+            passwordlessAuthnSelected: '',
+            j_username: Cypress.env('OIDC_USER'),
+            j_password: Cypress.env('OIDC_PASS'),
+          },
+        }).then(res => {
+          // assuming cookies are set only for successful login attempts
+          if (!res.headers?.['set-cookie']) {
+            cy.log('Failed OIDC login attempt!!');
+          }
+          cy.wrap(res.headers?.['set-cookie']).should('be.ok');
+        });
+      });
+    }
+
+    cy.visit(`${config.clusterAddress}/clusters`)
+      .getIframeBody()
+      .contains('Connect cluster')
       .click();
-  }
 
-  cy.getIframeBody()
-    .find('[role="dialog"]')
-    .contains('button', 'Connect cluster')
-    .click();
+    cy.getIframeBody()
+      .contains('Drag file here')
+      .attachFile(fileName, { subjectType: 'drag-n-drop' });
 
-  cy.url().should('match', expectedLocation);
-  cy.getIframeBody()
-    .find('thead')
-    .should('be.visible'); //wait for the namespaces XHR request to finish to continue running the tests. There's no <thead> while the request is pending.
+    cy.getIframeBody()
+      .contains('Next')
+      .click();
 
-  return cy.end();
+    if (storage) {
+      cy.getIframeBody()
+        .contains(storage)
+        .click();
+    }
+
+    cy.getIframeBody()
+      .find('[role="dialog"]')
+      .contains('button', 'Connect cluster')
+      .click();
+
+    cy.url().should('match', expectedLocation);
+    cy.getIframeBody()
+      .find('thead')
+      .should('be.visible'); //wait for the namespaces XHR request to finish to continue running the tests. There's no <thead> while the request is pending.
+
+    return cy.end();
+  });
 });

--- a/tests/support/login-commands.js
+++ b/tests/support/login-commands.js
@@ -19,7 +19,7 @@ Cypress.Commands.add('loginAndSelectCluster', function(params) {
       const URLelement = kubeconfig.users[0].user.exec.args.find(el =>
         el.includes('oidc-issuer-url'),
       );
-      // kubeconfig should only specify a scheme and a domain without any paths, i.e, https://apskyxzcl.accounts400.ondemand.com
+      // kubeconfig should only specify a scheme and a domain without the "/ui/protected/profilemanagement" part , i.e, https://apskyxzcl.accounts400.ondemand.com
       const OICD_URL = /oidc-issuer-url=(?<url>(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,}))/.exec(
         URLelement,
       )?.groups?.url;
@@ -27,7 +27,7 @@ Cypress.Commands.add('loginAndSelectCluster', function(params) {
       // validating the input
       if (!(OICD_URL && USERNAME && PASSWORD)) {
         cy.log(
-          'Either OIDC url, username or password is missing. URL is obtained from kubeconfig "--oidc-issuer-url" field. Credentials are provided through Cypress env variables.',
+          'Either OIDC url, username or password is missing. URL is obtained from kubeconfig\'s "--oidc-issuer-url" field. Credentials are provided through Cypress env variables.',
         );
       }
       cy.wrap(OICD_URL && USERNAME && PASSWORD).should('be.ok');
@@ -80,8 +80,8 @@ Cypress.Commands.add('loginAndSelectCluster', function(params) {
             tfaToken: '',
             css: '',
             passwordlessAuthnSelected: '',
-            j_username: Cypress.env('OIDC_USER'),
-            j_password: Cypress.env('OIDC_PASS'),
+            j_username: USERNAME,
+            j_password: PASSWORD,
           },
         }).then(res => {
           // assuming cookies are set only for successful login attempts

--- a/tests/support/login-commands.js
+++ b/tests/support/login-commands.js
@@ -14,14 +14,12 @@ Cypress.Commands.add('loginAndSelectCluster', function(params) {
   const { fileName, expectedLocation, storage } = { ...defaults, ...params };
 
   cy.wrap(loadKubeconfig()).then(kubeconfig => {
-    // conditionally log in to OIDC
     if (kubeconfig.users?.[0]?.user?.exec?.args) {
-      // obtaining OIDC URL
+      // conditionally logs in to OIDC
       const URLelement = kubeconfig.users[0].user.exec.args.find(el =>
         el.includes('oidc-issuer-url'),
       );
-      // if you experience an error with URL address during tests, please note kubeconfig should
-      // only specify scheme and domain, i.e, https://apskyxzcl.accounts400.ondemand.com
+      // kubeconfig should only specify a scheme and a domain without any paths, i.e, https://apskyxzcl.accounts400.ondemand.com
       const OICD_URL = /oidc-issuer-url=(?<url>(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,}))/.exec(
         URLelement,
       )?.groups?.url;
@@ -29,7 +27,7 @@ Cypress.Commands.add('loginAndSelectCluster', function(params) {
       // validating the input
       if (!(OICD_URL && USERNAME && PASSWORD)) {
         cy.log(
-          'Either OIDC url, username or password is missing. URL is obained from kubeconfig "--oidc-issuer-url". Credentials are provided through Cypress env.',
+          'Either OIDC url, username or password is missing. URL is obtained from kubeconfig "--oidc-issuer-url" field. Credentials are provided through Cypress env variables.',
         );
       }
       cy.wrap(OICD_URL && USERNAME && PASSWORD).should('be.ok');
@@ -56,7 +54,7 @@ Cypress.Commands.add('loginAndSelectCluster', function(params) {
             ?.auth || NO_VALUE;
 
         cy.log('Sending OIDC auth request');
-        // if a response has status different than 2xx or 3xx, test will fail
+        // if a response has status different from 2xx or 3xx, test will fail
         cy.request({
           log: true,
           url: `${OICD_URL}/saml2/idp/sso`,

--- a/tests/tests/test-replica-sets.spec.js
+++ b/tests/tests/test-replica-sets.spec.js
@@ -108,8 +108,6 @@ context('Create a Replica Set', () => {
       .find('[role="document"]')
       .contains('button', 'Update')
       .click();
-
-    cy.reload();
   });
 
   it('Checks the new Docker image', () => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Adds an option to run Cypress tests on a cluster autheticated via OICD. Autodetects the authentication type. 

If you use OIDC, remember to provide a username and password, like for example: 

CYPRESS_OIDC_PASS=XXXXX CYPRESS_OIDC_USER=xxx@xxx.com $(npm bin)/cypress run --browser chrome

**Related issue(s)**
Resolves #835 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
