### PR TITLE
Resolve build warnings

### DIFF
--- a/core-ui/package.json
+++ b/core-ui/package.json
@@ -19,9 +19,9 @@
     "yup": "^0.28.3"
   },
   "scripts": {
-    "start": "(cd ..; gulp copy-themes)& PORT=8889 ../node_modules/.bin/react-scripts start",
+    "start": "(cd ..; gulp copy-themes)& PORT=8889 GENERATE_SOURCEMAP=false ../node_modules/.bin/react-scripts start",
     "start:kyma": "BROWSER=none npm run start",
-    "build": "(cd ..; npm run copy-themes) && PUBLIC_URL=/core-ui INLINE_RUNTIME_CHUNK=false ../node_modules/.bin/react-scripts build",
+    "build": "(cd ..; npm run copy-themes) && PUBLIC_URL=/core-ui INLINE_RUNTIME_CHUNK=false GENERATE_SOURCEMAP=false ../node_modules/.bin/react-scripts build",
     "test": "../node_modules/.bin/react-scripts test",
     "eject": "../node_modules/.bin/react-scripts eject"
   },

--- a/service-catalog-ui/package.json
+++ b/service-catalog-ui/package.json
@@ -10,9 +10,9 @@
     "react-jsonschema-form": "1.7.0"
   },
   "scripts": {
-    "start": "(cd ..; gulp copy-themes) && BROWSER=none PORT=8000  ../node_modules/.bin/react-scripts start",
+    "start": "(cd ..; gulp copy-themes) && BROWSER=none PORT=8000 GENERATE_SOURCEMAP=false ../node_modules/.bin/react-scripts start",
     "start:kyma": "npm run start",
-    "build": "(cd ..; npm run copy-themes) && PUBLIC_URL=/service-catalog INLINE_RUNTIME_CHUNK=false ../node_modules/.bin/react-scripts build",
+    "build": "(cd ..; npm run copy-themes) && PUBLIC_URL=/service-catalog INLINE_RUNTIME_CHUNK=false GENERATE_SOURCEMAP=false ../node_modules/.bin/react-scripts build",
     "test": "echo We have no tests at this moment"
   },
   "eslintConfig": {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Pass `GENERATE_SOURCEMAP=false` to resolve missing react-tippy source map warning. It looks like a [bug in CRA](https://github.com/facebook/create-react-app/discussions/11767).

- We can't have a fix for `DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE` - `onAfterSetupMiddleware` function is used by CRA again ([here](https://github.com/facebook/create-react-app/blob/fd8c5f7b1b1d19d10d24cc2f9fdfc110585dc030/packages/react-scripts/config/webpackDevServer.config.js#L112)).

- I noticed that `core` is complaining about big size of `lib/vs` (the minified Monaco). It's not used actually by `core`, but by `react-shared` - `core` just copies it so `shared` can access it lazily. We could remove some warnings (with help of https://www.npmjs.com/package/webpack-exclude-assets-plugin), but I don't consider it _that_ valuable.

