### PR TITLE
Fix schema inferring

### DIFF
--- a/core-ui/src/components/App/resourceSchemas/resourceSchemas.worker.js
+++ b/core-ui/src/components/App/resourceSchemas/resourceSchemas.worker.js
@@ -102,24 +102,28 @@ self.onmessage = $event => {
   }
 
   if ($event.data[0] === 'getSchema') {
-    const schemaId = JSON.parse(
-      JSON.stringify(jsonSchemas[activeClusterName][$event.data[1]]),
-    );
-    const existingCustomFormats = getExistingCustomFormats(schemaId);
-    const schemaCustomFormatsResolved = replaceObjects(
-      existingCustomFormats,
-      schemaId,
-    );
-    if (schemaCustomFormatsResolved) {
-      self.postMessage({
-        type: 'schemaComputed',
-        schema: schemaCustomFormatsResolved,
-      });
-    } else {
-      self.postMessage({
-        type: 'customError',
-        error: new Error('Resource schema not found'),
-      });
+    if (jsonSchemas[activeClusterName][$event.data[1]]) {
+      const schemaId = JSON.parse(
+        JSON.stringify(jsonSchemas[activeClusterName][$event.data[1]]),
+      );
+      const existingCustomFormats = getExistingCustomFormats(schemaId);
+      const schemaCustomFormatsResolved = replaceObjects(
+        existingCustomFormats,
+        schemaId,
+      );
+      if (schemaCustomFormatsResolved) {
+        self.postMessage({
+          type: 'schemaComputed',
+          schema: schemaCustomFormatsResolved,
+        });
+        return;
+      }
     }
+
+    // post message if schema was not found
+    self.postMessage({
+      type: 'customError',
+      error: new Error('Resource schema not found'),
+    });
   }
 };

--- a/core-ui/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.js
+++ b/core-ui/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.js
@@ -53,7 +53,6 @@ export function KubeconfigUpload({
         autocompletionDisabled
         language="yaml"
         value={kubeconfig ? jsyaml.dump(kubeconfig) : ''}
-        customSchemaId="cluster"
         onMount={setEditor}
         onChange={updateKubeconfig}
       />

--- a/core-ui/src/components/Functions/FunctionDetails/Tabs/Code/CodeAndDependencies/CodeAndDependencies.js
+++ b/core-ui/src/components/Functions/FunctionDetails/Tabs/Code/CodeAndDependencies/CodeAndDependencies.js
@@ -150,7 +150,6 @@ export default function CodeAndDependencies({ func }) {
       title: t('functions.variable.header.source'),
       body: (
         <Editor
-          id="function-code"
           language={monacoEditorLang}
           originalValue={func.spec.source}
           value={code}
@@ -166,7 +165,6 @@ export default function CodeAndDependencies({ func }) {
       title: t('functions.details.title.dependencies'),
       body: (
         <Editor
-          id="function-dependencies"
           language={monacoEditorDeps}
           originalValue={func.spec.deps}
           value={dependencies}

--- a/core-ui/src/components/Functions/FunctionDetails/Tabs/Code/CodeAndDependencies/Editor.js
+++ b/core-ui/src/components/Functions/FunctionDetails/Tabs/Code/CodeAndDependencies/Editor.js
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import { Editor as MonacoEditor } from 'shared/components/MonacoEditorESM/Editor';
 
 export default function Editor({
-  id,
   language = '',
   controlledValue = '',
   setControlledValue = '',
@@ -24,7 +23,6 @@ export default function Editor({
       language={language}
       value={controlledValue}
       onChange={handleControlledChange}
-      customSchemaId={id}
     />
   );
 }

--- a/core-ui/src/hooks/useGetSchema.js
+++ b/core-ui/src/hooks/useGetSchema.js
@@ -8,7 +8,7 @@ import {
 import { AppContext } from 'components/App/AppContext';
 
 export const useGetSchema = ({ schemaId, skip, resource }) => {
-  if (!schemaId) {
+  if (!schemaId && resource) {
     const { group, version, kind } = resource;
     schemaId = `${group}/${version}/${kind}`;
   }

--- a/core-ui/src/resources/Namespaces/NamespaceCreate.js
+++ b/core-ui/src/resources/Namespaces/NamespaceCreate.js
@@ -161,7 +161,7 @@ export function NamespaceCreate({
           <Editor
             value={limits}
             setValue={setLimits}
-            resourceSchemaId="v1/LimitRange"
+            schemaId="v1/LimitRange"
           />
         </ResourceForm.CollapsibleSection>
       ) : null}
@@ -172,7 +172,7 @@ export function NamespaceCreate({
           <Editor
             value={memory}
             setValue={setMemory}
-            resourceSchemaId="v1/ResourceQuota"
+            schemaId="v1/ResourceQuota"
           />
         </ResourceForm.CollapsibleSection>
       ) : null}

--- a/core-ui/src/resources/Namespaces/NamespaceCreate.js
+++ b/core-ui/src/resources/Namespaces/NamespaceCreate.js
@@ -161,7 +161,7 @@ export function NamespaceCreate({
           <Editor
             value={limits}
             setValue={setLimits}
-            customSchemaId="v1/LimitRange"
+            resourceSchemaId="v1/LimitRange"
           />
         </ResourceForm.CollapsibleSection>
       ) : null}
@@ -172,7 +172,7 @@ export function NamespaceCreate({
           <Editor
             value={memory}
             setValue={setMemory}
-            customSchemaId="v1/ResourceQuota"
+            resourceSchemaId="v1/ResourceQuota"
           />
         </ResourceForm.CollapsibleSection>
       ) : null}
@@ -193,7 +193,6 @@ export function NamespaceCreate({
       initialResource={initialNamespace}
       afterCreatedFn={afterNamespaceCreated}
       setCustomValid={setCustomValid}
-      customSchemaId="v1/Namespace"
       labelsProps={{
         lockedKeys: [ISTIO_INJECTION_LABEL],
         lockedValues: [ISTIO_INJECTION_LABEL],

--- a/core-ui/src/resources/Namespaces/templates.js
+++ b/core-ui/src/resources/Namespaces/templates.js
@@ -1,5 +1,7 @@
 export function createNamespaceTemplate() {
   return {
+    kind: 'Namespace',
+    apiVersion: 'v1',
     metadata: {
       name: '',
       labels: {},

--- a/core-ui/src/shared/ResourceForm/components/ResourceForm.js
+++ b/core-ui/src/shared/ResourceForm/components/ResourceForm.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import classnames from 'classnames';
 import jsyaml from 'js-yaml';
 import { EditorActions } from 'shared/contexts/YamlEditorContext/EditorActions';
@@ -33,15 +33,18 @@ export function ResourceForm({
   className,
   onlyYaml = false,
   toggleFormFn,
-  customSchemaId,
   autocompletionDisabled,
-  customSchemaUri,
   readOnly,
   handleNameChange,
   nameProps,
   labelsProps,
   disableDefaultFields,
 }) {
+  // readonly schema ID, set only once
+  const [resourceSchemaId] = useState(
+    resource.apiVersion + '/' + resource.kind,
+  );
+
   if (!handleNameChange) {
     handleNameChange = name => {
       jp.value(resource, '$.metadata.name', name);
@@ -105,10 +108,9 @@ export function ResourceForm({
       value={resource}
       onChange={setResource}
       onMount={setActionsEditor}
-      customSchemaId={customSchemaId}
-      customSchemaUri={customSchemaUri}
       autocompletionDisabled={autocompletionDisabled}
       readOnly={readOnly}
+      schemaId={resourceSchemaId}
     />
   );
   editor = renderEditor

--- a/core-ui/src/shared/ResourceForm/fields/Editor.js
+++ b/core-ui/src/shared/ResourceForm/fields/Editor.js
@@ -1,7 +1,6 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import jsyaml from 'js-yaml';
-import * as jp from 'jsonpath';
 import { Editor as MonacoEditor } from 'shared/components/MonacoEditorESM/Editor';
 
 export function Editor({
@@ -10,7 +9,7 @@ export function Editor({
   setValue,
   language = 'yaml',
   convert = true,
-  customSchemaId,
+  schemaId,
   ...props
 }) {
   const { t } = useTranslation();
@@ -27,13 +26,6 @@ export function Editor({
       return value;
     }
   }, [value, language, convert]);
-
-  // TODO (task created) schema is lost if user deletes all the resource with the exception of one line, goes to simple and returns to editor
-  const resourceSchemaId = useRef(
-    convert
-      ? `${jp.value(value, `$.apiVersion`)}/${jp.value(value, `$.kind`)}`
-      : '',
-  );
 
   const handleChange = useCallback(
     text => {
@@ -71,7 +63,7 @@ export function Editor({
       value={parsedValue}
       onChange={handleChange}
       error={error}
-      customSchemaId={customSchemaId || resourceSchemaId.current}
+      schemaId={schemaId}
     />
   );
 }

--- a/core-ui/src/shared/components/MonacoEditorESM/Editor.js
+++ b/core-ui/src/shared/components/MonacoEditorESM/Editor.js
@@ -22,7 +22,7 @@ export function Editor({
   language,
   onMount,
   updateValueOnParentChange,
-  customSchemaId, // custom key to find the json schema, don't use if the default key works (apiVersion/kind)
+  schemaId, // key to find the json schema,
   autocompletionDisabled,
   customSchemaUri, // custom link to be displayed in the autocompletion tooltips
   height,
@@ -41,7 +41,7 @@ export function Editor({
     loading,
   } = useAutocompleteWorker({
     value,
-    customSchemaId,
+    schemaId,
     autocompletionDisabled,
     customSchemaUri,
     readOnly,

--- a/core-ui/src/shared/components/MonacoEditorESM/Editor.js
+++ b/core-ui/src/shared/components/MonacoEditorESM/Editor.js
@@ -101,7 +101,7 @@ export function Editor({
             dismissible
           >
             {t('common.create-form.autocomplete-unavailable-error', {
-              error: schemaError,
+              error: schemaError.error || schemaError.message || schemaError,
             })}
           </MessageStrip>
         )}

--- a/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
+++ b/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
@@ -57,11 +57,6 @@ export function useAutocompleteWorker({
   readOnly,
   language,
 }) {
-  // schemaId gets calculated only once, to find the json validation schema by a key
-  // it means each supported resource must have apiVersion and kind initially defined
-  // if it's not possible, pass the additional prop customSchemaId.
-  // if none of the values is provided, the schemaId will be randomized (Monaco uses this
-  // value as a model id and model stores information on editor's value, language etc.)
   const [schemaId] = useState(customSchemaId || getDefaultSchemaId(value));
   const [schemaLink] = useState(getSchemaLink(value, language));
 

--- a/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
+++ b/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
@@ -41,12 +41,13 @@ let activeSchemaPath = null;
 
 export function useAutocompleteWorker({
   value,
-  schemaId,
+  schemaId: predefinedSchemaId,
   autocompletionDisabled,
   customSchemaUri,
   readOnly,
   language,
 }) {
+  const [schemaId] = useState(predefinedSchemaId || Math.random().toString());
   const [schemaLink] = useState(getSchemaLink(value, language));
 
   const { schema, loading, error } = useGetSchema({

--- a/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
+++ b/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
@@ -39,25 +39,14 @@ window.MonacoEnvironment = {
 
 let activeSchemaPath = null;
 
-const getDefaultSchemaId = resource => {
-  const { apiVersion, kind } = resource || {};
-
-  if (apiVersion && kind) {
-    return `${apiVersion}/${kind}`;
-  } else {
-    return `${Math.random()}`;
-  }
-};
-
 export function useAutocompleteWorker({
   value,
-  customSchemaId,
+  schemaId,
   autocompletionDisabled,
   customSchemaUri,
   readOnly,
   language,
 }) {
-  const [schemaId] = useState(customSchemaId || getDefaultSchemaId(value));
   const [schemaLink] = useState(getSchemaLink(value, language));
 
   const { schema, loading, error } = useGetSchema({

--- a/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
+++ b/core-ui/src/shared/components/MonacoEditorESM/autocompletion/useAutocompleteWorker.js
@@ -50,6 +50,13 @@ export function useAutocompleteWorker({
   const [schemaId] = useState(predefinedSchemaId || Math.random().toString());
   const [schemaLink] = useState(getSchemaLink(value, language));
 
+  if (!autocompletionDisabled && !predefinedSchemaId) {
+    console.warn(
+      'useAutocompleteWorker: autocompletion is on, but no `predefinedSchemaId` provided. Disabling autocompletion.',
+    );
+    autocompletionDisabled = true;
+  }
+
   const { schema, loading, error } = useGetSchema({
     schemaId,
     skip: autocompletionDisabled,

--- a/core-ui/src/shared/components/SchemaViewer/SchemaViewer.js
+++ b/core-ui/src/shared/components/SchemaViewer/SchemaViewer.js
@@ -52,7 +52,6 @@ export function SchemaViewer({ name, schema }) {
         )}
         {schemaMode === 'json' && (
           <EditorWrapper
-            customSchemaId={`crd-schema-editor-${name}`}
             language="json"
             height="20em"
             value={schema}
@@ -67,7 +66,6 @@ export function SchemaViewer({ name, schema }) {
         )}
         {schemaMode === 'yaml' && (
           <EditorWrapper
-            customSchemaId={`crd-schema-editor-${name}`}
             language="yaml"
             autocompletionDisabled
             height="20em"

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1721
+          image: eu.gcr.io/kyma-project/busola-web:PR-1737
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- As in connected issue - now we pass the schemaId just once, instead of computing it each time. It will be always valid:
  - On `create` from, it's taken from template, which we define - we it's valid.
  - On `edit` form, it's provided by object which must have been valid already to be created.
- Adjust error handling for schema worker

**Related issue(s)**
Closes #1329 
