### PR TITLE
Fix incorrect Table Widget to not break the page 

### DIFF
--- a/core-ui/src/components/Extensibility/components/Plain.js
+++ b/core-ui/src/components/Extensibility/components/Plain.js
@@ -6,7 +6,7 @@ export function Plain({ value, structure, schema }) {
   return (
     <div>
       {structure.children?.map(def => (
-        <Widget value={value} structure={def} schema={schema} />
+        <Widget value={value} structure={def} schema={schema} key={def} />
       ))}
     </div>
   );

--- a/core-ui/src/components/Extensibility/components/Plain.js
+++ b/core-ui/src/components/Extensibility/components/Plain.js
@@ -5,9 +5,11 @@ import { Widget } from './Widget';
 export function Plain({ value, structure, schema }) {
   return (
     <div>
-      {structure.children?.map(def => (
-        <Widget value={value} structure={def} schema={schema} key={def} />
-      ))}
+      {structure.children?.map((def, idx) => {
+        return (
+          <Widget value={value} structure={def} schema={schema} key={idx} />
+        );
+      })}
     </div>
   );
 }

--- a/core-ui/src/components/Extensibility/components/Table.js
+++ b/core-ui/src/components/Extensibility/components/Table.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { isNil } from 'lodash';
 
 import { GenericList } from 'shared/components/GenericList/GenericList';
 
@@ -8,7 +9,7 @@ import { Widget } from './Widget';
 
 const handleTableValue = (value, t) => {
   switch (true) {
-    case value === undefined: {
+    case isNil(value): {
       return { entries: [] };
     }
     case Array.isArray(value): {
@@ -19,7 +20,7 @@ const handleTableValue = (value, t) => {
     default: {
       return {
         entries: [],
-        invalidConfigurationMessage: t('extensibility.widgets.table.error'),
+        genericErrorMessage: t('extensibility.widgets.table.error'),
       };
     }
   }
@@ -40,7 +41,7 @@ export function Table({ value, structure, schema }) {
     <GenericList
       showSearchSuggestion={false}
       title={tExt(structure.name, {
-        defaultValue: t(structure.path, {
+        defaultValue: tExt(structure.path, {
           defaultValue: ' ',
         }),
       })}

--- a/core-ui/src/components/Extensibility/components/Table.js
+++ b/core-ui/src/components/Extensibility/components/Table.js
@@ -1,13 +1,33 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { GenericList } from 'shared/components/GenericList/GenericList';
 
 import { useGetTranslation } from '../helpers';
 import { Widget } from './Widget';
 
+const handleTableValue = (value, t) => {
+  switch (true) {
+    case value === undefined: {
+      return { entries: [] };
+    }
+    case Array.isArray(value): {
+      return {
+        entries: value,
+      };
+    }
+    default: {
+      return {
+        entries: [],
+        invalidConfigurationMessage: t('extensibility.widgets.table.error'),
+      };
+    }
+  }
+};
+
 export function Table({ value, structure, schema }) {
   const { widgetT } = useGetTranslation();
-
+  const { t } = useTranslation();
   const headerRenderer = () =>
     (structure.children || []).map(column => widgetT([structure, column]));
 
@@ -19,9 +39,9 @@ export function Table({ value, structure, schema }) {
   return (
     <GenericList
       showSearchSuggestion={false}
-      entries={value || []}
       headerRenderer={headerRenderer}
       rowRenderer={rowRenderer}
+      {...handleTableValue(value, t)}
     />
   );
 }

--- a/core-ui/src/shared/components/GenericList/GenericList.js
+++ b/core-ui/src/shared/components/GenericList/GenericList.js
@@ -58,7 +58,7 @@ export const GenericList = ({
   i18n,
   allowSlashShortcut,
   sortBy,
-  invalidConfigurationMessage,
+  genericErrorMessage,
 }) => {
   if (typeof sortBy === 'function') sortBy = sortBy(defaultSort);
 
@@ -176,7 +176,7 @@ export const GenericList = ({
       }
       return (
         <BodyFallback>
-          <p>{invalidConfigurationMessage || t(notFoundMessage)}</p>
+          <p>{genericErrorMessage || t(notFoundMessage)}</p>
         </BodyFallback>
       );
     }
@@ -300,7 +300,7 @@ GenericList.propTypes = {
   compact: PropTypes.bool,
   className: PropTypes.string,
   currentlyEditedResourceUID: PropTypes.string,
-  invalidConfigurationMessage: PropTypes.string,
+  genericErrorMessage: PropTypes.string,
 };
 
 GenericList.defaultProps = {
@@ -317,5 +317,5 @@ GenericList.defaultProps = {
   serverDataLoading: false,
   hasExternalMargin: true,
   compact: true,
-  invalidConfigurationMessage: null,
+  genericErrorMessage: null,
 };

--- a/core-ui/src/shared/components/GenericList/GenericList.js
+++ b/core-ui/src/shared/components/GenericList/GenericList.js
@@ -58,6 +58,7 @@ export const GenericList = ({
   i18n,
   allowSlashShortcut,
   sortBy,
+  invalidConfigurationMessage,
 }) => {
   if (typeof sortBy === 'function') sortBy = sortBy(defaultSort);
 
@@ -175,7 +176,7 @@ export const GenericList = ({
       }
       return (
         <BodyFallback>
-          <p>{t(notFoundMessage)}</p>
+          <p>{invalidConfigurationMessage || t(notFoundMessage)}</p>
         </BodyFallback>
       );
     }
@@ -299,6 +300,7 @@ GenericList.propTypes = {
   compact: PropTypes.bool,
   className: PropTypes.string,
   currentlyEditedResourceUID: PropTypes.string,
+  invalidConfigurationMessage: PropTypes.string,
 };
 
 GenericList.defaultProps = {
@@ -315,4 +317,5 @@ GenericList.defaultProps = {
   serverDataLoading: false,
   hasExternalMargin: true,
   compact: true,
+  invalidConfigurationMessage: null,
 };

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -993,6 +993,9 @@ events:
   title: Events
 extensibility:
   error: Your extension configuration is incorrect.
+  widgets:
+    table:
+      error: The table widget configuration is incorrect. Path value should be an array type.
 functions:
   buttons:
     connected-repositories: Connected Repositories

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -592,7 +592,7 @@ common:
     error: Error
     generate-name: Generate name
     hide: Hide read-only fields
-    k8s-name-input: 'Name must consist of lowercase alphanumeric characters, can contain ''-'' (e.g.: ''my-name1'').'
+    k8s-name-input: "Name must consist of lowercase alphanumeric characters, can contain '-' (e.g.: 'my-name1')."
     key: Key must start and end with an alphanumeric character, can contain '-', '_' or '.'.
     key-value: Key and value must start and end with an alphanumeric character, can contain '-', '_' or '.'.
     line: Ln
@@ -1478,7 +1478,7 @@ jobs:
     complete: Job completed
     not-complete: Job in progress
 kubeconfig-id:
-  error: 'Couldn''t load kubeconfig ID; configuration not changed (Error: ${{error}})'
+  error: "Couldn't load kubeconfig ID; configuration not changed (Error: ${{error}})"
   must-be-an-object: Kubeconfig must be a JSON or YAML object.
 legal:
   copyright: Copyright

--- a/core/src/i18n/en.yaml
+++ b/core/src/i18n/en.yaml
@@ -592,7 +592,7 @@ common:
     error: Error
     generate-name: Generate name
     hide: Hide read-only fields
-    k8s-name-input: "Name must consist of lowercase alphanumeric characters, can contain '-' (e.g.: 'my-name1')."
+    k8s-name-input: 'Name must consist of lowercase alphanumeric characters, can contain ''-'' (e.g.: ''my-name1'').'
     key: Key must start and end with an alphanumeric character, can contain '-', '_' or '.'.
     key-value: Key and value must start and end with an alphanumeric character, can contain '-', '_' or '.'.
     line: Ln
@@ -995,7 +995,7 @@ extensibility:
   error: Your extension configuration is incorrect.
   widgets:
     table:
-      error: The table widget configuration is incorrect. Path value should be an array type.
+      error: The table widget configuration is incorrect. Path value must be an array type.
 functions:
   buttons:
     connected-repositories: Connected Repositories
@@ -1478,7 +1478,7 @@ jobs:
     complete: Job completed
     not-complete: Job in progress
 kubeconfig-id:
-  error: "Couldn't load kubeconfig ID; configuration not changed (Error: ${{error}})"
+  error: 'Couldn''t load kubeconfig ID; configuration not changed (Error: ${{error}})'
   must-be-an-object: Kubeconfig must be a JSON or YAML object.
 legal:
   copyright: Copyright


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed the bug of incorrect Table Widget breaking the details page
- Added a key prop to remove console errors
- Added a prop to the GenericList component that is displayed when there's an incorrect extensibility configuration 
- Added translations

**Related issue(s)**
Resolves #1440 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
