### PR TITLE
changed path of defaultKubeconfigId feature

### DIFF
--- a/core/src/luigi-config/kubeconfig-id/loadKubeconfigById.js
+++ b/core/src/luigi-config/kubeconfig-id/loadKubeconfigById.js
@@ -26,7 +26,7 @@ export async function loadKubeconfigById(kubeconfigId) {
     return null;
   }
 
-  const isHome = /^\/?$/.test(window.location.pathname);
+  const isHome = /^\/clusters?$/.test(window.location.pathname);
   const areClusters = Object.getOwnPropertyNames(getClusters()).length;
   const defaultKubeconfig = kubeconfigIdFeature.config.defaultKubeconfig;
 

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1591
+          image: eu.gcr.io/kyma-project/busola-web:PR-1625
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change the path of the defaultKubeconfig to `/clusters`

In a previous [MR](https://github.com/kyma-project/busola/pull/1591), @wchrapka implemented the feature for setting a default kubeconfigID on the root path of the application. While this is an improvement, it only somewhat fixes the underlying issue.  

With this implementation, the end user would still set their bookmarks to the `/clusters` path, since this is the URL that will be redirected to from the root path. This means, that (depending on the configured storage option) the user will at some point be met with an empty cluster list again. 

It was mentioned, that an invalid kubeconfig will lead to an infinite loop, which (in my testing) turns out to not actually be completely accurate.

This popup is presented twice:
![Screenshot 2022-07-19 at 13 31 04](https://user-images.githubusercontent.com/29383712/179741807-f251af93-2bc4-4100-ba48-12baefdd6818.png)

After accepting these popups, the empty cluster list is shown:

![Screenshot 2022-07-19 at 13 31 09](https://user-images.githubusercontent.com/29383712/179741307-c2204d22-f79c-4b84-a424-26339a0e9800.png)


In my opinion, this is acceptable behavior for an invalid kubeconfig, especially since this feature has to be set up explicitly. 

**Related issue(s)**

https://github.com/kyma-project/busola/issues/1438
https://github.com/kyma-project/busola/pull/1591

