### PR TITLE
Improve User Experience for users with Namespace Access only

### DIFF
--- a/core-ui/src/components/NoPermissions/NoPermissions.js
+++ b/core-ui/src/components/NoPermissions/NoPermissions.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import LuigiClient from '@luigi-project/client';
-import { Icon } from 'fundamental-react';
+import { Button, FormInput, Icon } from 'fundamental-react';
+import { useMicrofrontendContext } from 'react-shared';
 import { useTranslation } from 'react-i18next';
 import './NoPermissions.scss';
+import { addCluster } from 'components/Clusters/shared';
 
 // as Luigi docs say, "some special characters (<, >, ", ', /) in node parameters are HTML-encoded."
 function decodeHTMLEncoded(str) {
@@ -11,6 +13,11 @@ function decodeHTMLEncoded(str) {
 
 export function NoPermissions() {
   const { t } = useTranslation();
+  const [namespaceName, setNamespaceName] = useState('');
+  const {
+    currentCluster: { kubeconfig },
+  } = useMicrofrontendContext();
+
   let { error } = LuigiClient.getNodeParams();
   if (error) {
     error = decodeHTMLEncoded(error);
@@ -18,12 +25,50 @@ export function NoPermissions() {
     error = t('common.errors.no-permissions');
   }
 
+  const updateKubeconfig = () => {
+    const contextName = kubeconfig['current-context'];
+    const context =
+      kubeconfig.contexts?.find(ctx => ctx.name === contextName) ||
+      kubeconfig.contexts?.[0];
+
+    context.context.namespace = namespaceName;
+
+    addCluster({
+      kubeconfig,
+      currentContext: {
+        cluster: kubeconfig.clusters.find(
+          c => c.name === context.context.cluster,
+        ),
+        user: kubeconfig.users.find(u => u.name === context.context.user),
+      },
+    });
+  };
+
   return (
     <section className="no-permissions">
       <Icon ariaLabel="no-permissions" glyph="locked" />
       <header>{t('common.errors.no-permissions-header')}</header>
-      <p className="fd-margin--md">{error}</p>
+      <p className="fd-margin-top--md">{error}</p>
       <p>{t('common.errors.no-permissions-message')}</p>
+      <p className="fd-margin-top--md fd-margin-bottom--sm">
+        {t('no-permissions.enter-namespace-name')}
+      </p>
+      <form className="fd-display-flex">
+        <FormInput
+          className="fd-margin-0"
+          placeholder={t('no-permissions.enter-namespace-name-placeholder')}
+          value={namespaceName}
+          onChange={e => setNamespaceName(e.target.value)}
+        />
+        <Button
+          option="emphasized"
+          className="update-namespace-button"
+          disabled={!namespaceName}
+          onClick={updateKubeconfig}
+        >
+          Save
+        </Button>
+      </form>
     </section>
   );
 }

--- a/core-ui/src/components/NoPermissions/NoPermissions.scss
+++ b/core-ui/src/components/NoPermissions/NoPermissions.scss
@@ -21,3 +21,8 @@
     text-align: center;
   }
 }
+
+.update-namespace-button {
+  width: 100px;
+  margin-left: 20px;
+}

--- a/core-ui/src/index.scss
+++ b/core-ui/src/index.scss
@@ -359,6 +359,10 @@ input[type='checkbox'] {
   justify-content: space-between;
 }
 
+.fd-margin-0 {
+  margin: 0;
+}
+
 .fd-link {
   cursor: pointer;
 }

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -1522,7 +1522,7 @@ network-policies:
   present-but-empty: Present but empty selector selects all pods / namespaces.
   title: Network Policies
 no-permissions:
-  enter-namespace-name: 'If you expect to have access to some Namespace please enter it here:'
+  enter-namespace-name: 'If you expect to have access to a Namespace, please enter its name here:'
   enter-namespace-name-placeholder: Enter Namespace name
   title: No Permissions
 node-details:

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -471,7 +471,7 @@ common:
     no-permissions: You don't have enough permissions to view this content.
     no-permissions-header: Not enough permissions
     no-permissions-message: Contact your administrator to grant you access.
-    no-permissions-no-role: You have no role assigned
+    no-permissions-no-role: You have no role assigned.
   headers:
     annotations: Annotations
     created: Created
@@ -1522,6 +1522,8 @@ network-policies:
   present-but-empty: Present but empty selector selects all pods / namespaces.
   title: Network Policies
 no-permissions:
+  enter-namespace-name: 'If you expect to have access to some Namespace please enter it here:'
+  enter-namespace-name-placeholder: Enter Namespace name
   title: No Permissions
 node-details:
   all: All messages

--- a/core/src/luigi-config/communication.js
+++ b/core/src/luigi-config/communication.js
@@ -90,7 +90,7 @@ export const communication = {
     'busola.addCluster': async ({ params, switchCluster = true }) => {
       await saveClusterParams(params);
       if (switchCluster) {
-        setCluster(params.kubeconfig['current-context']);
+        await setCluster(params.kubeconfig['current-context']);
       }
     },
     'busola.deleteCluster': async ({ clusterName }) => {

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -152,6 +152,7 @@ async function createClusterManagementNodes(features) {
     hideFromNav: true,
     hideSideNav: true,
     viewUrl: config.coreUIModuleUrl + '/no-permissions',
+    context: { currentCluster: await getActiveCluster() },
   };
 
   return [clusterManagementNode, clusterNode, noPermissionsNode];
@@ -372,9 +373,10 @@ export async function createNavigationNodes(
 
   const clusterNodes = await createClusterNodes();
 
-  const namespaceNodes = await clusterNodes
-    .find(n => n.resourceType === 'namespaces')
-    .children[0].children();
+  const namespaceNodes =
+    (await clusterNodes
+      .find(n => n.resourceType === 'namespaces')
+      ?.children[0]?.children?.()) || [];
 
   const simplifyNodes = nodes =>
     nodes

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1098
+          image: eu.gcr.io/kyma-project/busola-web:PR-1102
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Testing**

* Unassign all your roles on https://apskyxzcl.accounts400.ondemand.com/admin/#/users
* Add yourself a role binding (e.g. `/cluster/shoot--hasselhoff--kmain/namespaces/default/rolebindings/details/ns2` - not that's a `Role`, not a `ClusterRole`)
* Use the following kubeconfig (basically OIDC kubeconfig, BUT without a _namespace_ in _context_)
```
apiVersion: v1
kind: Config
current-context: shoot--hasselhoff--kmain-oidc
contexts:
  - name: shoot--hasselhoff--kmain-oidc
    context:
      cluster: shoot--hasselhoff--kmain-oidc
      user: shoot--hasselhoff--kmain-oidc
clusters:
  - name: shoot--hasselhoff--kmain-oidc
    cluster:
      server: 'https://api.kmain.hasselhoff.shoot.canary.k8s-hana.ondemand.com'
      certificate-authority-data: >-
        LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM5akNDQWQ2Z0F3SUJBZ0lRTlpWYlkxTmRTcWtTQVh0a0tudjVsakFOQmdrcWhraUc5dzBCQVFzRkFEQVYKTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWek1CNFhEVEl5TURJeU5URXdNall5TUZvWERUTXlNREl5TlRFdwpNall5TUZvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBSko5TE9wd3gwT0pYMi9id01EODZ1Q0k0VkNNdVFCVVZTTGZjOFJnTWxNYjBpMTYKdWFvenFETzBTMnVCZUU0OW56WlFER2c2MGkzNTFXRkhMS0Q5dElzUzk4UjJEY2dWY3VwaDNhV0NsWWJWY1lnWApRcE8xdWhUZmc3L0ZpcWJyUDRZNXdXWStuT2dwWjdCbHNiVGJyMEtybzc1SzY3Q3drU3ZxemhZd1M0Uks0V0tHCkw1d3hwWHpWeEVYTkZsVS8zTkszT0RyTlMzTXlkTWJFQVZEcjdXaFpSd3RqMW1LQXdFaFFDbDNCUWM2YXpCYUoKdzRvTlNRaGpsdHNDSHRMS2hsdkMxUVZyQllGWjlaMnl6YlMrcHVleDdIQzlIVjczcUhjOHRMUnhObEo0NFlBZAp0Tlc4dy84R0NWWS9iSmEwNzE2czIwNmVYRjFxeGRpcmRLVVdWQWtDQXdFQUFhTkNNRUF3RGdZRFZSMFBBUUgvCkJBUURBZ0dtTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkRKK2lMMjBQYjR6enZJdHc2U1gKMFdPWm0ya3VNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUI3L3h0OS9DWjMwbzFhNVRmYnJLRHFkQTQva2NyVQpUcUxXR1FTZ0x0SHNmTkw3MFl5Y045OU8yNUhIWENqYVRVYTN6U21VYXpNNWlpbEt4Y1RUdWlLTzVKdlNBN09zCmhacWs3YnFMK2xrL0lzL0VnY3kwenBjK2JMUnFvN2FUZHl3RUUzQ0duMHhycG43cEwzZnFlY3drQUlJNVFQMSsKZ1lnU2xWaXVJQzd6c1hqZ3VGM1dpbVA4TEFJL0JrUURIdzAyc3JpSEFhVE5IRjhJS0hHeXk1cGJ6U3hXMzFlSwpCTGJ3S3J0VjZteWZEZE5zbkpyaXVZS1hqNW9WcnhSamhyZEs4VUFYNi9ucTlSWXFjZ0VueThnWWlGNnlhbE9HCkJ3TitDVnd1UFpxa24wc0pCV0lEbXJGQzR2aTY1TWh3d1lpUlAwYkVsVERWRVlqRHBWRWRTZE5xCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
users:
  - name: shoot--hasselhoff--kmain-oidc
    user:
      exec:
        apiVersion: client.authentication.k8s.io/v1beta1
        command: kubectl
        args:
          - oidc-login
          - get-token
          - '--oidc-issuer-url=https://apskyxzcl.accounts400.ondemand.com'
          - '--oidc-client-id=d0316c58-b0fe-45cd-9960-0fea0708355a'
          - '--oidc-extra-scope=openid'
          - '--grant-type=auto'
```
* You should be able to see `Not enough permissions`, but no with namespace name input
	* If you type random stuff, it will try to log you in, but it's gonna fail and go back to the same `Not enought permissions` view.
	* If you type a namespace name you have access to, you'll be redirected to NS details.

**Related issue(s)**

Closes #1080 
