### PR TITLE
Resolve build warnings

### DIFF
--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-996
+          image: eu.gcr.io/kyma-project/busola-web:PR-1061
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Pass `GENERATE_SOURCEMAP=false` to resolve missing react-tippy source map warning. It looks like a [bug in CRA](https://github.com/facebook/create-react-app/discussions/11767).

- We can't have a fix for `DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE` - `onAfterSetupMiddleware` function is used by CRA again ([here](https://github.com/facebook/create-react-app/blob/fd8c5f7b1b1d19d10d24cc2f9fdfc110585dc030/packages/react-scripts/config/webpackDevServer.config.js#L112)).

- I noticed that `core` is complaining about big size of `lib/vs` (the minified Monaco). It's not used actually by `core`, but by `react-shared` - `core` just copies it so `shared` can access it lazily. We could remove some warnings (with help of https://www.npmjs.com/package/webpack-exclude-assets-plugin), but I don't consider it _that_ valuable.

