### PR TITLE
Fix KeyValuePairRenderer

### DIFF
--- a/core-ui/src/components/Extensibility/components-form/KeyValuePairRenderer.js
+++ b/core-ui/src/components/Extensibility/components-form/KeyValuePairRenderer.js
@@ -4,6 +4,7 @@ import { KeyValueField } from 'shared/ResourceForm/fields';
 import { createOrderedMap } from '@ui-schema/ui-schema/Utils/createMap';
 import { useGetTranslation } from 'components/Extensibility/helpers';
 import { useTranslation } from 'react-i18next';
+import { getObjectValueWorkaround } from 'components/Extensibility/helpers';
 
 export function KeyValuePairRenderer({
   storeKeys,
@@ -11,7 +12,13 @@ export function KeyValuePairRenderer({
   value,
   onChange,
   required,
+  resource,
 }) {
+  // TODO the value obtained by ui-schema is undefined for this component
+  value = getObjectValueWorkaround(schema, resource, storeKeys, value);
+
+  console.log({ value });
+
   const { tFromStoreKeys } = useGetTranslation();
   const { t } = useTranslation();
 
@@ -27,7 +34,7 @@ export function KeyValuePairRenderer({
 
   return (
     <KeyValueField
-      value={value ? Object.fromEntries(value) : {}}
+      value={value ? value.toJS() : {}}
       setValue={value => {
         onChange({
           storeKeys,

--- a/core-ui/src/components/Extensibility/components-form/ResourceRefRenderer.js
+++ b/core-ui/src/components/Extensibility/components-form/ResourceRefRenderer.js
@@ -2,22 +2,19 @@ import React from 'react';
 import { ExternalResourceRef } from 'shared/components/ResourceRef/ExternalResourceRef';
 import { useGetList } from 'shared/hooks/BackendAPI/useGet';
 import pluralize from 'pluralize';
+import { createOrderedMap } from '@ui-schema/ui-schema/Utils/createMap';
+import { getObjectValueWorkaround } from 'components/Extensibility/helpers';
 
 export function ResourceRefRender({
   onChange,
-  onKeyDown,
   value,
   schema,
   storeKeys,
   required,
-  ...props
+  resource,
 }) {
   // TODO the value obtained by ui-schema is undefined for this component
-  const backupValueFromResource = storeKeys
-    .toArray()
-    .reduce((valueSoFar, currKey) => {
-      return valueSoFar[currKey];
-    }, props.resource);
+  value = getObjectValueWorkaround(schema, resource, storeKeys, value);
 
   const resourceType = pluralize(schema.get('kind') || '').toLowerCase();
 
@@ -27,7 +24,7 @@ export function ResourceRefRender({
 
   return (
     <ExternalResourceRef
-      value={value || backupValueFromResource}
+      value={value.toJS()}
       resources={data}
       setValue={value => {
         onChange({
@@ -36,7 +33,7 @@ export function ResourceRefRender({
           type: 'set',
           schema,
           required,
-          data: { value },
+          data: { value: createOrderedMap(value) },
         });
       }}
       required={required}

--- a/core-ui/src/components/Extensibility/helpers.js
+++ b/core-ui/src/components/Extensibility/helpers.js
@@ -4,6 +4,7 @@ import * as jp from 'jsonpath';
 import pluralize from 'pluralize';
 import jsonata from 'jsonata';
 import { EMPTY_TEXT_PLACEHOLDER } from 'shared/constants';
+import { OrderedMap } from 'immutable';
 
 export const TranslationBundleContext = createContext({
   translationBundle: 'extensibility',
@@ -94,4 +95,22 @@ export const useGetPlaceholder = structure => {
   }
 
   return { emptyLeafPlaceholder };
+};
+
+export const getObjectValueWorkaround = (
+  schema,
+  resource,
+  storeKeys,
+  value,
+) => {
+  // TODO the value obtained by ui-schema is undefined for this component
+  if (schema.toJS().type === 'object') {
+    value = OrderedMap(
+      storeKeys.toArray().reduce((valueSoFar, currKey) => {
+        return valueSoFar?.[currKey];
+      }, resource),
+    );
+  }
+
+  return value;
 };

--- a/core-ui/src/components/Extensibility/metadataSchema.js
+++ b/core-ui/src/components/Extensibility/metadataSchema.js
@@ -6,12 +6,14 @@ export const METADATA_SCHEMA = {
       extraPaths: [['metadata', 'labels', 'app.kubernetes.io/name']],
     },
     labels: {
+      type: 'object',
       additionalProperties: {
         type: 'string',
       },
       widget: 'KeyValuePair',
     },
     annotations: {
+      type: 'object',
       additionalProperties: {
         type: 'string',
       },

--- a/docs/extensibility/form-widgets.md
+++ b/docs/extensibility/form-widgets.md
@@ -100,7 +100,7 @@ KeyValuePair widgets render an `object` value as a list of dual text fields. One
 
 ```json
 {
-  "path": "spec.my-data[]",
+  "path": "spec.my-data",
   "widget": "KeyValuePair"
 }
 ```

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1581
+          image: eu.gcr.io/kyma-project/busola-web:PR-1586
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Move workaround for `type: object` from ResourceRefs to helpers
- Add workaround to KeyValuePairRenderer
- Bring back `type: object` to metadataSchema

**Related issue(s)**
Closes #1558 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
