### PR TITLE
feat: improve readable timestamp to show remaining time & fix: ResourceGraph

### DIFF
--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-2288
+          image: eu.gcr.io/kyma-project/busola-web:PR-2308
           imagePullPolicy: Always
           resources:
             requests:

--- a/src/resources/ServiceAccounts/index.ts
+++ b/src/resources/ServiceAccounts/index.ts
@@ -17,9 +17,19 @@ export const resourceGraphConfig = (): ResourceRelationConfig => ({
   relations: [
     {
       resource: { kind: 'Secret' },
-      filter: (sa, secret) =>
-        sa.secrets?.find((s: any) => s.name === secret.metadata.name) ||
-        sa.imagePullSecrets?.find((s: any) => s.name === secret.metadata.name),
+      filter: (sa, secret) => {
+        const secretAnnotations = Object.entries(
+          secret.metadata.annotations ?? {},
+        );
+        return (
+          secretAnnotations.find(
+            ([key, value]) =>
+              key === 'kubernetes.io/service-account.name' &&
+              value === sa.metadata.name,
+          ) ||
+          sa.imagePullSecrets?.find((s: any) => s.name === secret.metadata.name)
+        );
+      },
     },
   ],
 });

--- a/src/shared/components/ReadableCreationTimestamp/ReadableCreationTimestamp.tsx
+++ b/src/shared/components/ReadableCreationTimestamp/ReadableCreationTimestamp.tsx
@@ -18,19 +18,40 @@ const rtf = new Intl.RelativeTimeFormat('en', {
   style: 'long', // other values: "short" or "narrow"
 });
 
+function getRemainingTime(timestampAsDate: Date, currentDate: Date): string {
+  const dayDifference = getDayDifference(timestampAsDate, currentDate);
+
+  if (dayDifference > -1) return rtf.format(Math.ceil(dayDifference), 'day');
+
+  const hourDifference = getHourDifference(timestampAsDate, currentDate);
+  if (hourDifference > -1) return rtf.format(Math.ceil(hourDifference), 'hour');
+
+  return rtf.format(
+    Math.ceil(getMinuteDifference(timestampAsDate, currentDate)),
+    'minute',
+  );
+}
+
 export const getReadableTimestamp = (timestamp: string): string => {
   if (!timestamp) return EMPTY_TEXT_PLACEHOLDER;
 
-  const now = new Date();
-  const createdAt = new Date(timestamp);
+  const currentDate = new Date();
+  const timestampAsDate = new Date(timestamp);
 
-  const dayDifference = getDayDifference(createdAt, now);
+  if (timestampAsDate > currentDate)
+    return getRemainingTime(timestampAsDate, currentDate);
+
+  const dayDifference = getDayDifference(timestampAsDate, currentDate);
+
   if (dayDifference < -1) return rtf.format(Math.ceil(dayDifference), 'day');
 
-  const hourDifference = getHourDifference(createdAt, now);
+  const hourDifference = getHourDifference(timestampAsDate, currentDate);
   if (hourDifference < -1) return rtf.format(Math.ceil(hourDifference), 'hour');
 
-  return rtf.format(Math.ceil(getMinuteDifference(createdAt, now)), 'minute');
+  return rtf.format(
+    Math.ceil(getMinuteDifference(timestampAsDate, currentDate)),
+    'minute',
+  );
 };
 
 export const ReadableCreationTimestamp = ({


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes:
- improve readable timestamp to show remaining time
- fix matching ServiceAccounts with its Secrets on ResourceGraph 

How to test?
1. Use the extension from the following [PR](https://github.com/kyma-project/kyma-dashboard/pull/74)
2. Choose `istio-system` namespace
3. Go to the list view of the extension
4. `Expiration time` column should display `in X days` instead of `in X minutes`

**Related issue(s)**
part of https://github.com/kyma-project/busola/issues/1958
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
