### PR TITLE
Improve the name widget

### DIFF
--- a/core-ui/src/components/Extensibility/components-form/NameRenderer.js
+++ b/core-ui/src/components/Extensibility/components-form/NameRenderer.js
@@ -10,28 +10,34 @@ export function NameRenderer({
   onChange,
   schema,
   required,
+  extraPaths = [],
+  ...props
 }) {
+  console.log('extraPaths', extraPaths);
+  console.log('more props', props);
   return (
     <K8sNameField
       value={value}
       kind={resource.kind}
       setValue={value => {
-        onChange({
-          storeKeys,
-          scopes: ['value'],
-          type: 'set',
-          schema,
-          required,
-          data: { value },
-        });
-        onChange({
-          storeKeys: List(['metadata', 'labels', 'app.kubernetes.io/name']),
-          scopes: ['value'],
-          type: 'set',
-          schema,
-          required,
-          data: { value },
-        });
+        onChange([
+          {
+            storeKeys,
+            scopes: ['value'],
+            type: 'set',
+            schema,
+            required,
+            data: { value },
+          },
+          ...extraPaths.map(path => ({
+            storeKeys: List(Array.isArray(path) ? path : path.split('.')),
+            scopes: ['value'],
+            type: 'set',
+            schema,
+            required,
+            data: { value },
+          })),
+        ]);
       }}
       validate={value => !!value}
     />

--- a/core-ui/src/components/Extensibility/components-form/NameRenderer.js
+++ b/core-ui/src/components/Extensibility/components-form/NameRenderer.js
@@ -10,11 +10,10 @@ export function NameRenderer({
   onChange,
   schema,
   required,
-  extraPaths = [],
   ...props
 }) {
-  console.log('extraPaths', extraPaths);
-  console.log('more props', props);
+  const extraPaths = schema.get('extraPaths')?.toJS() || [];
+
   return (
     <K8sNameField
       value={value}

--- a/core-ui/src/components/Extensibility/metadataSchema.js
+++ b/core-ui/src/components/Extensibility/metadataSchema.js
@@ -3,6 +3,7 @@ export const METADATA_SCHEMA = {
     name: {
       type: 'string',
       widget: 'Name',
+      extraPaths: [['metadata', 'labels', 'app.kubernetes.io/name']],
     },
     labels: {
       type: 'object',


### PR DESCRIPTION
Add extraPaths as a parameter instead of hardcoding `['metadata', 'labels', 'app.kubernetes.io/name']` into the component
