### PR TITLE
Remove messages on OAuth details view. Display a link to secret if it exists 

### DIFF
--- a/core-ui/src/resources/OAuth2Clients/OAuth2ClientDetails.js
+++ b/core-ui/src/resources/OAuth2Clients/OAuth2ClientDetails.js
@@ -10,7 +10,6 @@ import OAuthClientSpecPanel from './OAuthClientSpecPanel';
 import { OAuth2ClientCreate } from './OAuth2ClientCreate';
 
 function SecretComponent({ namespaceName, secretName }) {
-  const { t } = useTranslation();
   const { data: secret, error, loading = true } = useGet(
     `/api/v1/namespaces/${namespaceName}/secrets/${secretName}`,
     {
@@ -18,9 +17,7 @@ function SecretComponent({ namespaceName, secretName }) {
     },
   );
 
-  if (loading) return t('common.headers.loading');
-  if (error) return `${t('common.tooltips.error')} ${error.message}`;
-
+  if (loading || error) return null;
   return <SecretData secret={secret} />;
 }
 
@@ -35,7 +32,11 @@ export function OAuth2ClientDetails(props) {
     />
   );
   const Configuration = resource => (
-    <OAuthClientSpecPanel key="configuration" spec={resource.spec} />
+    <OAuthClientSpecPanel
+      key="configuration"
+      spec={resource.spec}
+      namespace={resource.metadata.namespace}
+    />
   );
 
   const statusColumn = {

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1247
+          image: eu.gcr.io/kyma-project/busola-web:PR-1252
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
I decided to not display an error/loading message when a secret doesn't exist because this is what we usually do in other resources(SC/PV/PVC). If a `secretName` value exists but the secret doesn't, the name of the secret is displayed but without a link to the details.

Changes proposed in this pull request:

- Remove an error/loading message on oauth details view
- Add displaying a link to the secret if it exists

**Related issue(s)**
Closes #1106 

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
