### PR TITLE
Fix pizzas form example

### DIFF
--- a/examples/pizzas/configuration/pizzas-configmap.yaml
+++ b/examples/pizzas/configuration/pizzas-configmap.yaml
@@ -88,9 +88,9 @@ data:
       { "path": "spec.description", "widget": "Text" , "simple": true},
       { "path": "spec.sauce", "widget": "Text" , "simple": true},
       { "path": "spec.toppings", "widget": "GenericList", "simple": true},
-      { "path": "spec.toppings.name", "simple": true},
-      { "path": "spec.toppings.price", "simple": true},
-      { "path": "spec.toppings.quantity", "simple": true},
+      { "path": "spec.toppings[].name", "simple": true},
+      { "path": "spec.toppings[].price", "simple": true},
+      { "path": "spec.toppings[].quantity", "simple": true},
       { "path": "spec.comments", "widget": "SimpleList", "simple": true},
       {
         "path": "spec.recipeSecret",
@@ -106,9 +106,9 @@ data:
       "widget": "GenericList",
       "simple": true
       },
-      { "path": "spec.ownerReferences.apiVersion", "simple": true},
-      { "path": "spec.ownerReferences.kind", "simple": true},
-      { "path": "spec.ownerReferences.name", "simple": true}
+      { "path": "spec.ownerReferences[].apiVersion", "simple": true},
+      { "path": "spec.ownerReferences[].kind", "simple": true},
+      { "path": "spec.ownerReferences[].name", "simple": true}
     ]
   list: |-
     [
@@ -217,4 +217,7 @@ data:
       spec.toppings.price: Price ($)
       spec.toppings.quantity: Quantity
       spec.ownerReferences: Owner References
+      spec.ownerReferences.apiVersion: API Version
+      spec.ownerReferences.kind: Kind
+      spec.ownerReferences.name: Name
   version: '0.5'


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adjust usage of `GenericList` widget. Without that the expanded Form>Toppings>Topping section was empty.
- Add missing translations for `ownerReferences` properties
