### PR TITLE
Fix maximum call stack size exceeded in helm releases and secrets

### DIFF
--- a/core-ui/src/components/HelmReleases/decodeHelmRelease.js
+++ b/core-ui/src/components/HelmReleases/decodeHelmRelease.js
@@ -8,7 +8,9 @@ export function decodeHelmRelease(encodedRelease) {
     // ungzip
     const charArray = s.split('').map(c => c.charCodeAt(0));
     const data = inflate(new Uint8Array(charArray));
-    const strRelease = String.fromCharCode.apply(null, new Uint16Array(data));
+
+    const decoder = new TextDecoder();
+    const strRelease = decoder.decode(data);
     return JSON.parse(strRelease);
   } catch (e) {
     console.warn(e);

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-2184
+          image: eu.gcr.io/kyma-project/busola-web:PR-2188
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:


- String.fromCharCode.apply returns Maximum call stack size exceeded on bigger objects
- Change it to TextDecoder

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
