### PR TITLE
Repair calling prettifyNamePlural function

### DIFF
--- a/core-ui/src/resources/DnsEntries/DnsEntryList.js
+++ b/core-ui/src/resources/DnsEntries/DnsEntryList.js
@@ -35,7 +35,7 @@ export function DnsEntryList(params) {
     <ResourcesList
       customColumns={customColumns}
       description={description}
-      resourceName="DNS Entries"
+      resourceName={t('dnsentries.title')}
       createResourceForm={DnsEntryCreate}
       {...params}
     />

--- a/core-ui/src/shared/components/ResourceDetails/ResourceDetails.js
+++ b/core-ui/src/shared/components/ResourceDetails/ResourceDetails.js
@@ -80,7 +80,7 @@ function ResourceDetailsRenderer(props) {
   if (error) {
     const breadcrumbItems = props.breadcrumbs || [
       {
-        name: prettifyNamePlural(props.resourceTitle || props.resourceType),
+        name: prettifyNamePlural(props.resourceTitle, props.resourceType),
         path: '/',
         fromContext: props.resourceType.toLowerCase(),
       },

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1281
+          image: eu.gcr.io/kyma-project/busola-web:PR-1293
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When a resource doesn't exist UI is displaying resourceName without space in some cases.
Changes proposed in this pull request:
- Change `||` to `,` in calling function
- ...
- ...

**Related issue(s)**
Closes #1227 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
