### PR TITLE
Fix typo in en.yaml

### DIFF
--- a/public/i18n/en.yaml
+++ b/public/i18n/en.yaml
@@ -1015,7 +1015,7 @@ pods:
     volumes: Volumes
   message:
     failed-to-download: Failed to download the logs
-    no-logs-available: No logs avaliable for the '{{containerName}}' container
+    no-logs-available: No logs available for the '{{containerName}}' container
     type-not-found: '{{type}} not found'
   name_singular: Pod
   node: Node


### PR DESCRIPTION
I noticed a small typo: **avaliable** <> **available**
