### PR TITLE
fix switching focus on enter in textarea in config maps

### DIFF
--- a/core-ui/src/shared/ResourceForm/fields/DataField.js
+++ b/core-ui/src/shared/ResourceForm/fields/DataField.js
@@ -15,15 +15,13 @@ export function DataField({ title, ...props }) {
       readableFromFile
       className="resource-form__data-field"
       title={title || t('common.labels.data')}
-      input={({ value, setValue, ...props }) => (
+      input={({ setValue, ...props }) => (
         <FormTextarea
           compact
-          key="value"
-          value={value}
           onChange={e => setValue(e.target.value)}
-          placeholder={t('components.key-value-field.enter-value')}
           className="value-textarea"
           {...props}
+          onKeyDown={() => {}} // overwrites default onKeyDown that switches focus when Enter is pressed
         />
       )}
       {...props}

--- a/core-ui/src/shared/ResourceForm/fields/DataField.scss
+++ b/core-ui/src/shared/ResourceForm/fields/DataField.scss
@@ -1,7 +1,7 @@
 .resource-form__data-field {
   .value-textarea {
     resize: vertical;
-    height: 26px;
+    height: 52px;
   }
 
   .read-from-file {

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-967
+          image: eu.gcr.io/kyma-project/busola-web:PR-988
           imagePullPolicy: Always
           resources:
             requests:

--- a/tests/tests/test-secrets.spec.js
+++ b/tests/tests/test-secrets.spec.js
@@ -31,9 +31,12 @@ context('Test Secrets', () => {
 
     cy.getIframeBody()
       .find('[placeholder="Enter key"]:visible')
-      .type(
-        `${SECRET_KEY}{enter}{backspace}${SECRET_VALUE}{enter}${SECRET2_KEY}{enter}{backspace}${SECRET2_VALUE}`,
-      );
+      .type(`${SECRET_KEY}{enter}{backspace}${SECRET_VALUE}`);
+
+    cy.getIframeBody()
+      .find('[placeholder="Enter key"]:visible')
+      .last()
+      .type(`${SECRET2_KEY}{enter}{backspace}${SECRET2_VALUE}`);
 
     cy.getIframeBody()
       .contains('Encode')


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Fix switching focus on enter in textarea in config maps

**Related issue(s)**
Fixes #820
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
