### PR TITLE
Proxy: change 503 to 502

### DIFF
--- a/backend/common.js
+++ b/backend/common.js
@@ -105,7 +105,7 @@ export const makeHandleRequest = () => {
 
       // change all 503 into 502
       const statusCode =
-        k8sResponse.statusCode !== 503 ? k8sResponse.statusCode : 502;
+        k8sResponse.statusCode === 503 ? 502 : k8sResponse.statusCode ;
 
       res.writeHead(statusCode, {
         'Content-Type': k8sResponse.headers['Content-Type'] || 'text/json',

--- a/backend/common.js
+++ b/backend/common.js
@@ -105,7 +105,7 @@ export const makeHandleRequest = () => {
 
       // change all 503 into 502
       const statusCode =
-        k8sResponse.statusCode === 503 ? 502 : k8sResponse.statusCode ;
+        k8sResponse.statusCode === 503 ? 502 : k8sResponse.statusCode;
 
       res.writeHead(statusCode, {
         'Content-Type': k8sResponse.headers['Content-Type'] || 'text/json',

--- a/backend/common.js
+++ b/backend/common.js
@@ -103,7 +103,11 @@ export const makeHandleRequest = () => {
           'Response headers are potentially dangerous',
         );
 
-      res.writeHead(k8sResponse.statusCode, {
+      // change all 503 into 502
+      const statusCode =
+        k8sResponse.statusCode !== 503 ? k8sResponse.statusCode : 502;
+
+      res.writeHead(statusCode, {
         'Content-Type': k8sResponse.headers['Content-Type'] || 'text/json',
         'Content-Encoding': k8sResponse.headers['content-encoding'] || '',
       });

--- a/resources/backend/deployment.yaml
+++ b/resources/backend/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: backend
-          image: eu.gcr.io/kyma-project/busola-backend:PR-1744
+          image: eu.gcr.io/kyma-project/busola-backend:PR-1806
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
**Testing**

Use the following code in our App.js - it makes continuous calls that return 503/502:

```
import { useSingleGet } from 'shared/hooks/BackendAPI/useGet';

export default function App() {
const fetch = useSingleGet();

  setInterval(async () => {
    try {
      console.log(
        await fetch(
          '/api/v1/namespaces/kyma-system/services/monitoring-prometheus:web/proxy/api/v1/status/runtimeinfo',
        ),
      );
    } catch (e) {
      console.log(e);
    }
  }, 2000);

  return null;
```

