### PR TITLE
fix for no refreshing monaco for presets

### DIFF
--- a/core-ui/src/shared/ResourceForm/components/Presets.js
+++ b/core-ui/src/shared/ResourceForm/components/Presets.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown } from 'shared/components/Dropdown/Dropdown';
 
@@ -10,17 +10,20 @@ export function Presets({ presets, onSelect, ...otherProps }) {
   }));
 
   return (
-    <Dropdown
-      placeholder={t('common.create-form.choose-preset')}
-      compact
-      options={options}
-      selectedKey={''}
-      onSelect={(e, preset) => {
-        e.stopPropagation();
-        onSelect(presets.find(p => p.name === preset.key));
-      }}
-      i18n={i18n}
-      {...otherProps}
-    />
+    <div className="fd-margin-bottom--sm">
+      <Dropdown
+        label={'Presets'}
+        placeholder={t('common.create-form.choose-preset')}
+        compact
+        options={options}
+        selectedKey={''}
+        onSelect={(e, preset) => {
+          e.stopPropagation();
+          onSelect(presets.find(p => p.name === preset.key));
+        }}
+        i18n={i18n}
+        {...otherProps}
+      />
+    </div>
   );
 }

--- a/core-ui/src/shared/ResourceForm/components/ResourceForm.js
+++ b/core-ui/src/shared/ResourceForm/components/ResourceForm.js
@@ -72,6 +72,10 @@ export function ResourceForm({
 
   const [mode, setMode] = React.useState(handleInitialMode);
   const [actionsEditor, setActionsEditor] = React.useState(null);
+
+  // workaround for no refreshing Monaco after choosing preset
+  const [yamlKey, setYamlKey] = React.useState(Math.random(999));
+
   const validationRef = useRef(true);
 
   useEffect(() => {
@@ -96,6 +100,7 @@ export function ResourceForm({
         if (onChange) {
           onChange(new Event('input', { bubbles: true }));
         }
+        setYamlKey(Math.random(999));
       }}
     />
   );
@@ -147,7 +152,7 @@ export function ResourceForm({
           </div>
         )}
         {mode === ModeSelector.MODE_YAML && (
-          <>
+          <React.Fragment key={yamlKey}>
             <EditorActions
               val={convertedResource}
               editor={actionsEditor}
@@ -156,7 +161,7 @@ export function ResourceForm({
               i18n={i18n}
             />
             {editor}
-          </>
+          </React.Fragment>
         )}
         {/* always keep the advanced form to ensure validation */}
         <div

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1719
+          image: eu.gcr.io/kyma-project/busola-web:PR-1725
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It's not so pretty workaround, but it works. I'll add a task to fix Monaco and remove this workaround.
Changes proposed in this pull request:

- added a random key for Monaco to trigger refresh after choosing preset
- ...
- ...

**Related issue(s)**
Closes #1632 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
