### PR TITLE
Add TAG_DEFAULT_TAG build-arg to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # ---- Base Alpine with Node ----
 FROM alpine:3.15.0 AS builder
+ARG TAG_DEFAULT_TAG
+
 RUN apk add --update nodejs npm
 
 WORKDIR /app
@@ -15,9 +17,7 @@ ENV CI true
 
 COPY . /app
 
-RUN make resolve
-RUN make validate
-RUN make pull-licenses
+RUN sed -i "s/version: dev/version: ${TAG_DEFAULT_TAG}/" public/version.yaml && make resolve validate
 
 RUN npm test 2>&1 && npm run build:docker
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,6 +2,8 @@
 
 # ---- Base Alpine with Node ----
 FROM alpine:3.15.0 AS builder
+ARG TAG_DEFAULT_TAG
+
 RUN apk add --update nodejs npm
 
 WORKDIR /app
@@ -17,9 +19,7 @@ ENV CI true
 
 COPY . /app
 
-RUN make resolve
-RUN make validate
-RUN make pull-licenses
+RUN sed -i "s/version: dev/version: ${TAG_DEFAULT_TAG}/" public/version.yaml && make resolve validate
 
 RUN npm test 2>&1 && npm run build:docker
 RUN cd /app/backend && npm run build

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,10 @@ release: build-image push-image
 release-local: build-image-local push-image-local
 
 build-image:
-	sed -i 's/version: dev/version: ${TAG}/' public/version.yaml
-	docker build -t $(IMG_NAME) -f Dockerfile .
+	docker build --build-arg=TAG_DEFAULT_TAG=$(TAG) -t $(IMG_NAME) -f Dockerfile .
 
 build-image-local:
-	sed -i 's/version: dev/version: ${TAG}/' public/version.yaml
-	docker build -t $(LOCAL_IMG_NAME) -f Dockerfile.local .
+	docker build --build-arg=TAG_DEFAULT_TAG=$(TAG) -t $(LOCAL_IMG_NAME) -f Dockerfile.local .
 
 push-image:
 	docker tag $(IMG_NAME) $(IMG):$(TAG)

--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: eu.gcr.io/kyma-project/busola-web:PR-2375
+          image: eu.gcr.io/kyma-project/busola-web:PR-2379
           imagePullPolicy: Always
           resources:
             requests:

--- a/src/sidebar/Footer/useGetBusolaVersion.ts
+++ b/src/sidebar/Footer/useGetBusolaVersion.ts
@@ -16,8 +16,9 @@ function createGithubLink(version: string): string {
     if (version.toString().startsWith('PR-')) {
       return `${BUSOLA_GITHUB_LINKS.PULLS}/${version.slice(3)}`;
     }
-
-    return `${BUSOLA_GITHUB_LINKS.COMMITS}/${version}`;
+    // if the string doesn't match regex, returns full string anyway
+    const commit = version.replace(/v[0-9]-/, '');
+    return `${BUSOLA_GITHUB_LINKS.COMMITS}/${commit}`;
   }
 
   return BUSOLA_GITHUB_LINKS.REPOSITORY;


### PR DESCRIPTION
In order to migrate to image-builder and remove privileged mode from build jobs `sed`'ing needs to be moved into the Dockerfile with usage of `--build-arg`.

Additionally update getGithubLink logic to parse new tag format. This should be safe and always return at least a 1 object array.

https://github.com/kyma-project/test-infra/issues/5891