### PR TITLE
Cleanup build process: remove extensions

### DIFF
--- a/Dockerfile.extensions.local
+++ b/Dockerfile.extensions.local
@@ -1,4 +1,0 @@
-# use the name of an image built on a pipeline
-FROM busola
-
-RUN mv /app/extensions.yaml /app/core/assets/extensions/extensions.yaml

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -25,11 +25,6 @@ RUN cd /app/core && make test && make build-docker
 RUN cd /app/core-ui && make test && make build
 RUN cd /app/backend && npm run build
 
-# build extensions, to be used at 3rd stage, in Dockerfile.extensions.local
-RUN cp -a examples/resources/istio extensions
-RUN npm run prepare-extensions
-RUN npm run pack-extensions
-
 # ---- Serve ----
 FROM alpine:3.15.0
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 IMG_NAME = busola-web
 LOCAL_IMG_NAME = busola
-KYMA_DASHBOARD_IMG_NAME = kyma-dashboard
 IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(IMG_NAME)
 LOCAL_IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(LOCAL_IMG_NAME)
 KYMA_DASHBOARD_IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(KYMA_DASHBOARD_IMG_NAME)
@@ -27,7 +26,7 @@ endif
 
 release: build-image push-image
 
-release-local: build-image-local push-image-local build-image-kyma-dashboard push-image-kyma-dashboard
+release-local: build-image-local push-image-local
 
 build-image:
 	sed -i 's/version: dev/version: ${TAG}/' core/src/assets/version.yaml
@@ -36,9 +35,6 @@ build-image:
 build-image-local:
 	sed -i 's/version: dev/version: ${TAG}/' core/src/assets/version.yaml
 	docker build -t $(LOCAL_IMG_NAME) -f Dockerfile.local .
-
-build-image-kyma-dashboard:
-	docker build -t $(KYMA_DASHBOARD_IMG_NAME) -f Dockerfile.extensions.local .
 
 push-image:
 	docker tag $(IMG_NAME) $(IMG):$(TAG)
@@ -58,17 +54,6 @@ ifeq ($(JOB_TYPE), postsubmit)
 	@echo "Tag image with latest"
 	docker tag $(LOCAL_IMG_NAME) $(LOCAL_IMG):latest
 	docker push $(LOCAL_IMG):latest
-else
-	@echo "Image tagging with latest skipped"
-endif
-
-push-image-kyma-dashboard:
-	docker tag $(KYMA_DASHBOARD_IMG_NAME) $(KYMA_DASHBOARD_IMG):$(TAG)
-	docker push $(KYMA_DASHBOARD_IMG):$(TAG)
-ifeq ($(JOB_TYPE), postsubmit)
-	@echo "Tag image with latest"
-	docker tag $(KYMA_DASHBOARD_IMG_NAME) $(KYMA_DASHBOARD_IMG):latest
-	docker push $(KYMA_DASHBOARD_IMG):latest
 else
 	@echo "Image tagging with latest skipped"
 endif

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-1918
+          image: eu.gcr.io/kyma-project/busola-web:PR-2059
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Don't build `kyma-dashboard` image, as it's built in [kyma-dashboard](https://github.com/kyma-project/kyma-dashboard/) - so remove `Dockerfile.extensions.local`.
- I decided not to remove Gulp & npm scripts entries (e.g. `pack-extensions`), as well as docs (`Embedding an extension in Busola` in `docs/extensibility/README.md`) since some open-source Busola user may use it.