### PR TITLE
Prevent layout shifts on cluster overview

### DIFF
--- a/core-ui/src/components/Clusters/views/ClusterOverview/ClusterNodes/ClusterNodes.js
+++ b/core-ui/src/components/Clusters/views/ClusterOverview/ClusterNodes/ClusterNodes.js
@@ -146,7 +146,7 @@ export function ClusterNodes() {
         rowRenderer={rowRenderer}
         serverDataError={usePrometheusQueries ? prometheusDataError : error}
         serverDataLoading={
-          usePrometheusQueries ? prometheusDataLoading : loading
+          !data && (usePrometheusQueries ? prometheusDataLoading : loading)
         }
         pagination={{ autoHide: true }}
         i18n={i18n}

--- a/core-ui/src/components/Clusters/views/ClusterOverview/ClusterNodes/ResourceCommitment/CommitmentGraph.js
+++ b/core-ui/src/components/Clusters/views/ClusterOverview/ClusterNodes/ResourceCommitment/CommitmentGraph.js
@@ -95,9 +95,11 @@ export function CommitmentGraph({ data }) {
         horizontalPadding +
         Math.min(utilized, LIMITS_WARNING_VALUE) * ratio * innerWidth;
       const y = barHStart;
+      ctx.beginPath();
       ctx.moveTo(x, y);
       ctx.lineTo(x - 10, y - 11);
       ctx.lineTo(x + 10, y - 11);
+      ctx.closePath();
       ctx.fill();
       ctx.fillRect(x - 1, y, 2, barHeight);
       ctx.fillText(

--- a/core-ui/src/components/Clusters/views/ClusterOverview/ClusterNodes/ResourceCommitment/queries.js
+++ b/core-ui/src/components/Clusters/views/ClusterOverview/ClusterNodes/ResourceCommitment/queries.js
@@ -1,3 +1,4 @@
+import { isNil } from 'lodash';
 import { useGet } from 'shared/hooks/BackendAPI/useGet';
 
 function usePrometheusQuery(serviceUrl, query, time) {
@@ -20,7 +21,7 @@ export function useCurrentQuery({ serviceUrl, time, queryType }) {
       data: Object.fromEntries(
         requests.map(request => [request.name, request.query.value]),
       ),
-      loading: requests.some(request => request.query.loading), // any loading=true
+      loading: requests.some(request => isNil(request.query.value)), // any value is not present
       error: requests.find(request => request.query.error)?.query?.error, // find first error
     };
   };

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1389
+          image: eu.gcr.io/kyma-project/busola-web:PR-1393
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Don't show loading indicator on Nodes list and `CommitmentGraph` after it was loaded once.
- Fix small bug with `CommitmentGraph` - the little arrow at "Utilized" wasn't cleared properly.

**Testing**

- For Nodes list, change `core-ui/src/shared/hooks/usePrometheus.js:180` - instead of `step * 1000` (usually 1 minute), use something like `5000` (5s).
- For graph, change the same thing in `core-ui/src/components/Clusters/views/ClusterOverview/ClusterNodes/ResourceCommitment/useMetricsQuery.js:30`.

**Related issue(s)**

Closes #1384 
