### PR TITLE
Handle CMs & Secrets connected to Pod via volume

### DIFF
--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1305
+          image: eu.gcr.io/kyma-project/busola-web:PR-1339
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Sooo Pod can be connected not only by `pod.spec.containers[*].env`, but also by `pod.spec.volumes` 🤦 

**Related issue(s)**

Closes #1331 
