### PR TITLE
change schema validation library

### DIFF
--- a/core-ui/package-lock.json
+++ b/core-ui/package-lock.json
@@ -29,6 +29,7 @@
         "graphviz-react": "^1.2.0",
         "http-status-codes": "^2.2.0",
         "jsonata": "^1.8.6",
+        "jsonschema": "^1.4.1",
         "lodash-es": "^4.17.21",
         "monaco-editor": "^0.33.0",
         "monaco-yaml": "^4.0.0-alpha.2",
@@ -43,6 +44,7 @@
         "react-tippy": "^1.4.0",
         "recoil": "^0.7.5",
         "rfc6902": "^4.0.1",
+        "url": "^0.11.0",
         "use-debounce": "^7.0.1",
         "yup": "^0.28.5"
       },
@@ -13630,6 +13632,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.0.tgz",
@@ -16381,6 +16391,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -19021,6 +19040,20 @@
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
+    },
+    "node_modules/url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.0",
@@ -30238,6 +30271,11 @@
       "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
+    "jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ=="
+    },
     "jsx-ast-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.0.tgz",
@@ -32156,6 +32194,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -34163,6 +34206,22 @@
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+        }
+      }
     },
     "use-callback-ref": {
       "version": "1.3.0",

--- a/core-ui/package-lock.json
+++ b/core-ui/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@datasert/cronjs-parser": "^1.1.0",
-        "@exodus/schemasafe": "^1.0.0-rc.6",
         "@hookform/resolvers": "^2.8.8",
         "@luigi-project/client": "^1.21.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^3.1.1",
@@ -2360,11 +2359,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
     },
     "node_modules/@hookform/resolvers": {
       "version": "2.8.8",
@@ -21756,11 +21750,6 @@
           "dev": true
         }
       }
-    },
-    "@exodus/schemasafe": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
-      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
     },
     "@hookform/resolvers": {
       "version": "2.8.8",

--- a/core-ui/package.json
+++ b/core-ui/package.json
@@ -24,6 +24,7 @@
     "graphviz-react": "^1.2.0",
     "http-status-codes": "^2.2.0",
     "jsonata": "^1.8.6",
+    "jsonschema": "^1.4.1",
     "lodash-es": "^4.17.21",
     "monaco-editor": "^0.33.0",
     "monaco-yaml": "^4.0.0-alpha.2",
@@ -38,6 +39,7 @@
     "react-tippy": "^1.4.0",
     "recoil": "^0.7.5",
     "rfc6902": "^4.0.1",
+    "url": "^0.11.0",
     "use-debounce": "^7.0.1",
     "yup": "^0.28.5"
   },

--- a/core-ui/package.json
+++ b/core-ui/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@datasert/cronjs-parser": "^1.1.0",
-    "@exodus/schemasafe": "^1.0.0-rc.6",
     "@hookform/resolvers": "^2.8.8",
     "@luigi-project/client": "^1.21.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^3.1.1",

--- a/core-ui/src/shared/hooks/useValidateResourceBySchema/useValidateResourceBySchema.js
+++ b/core-ui/src/shared/hooks/useValidateResourceBySchema/useValidateResourceBySchema.js
@@ -12,6 +12,7 @@ const validateResourceBySchema = async resource => {
 
         if (result.errors.length > 0)
           return [currentRule.messageOnFailure, ...accumulator];
+
         return [...accumulator];
       } catch {
         return [...accumulator];

--- a/core-ui/src/shared/hooks/useValidateResourceBySchema/useValidateResourceBySchema.js
+++ b/core-ui/src/shared/hooks/useValidateResourceBySchema/useValidateResourceBySchema.js
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import { validator } from '@exodus/schemasafe';
+import { Validator } from 'jsonschema';
 
 const validateResourceBySchema = async resource => {
   const schema = await import('./schema.js');
@@ -7,10 +8,11 @@ const validateResourceBySchema = async resource => {
   const warnings = (schema?.schema.rules || []).reduce(
     (accumulator, currentRule) => {
       try {
-        const schemaValidator = validator(currentRule.schema);
-        const result = schemaValidator(resource);
+        const schemaValidator = new Validator();
+        const result = schemaValidator.validate(resource, currentRule.schema);
 
-        if (!result) return [currentRule.messageOnFailure, ...accumulator];
+        if (result.errors.length > 0)
+          return [currentRule.messageOnFailure, ...accumulator];
         return [...accumulator];
       } catch {
         return [...accumulator];

--- a/core-ui/src/shared/hooks/useValidateResourceBySchema/useValidateResourceBySchema.js
+++ b/core-ui/src/shared/hooks/useValidateResourceBySchema/useValidateResourceBySchema.js
@@ -1,5 +1,4 @@
 import { useRef, useState, useEffect } from 'react';
-import { validator } from '@exodus/schemasafe';
 import { Validator } from 'jsonschema';
 
 const validateResourceBySchema = async resource => {

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1928
+          image: eu.gcr.io/kyma-project/busola-web:PR-1936
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Current schema validator doesn't work on production environment becuase it uses `eval` and our security policy blocks it. We should change the validation library.

Changes proposed in this pull request:

- Replace schema validation library
- `url` library was installed because it is required in the library above, according to the [issue](https://github.com/tdegrunt/jsonschema/issues/367)

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
