### PR TITLE
remove deprecated nodejs12 (and nodejs10)

### DIFF
--- a/core-ui/src/components/Functions/config.js
+++ b/core-ui/src/components/Functions/config.js
@@ -47,8 +47,6 @@ const jsCodeAndDeps = {
 };
 
 const defaultCodeAndDeps = {
-  nodejs10: { ...jsCodeAndDeps },
-  nodejs12: { ...jsCodeAndDeps },
   nodejs14: { ...jsCodeAndDeps },
   nodejs16: { ...jsCodeAndDeps },
   python39: {

--- a/core-ui/src/components/Functions/constants.js
+++ b/core-ui/src/components/Functions/constants.js
@@ -15,7 +15,6 @@ export const FUNCTION_PHASES = {
   FAILED: 'FAILED',
 };
 
-export const PRETTY_RUNTIME_NODEJS12_NAME = 'Node.js 12 - Deprecated';
 export const PRETTY_RUNTIME_NODEJS14_NAME = 'Node.js 14';
 export const PRETTY_RUNTIME_NODEJS16_NAME = 'Node.js 16';
 export const PRETTY_RUNTIME_PYTHON39_NAME = 'Python 3.9';

--- a/core-ui/src/components/Functions/helpers/runtime/runtime.js
+++ b/core-ui/src/components/Functions/helpers/runtime/runtime.js
@@ -2,23 +2,19 @@ import { CONFIG } from 'components/Functions/config';
 import { formatMessage } from 'components/Functions/helpers/misc';
 
 import {
-  PRETTY_RUNTIME_NODEJS12_NAME,
   PRETTY_RUNTIME_NODEJS14_NAME,
   PRETTY_RUNTIME_NODEJS16_NAME,
   PRETTY_RUNTIME_PYTHON39_NAME,
 } from '../../constants';
 
-export const nodejs12 = 'nodejs12';
 export const nodejs14 = 'nodejs14';
 export const nodejs16 = 'nodejs16';
-export const nodejs10 = 'nodejs10';
 export const python39 = 'python39';
 
 export const functionAvailableLanguages = {
   // order of those keys is the same as order of available runtimes shown in Create Function Modal
   [nodejs16]: PRETTY_RUNTIME_NODEJS16_NAME,
   [nodejs14]: PRETTY_RUNTIME_NODEJS14_NAME,
-  [nodejs12]: PRETTY_RUNTIME_NODEJS12_NAME,
   [python39]: PRETTY_RUNTIME_PYTHON39_NAME,
 };
 
@@ -34,8 +30,6 @@ export const runtimeToMonacoEditorLang = runtime => {
       };
     case nodejs16:
     case nodejs14:
-    case nodejs12:
-    case nodejs10:
       return {
         language: 'javascript',
         dependencies: 'json',
@@ -54,8 +48,6 @@ export const getDefaultDependencies = (name, runtime) => {
       return CONFIG.defaultFunctionCodeAndDeps.python39.deps;
     case nodejs16:
     case nodejs14:
-    case nodejs12:
-    case nodejs10:
       return !name
         ? ''
         : formatMessage(CONFIG.defaultFunctionCodeAndDeps.nodejs14.deps, {
@@ -68,10 +60,8 @@ export const getDefaultDependencies = (name, runtime) => {
 
 export const checkDepsValidity = (runtime, deps) => {
   switch (runtime) {
-    case nodejs10:
     case nodejs16:
     case nodejs14:
-    case nodejs12:
       return deps.length === 0 || isJson(deps);
     default:
       return true;

--- a/core-ui/src/components/Functions/helpers/runtime/test/runtime.test.js
+++ b/core-ui/src/components/Functions/helpers/runtime/test/runtime.test.js
@@ -10,7 +10,6 @@ describe('prettyRuntime', () => {
     ['python39', 'Python 3.9'],
     ['nodejs16', 'Node.js 16'],
     ['nodejs14', 'Node.js 14'],
-    ['nodejs12', 'Node.js 12 - Deprecated'],
     [undefined, 'Unknown: undefined'],
     [null, 'Unknown: null'],
     ['custom-one', 'Unknown: custom-one'],
@@ -25,7 +24,6 @@ describe('runtimeToMonacoEditorLang', () => {
     ['python39', { language: 'python', dependencies: 'plaintext' }],
     ['nodejs16', { language: 'javascript', dependencies: 'json' }],
     ['nodejs14', { language: 'javascript', dependencies: 'json' }],
-    ['nodejs12', { language: 'javascript', dependencies: 'json' }],
     ['', { language: 'plaintext', dependencies: 'plaintext' }],
     [undefined, { language: 'plaintext', dependencies: 'plaintext' }],
     [null, { language: 'plaintext', dependencies: 'plaintext' }],
@@ -48,15 +46,6 @@ describe('getDefaultDependencies', () => {
 }`,
     ],
     [
-      'other-test-name',
-      'nodejs12',
-      `{ 
-  "name": "other-test-name",
-  "version": "1.0.0",
-  "dependencies": {}
-}`,
-    ],
-    [
       'yet-another-test-name',
       'nodejs16',
       `{ 
@@ -67,9 +56,8 @@ describe('getDefaultDependencies', () => {
     ],
     [null, 'python39', ''],
     [undefined, 'nodejs14', ''],
-    [undefined, 'nodejs12', ''],
     [undefined, 'nodejs16', ''],
-    ['', 'nodejs12', ``],
+    ['', 'nodejs16', ``],
   ])('.getDefaultDependencies(%s, %s)', (name, runtime, expected) => {
     const result = getDefaultDependencies(name, runtime);
     expect(result).toEqual(expected);

--- a/examples/resources/serverless/functions.yaml
+++ b/examples/resources/serverless/functions.yaml
@@ -53,8 +53,7 @@ data:
       - name: header.runtime
         source: >-
           spec.runtime = 'nodejs16' ? 'Node.js 16' : (spec.runtime = 'nodejs14' ?
-          'Node.js 14' : (spec.runtime = 'nodejs12' ? 'Node.js 12 - Deprecated' :
-          (spec.runtime = 'python39' ? 'Python 3.9' : spec.runtime)))
+          'Node.js 14' : (spec.runtime = 'python39' ? 'Python 3.9' : spec.runtime))
     body:
       - widget: Tabs
         children:
@@ -180,7 +179,6 @@ data:
       path: spec.runtime
       placeholder: placeholders.spec.runtime
       enum:
-        - nodejs12
         - nodejs14
         - nodejs16
         - python39
@@ -302,8 +300,7 @@ data:
     - name: header.runtime
       source: >-
         spec.runtime = 'nodejs16' ? 'Node.js 16' : (spec.runtime = 'nodejs14' ?
-        'Node.js 14' : (spec.runtime = 'nodejs12' ? 'Node.js 12 - Deprecated' :
-        (spec.runtime = 'python39' ? 'Python 3.9' : spec.runtime)))
+        'Node.js 14' : (spec.runtime = 'python39' ? 'Python 3.9' : spec.runtime))
     - name: header.sourceType
       source: 'spec.source.gitRepository ? "Git Repository" : "Inline Editor"'
     - name: header.status
@@ -412,7 +409,6 @@ data:
       Status: Status
       Runtime: Runtime
       'Source Type': Source Type
-      spec.runtime.nodejs12: Node.js 12 - Deprecated
       spec.runtime.nodejs14: Node.js 14
       spec.runtime.nodejs16: Node.js 16
       spec.runtime.python39: Python 3.9

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1962
+          image: eu.gcr.io/kyma-project/busola-web:PR-1948
           imagePullPolicy: Always
           resources:
             requests:

--- a/tests/tests/namespace/run-prepare-functions.spec.js
+++ b/tests/tests/namespace/run-prepare-functions.spec.js
@@ -30,7 +30,7 @@ context('Prepare funtions for testing', () => {
       .click();
 
     cy.getIframeBody()
-      .contains('Node.js 12')
+      .contains('Node.js 16')
       .click();
 
     cy.getIframeBody()
@@ -39,7 +39,7 @@ context('Prepare funtions for testing', () => {
       .click();
 
     cy.getIframeBody()
-      .contains('Node.js 12')
+      .contains('Node.js 16')
       .should('be.visible');
   });
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- removed nodejs12 - user should not be able to use nodejs12 from kyma UI

**Related issue(s)**

See also https://github.com/kyma-project/kyma/issues/15771