### PR TITLE
Change widgets in NamespaceOverview

### DIFF
--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: europe-docker.pkg.dev/kyma-project/dev/busola-web:PR-2719
+          image: europe-docker.pkg.dev/kyma-project/dev/busola-web:PR-2737
           imagePullPolicy: Always
           resources:
             requests:

--- a/src/components/Clusters/views/ClusterOverview/ClusterStats.js
+++ b/src/components/Clusters/views/ClusterOverview/ClusterStats.js
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { UI5RadialChart } from 'shared/components/UI5RadialChart/UI5RadialChart';
 import { Card, CardHeader, Title } from '@ui5/webcomponents-react';
 import { CountingCard } from 'shared/components/CountingCard/CountingCard';
-import { CardWithTooltip } from 'shared/components/CardWithTooltip/CardWithTooltip';
 import { ProgressIndicatorWithPercentage } from 'shared/components/ProgressIndicatorWithPercentage/ProgressIndicatorWithPercentage';
 import { useGetList } from 'shared/hooks/BackendAPI/useGet';
 import {
@@ -96,48 +95,52 @@ export default function ClusterStats({ data }) {
           />
         </Card>
         {(podsData || deploymentsData) && (
-          <CardWithTooltip
-            title={t('cluster-overview.statistics.namespaces-health')}
-            tooltip={{
-              content: t('cluster-overview.tooltips.namespaces-health-info'),
-              position: 'bottom',
-            }}
-            icon={'sys-help'}
+          <Card
+            header={
+              <CardHeader
+                titleText={t('cluster-overview.statistics.namespaces-health')}
+              />
+            }
           >
-            {podsData && (
-              <ProgressIndicatorWithPercentage
-                title={t('cluster-overview.statistics.healthy-pods')}
-                value={calculatePercents(healthyPods, podsData?.length)}
-                dataBarColor={'var(--sapIndicationColor_8)'}
-                remainingBarColor={'var(--sapIndicationColor_8b)'}
-                tooltip={{
-                  content: t('cluster-overview.tooltips.healthy-pods', {
-                    value: healthyPods,
-                    max: podsData?.length,
-                  }),
-                  position: 'bottom',
-                }}
-              />
-            )}
-            {deploymentsData && (
-              <ProgressIndicatorWithPercentage
-                title={t('cluster-overview.statistics.healthy-deployments')}
-                value={calculatePercents(
-                  healthyDeployments,
-                  deploymentsData?.length,
-                )}
-                dataBarColor={'var(--sapIndicationColor_6)'}
-                remainingBarColor={'var(--sapIndicationColor_6b)'}
-                tooltip={{
-                  content: t('cluster-overview.tooltips.healthy-deployments', {
-                    value: healthyDeployments,
-                    max: deploymentsData?.length,
-                  }),
-                  position: 'bottom',
-                }}
-              />
-            )}
-          </CardWithTooltip>
+            <div style={spacing.sapUiSmallMargin}>
+              {podsData && (
+                <ProgressIndicatorWithPercentage
+                  title={t('cluster-overview.statistics.healthy-pods')}
+                  value={calculatePercents(healthyPods, podsData?.length)}
+                  dataBarColor={'var(--sapIndicationColor_8)'}
+                  remainingBarColor={'var(--sapIndicationColor_8b)'}
+                  tooltip={{
+                    content: t('cluster-overview.tooltips.healthy-pods', {
+                      value: healthyPods,
+                      max: podsData?.length,
+                    }),
+                    position: 'bottom',
+                  }}
+                />
+              )}
+              {deploymentsData && (
+                <ProgressIndicatorWithPercentage
+                  title={t('cluster-overview.statistics.healthy-deployments')}
+                  value={calculatePercents(
+                    healthyDeployments,
+                    deploymentsData?.length,
+                  )}
+                  dataBarColor={'var(--sapIndicationColor_6)'}
+                  remainingBarColor={'var(--sapIndicationColor_6b)'}
+                  tooltip={{
+                    content: t(
+                      'cluster-overview.tooltips.healthy-deployments',
+                      {
+                        value: healthyDeployments,
+                        max: deploymentsData?.length,
+                      },
+                    ),
+                    position: 'bottom',
+                  }}
+                />
+              )}
+            </div>
+          </Card>
         )}
       </div>
       <div

--- a/src/resources/Namespaces/AllNamespacesDetails.js
+++ b/src/resources/Namespaces/AllNamespacesDetails.js
@@ -29,9 +29,12 @@ export function AllNamespacesDetails(props) {
         title={t('navigation.all-namespaces')}
         breadcrumbItems={breadcrumbItems}
         content={
-          <div className="panel-grid" style={spacing.sapUiMediumMargin}>
-            <NamespaceWorkloads />
+          <div
+            className="all-namespaces-details panel-grid"
+            style={{ ...spacing.sapUiMediumMargin }}
+          >
             <ResourcesUsage />
+            <NamespaceWorkloads />
           </div>
         }
       />

--- a/src/resources/Namespaces/NamespaceDetails.js
+++ b/src/resources/Namespaces/NamespaceDetails.js
@@ -87,9 +87,12 @@ export function NamespaceDetails(props) {
       customColumns={customColumns}
       headerActions={headerActions}
     >
-      <div className="panel-grid" style={spacing.sapUiSmallMargin}>
-        <NamespaceWorkloads namespace={props.resourceName} />
+      <div
+        className="namespace-details panel-grid"
+        style={spacing.sapUiSmallMargin}
+      >
         <ResourcesUsage namespace={props.resourceName} />
+        <NamespaceWorkloads namespace={props.resourceName} />
       </div>
       {LimitrangesList}
       {ResourceQuotasList}

--- a/src/resources/Namespaces/NamespaceDetails.scss
+++ b/src/resources/Namespaces/NamespaceDetails.scss
@@ -1,32 +1,18 @@
-.namespace-workloads__body {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-}
-
-.resources-usage__body {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-}
-
 .namespace-details,
 .all-namespaces-details {
   &.panel-grid {
-    grid-template-columns: 2fr 1fr;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: 20px;
   }
 }
 
-@media (max-width: 500px) {
-  .namespace-workloads__body {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-  }
-
-  .resources-usage__body {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
+@media (min-width: 950px) {
+  .namespace-details,
+  .all-namespaces-details {
+    &.panel-grid {
+      display: flex;
+      flex-direction: row;
+    }
   }
 }

--- a/src/resources/Namespaces/NamespaceDetails.scss
+++ b/src/resources/Namespaces/NamespaceDetails.scss
@@ -6,6 +6,15 @@
 .resources-usage__body {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.namespace-details,
+.all-namespaces-details {
+  &.panel-grid {
+    grid-template-columns: 2fr 1fr;
+    gap: 20px;
+  }
 }
 
 @media (max-width: 500px) {

--- a/src/resources/Namespaces/NamespaceWorkloads/NamespaceWorkloads.js
+++ b/src/resources/Namespaces/NamespaceWorkloads/NamespaceWorkloads.js
@@ -48,6 +48,7 @@ export function NamespaceWorkloads({ namespace }) {
               titleText={t('cluster-overview.statistics.namespaces-health')}
             />
           }
+          className="namespace-workloads__body"
         >
           <div style={spacing.sapUiSmallMargin}>
             {podsData && (

--- a/src/resources/Namespaces/NamespaceWorkloads/NamespaceWorkloads.js
+++ b/src/resources/Namespaces/NamespaceWorkloads/NamespaceWorkloads.js
@@ -1,136 +1,36 @@
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-import { UI5RadialChart } from 'shared/components/UI5RadialChart/UI5RadialChart';
 import { useGetList } from 'shared/hooks/BackendAPI/useGet';
-import { Spinner } from 'shared/components/Spinner/Spinner';
-import { useUrl } from 'hooks/useUrl';
 
 import {
   getHealthyStatusesCount,
   getHealthyReplicasCount,
 } from './NamespaceWorkloadsHelpers';
-import { Icon } from '@ui5/webcomponents-react';
-import { UI5Panel } from 'shared/components/UI5Panel/UI5Panel';
-import { CardWithTooltip } from 'shared/components/CardWithTooltip/CardWithTooltip';
 import { ProgressIndicatorWithPercentage } from 'shared/components/ProgressIndicatorWithPercentage/ProgressIndicatorWithPercentage';
+import { Card, CardHeader } from '@ui5/webcomponents-react';
 import { spacing } from '@ui5/webcomponents-react-base';
 
 NamespaceWorkloads.propTypes = { namespace: PropTypes.string.isRequired };
 
-const ResourceCircle = ({
-  data,
-  counter,
-  loading,
-  error,
-  resourceType,
-  color,
-  onClick,
-}) => {
+export function NamespaceWorkloads({ namespace }) {
   const { t } = useTranslation();
 
-  const tooltipContent = (value, total, resourceType) => {
-    if (total === 0) {
-      return t('namespaces.tooltips.no-resources', {
-        resourceType: resourceType,
-      });
-    } else {
-      return t('namespaces.tooltips.healthy-resources', {
-        value: value,
-        total: total,
-        resourceType: resourceType,
-      });
-    }
-  };
-
-  if (error) {
-    return (
-      <p>
-        {t('namespaces.overview.workloads.error', {
-          title: resourceType,
-          message: error.message,
-        })}
-      </p>
-    );
-  } else if (loading || !data) {
-    return <Spinner />;
-  }
-
-  return (
-    <UI5RadialChart
-      onClick={onClick}
-      color={color}
-      value={counter(data)}
-      max={data.length}
-      title={resourceType}
-      tooltip={{
-        content: tooltipContent(counter(data), data.length, resourceType),
-        position: 'bottom',
-      }}
-    />
-  );
-};
-
-const PodsCircle = ({ namespace }) => {
-  const { t } = useTranslation();
-  const { namespaceUrl } = useUrl();
-  const navigate = useNavigate();
-
-  const { data, error, loading = true } = useGetList()(
-    namespace ? `/api/v1/namespaces/${namespace}/pods` : '/api/v1/pods',
-    {
-      pollingInterval: 3100,
-    },
-  );
-  return (
-    <ResourceCircle
-      onClick={() => navigate(namespaceUrl('pods'))}
-      data={data}
-      counter={getHealthyStatusesCount}
-      loading={loading}
-      error={error}
-      resourceType={t('namespaces.overview.workloads.pods')}
-      color="var(--sapIndicationColor_5)"
-    />
-  );
-};
-
-const DeploymentsCircle = ({ namespace }) => {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-  const { namespaceUrl } = useUrl();
-  const { data, error, loading = true } = useGetList()(
-    namespace
-      ? `/apis/apps/v1/namespaces/${namespace}/deployments`
-      : '/apis/apps/v1/deployments',
+  const { data: podsData } = useGetList()(
+    namespace ? `/api/v1/namespaces/${namespace}/pods` : `/api/v1/pods`,
     {
       pollingInterval: 3200,
     },
   );
-  return (
-    <ResourceCircle
-      onClick={() => navigate(namespaceUrl('deployments'))}
-      data={data}
-      counter={getHealthyReplicasCount}
-      loading={loading}
-      error={error}
-      resourceType={t('namespaces.overview.workloads.deployments')}
-      color="var(--sapIndicationColor_6)"
-    />
+
+  const { data: deploymentsData } = useGetList()(
+    namespace
+      ? `/apis/apps/v1/namespaces/${namespace}/deployments`
+      : `/apis/apps/v1/deployments`,
+    {
+      pollingInterval: 3200,
+    },
   );
-};
-
-export function NamespaceWorkloads({ namespace }) {
-  const { t } = useTranslation();
-
-  const { data: podsData } = useGetList()(`/api/v1/pods`, {
-    pollingInterval: 3200,
-  });
-
-  const { data: deploymentsData } = useGetList()('/apis/apps/v1/deployments', {
-    pollingInterval: 3200,
-  });
 
   const healthyPods = getHealthyStatusesCount(podsData);
   const healthyDeployments = getHealthyReplicasCount(deploymentsData);
@@ -140,60 +40,52 @@ export function NamespaceWorkloads({ namespace }) {
   };
 
   return (
-    <UI5Panel
-      disableMargin
-      icon={
-        <Icon
-          className="bsl-icon-m"
-          name="stethoscope"
-          aria-label="Health icon"
-        />
-      }
-      title={t('namespaces.overview.workloads.title')}
-    >
-      <div
-        className="namespaceWorkloads_content"
-        style={{
-          ...spacing.sapUiTinyMarginTop,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '5px',
-        }}
-      >
-        {podsData && (
-          <ProgressIndicatorWithPercentage
-            title={t('cluster-overview.statistics.healthy-pods')}
-            value={calculatePercents(healthyPods, podsData?.length)}
-            dataBarColor={'var(--sapIndicationColor_8)'}
-            remainingBarColor={'var(--sapIndicationColor_8b)'}
-            tooltip={{
-              content: t('cluster-overview.tooltips.healthy-pods', {
-                value: healthyPods,
-                max: podsData?.length,
-              }),
-              position: 'bottom',
-            }}
-          />
-        )}
-        {deploymentsData && (
-          <ProgressIndicatorWithPercentage
-            title={t('cluster-overview.statistics.healthy-deployments')}
-            value={calculatePercents(
-              healthyDeployments,
-              deploymentsData?.length,
+    <>
+      {(podsData || deploymentsData) && (
+        <Card
+          header={
+            <CardHeader
+              titleText={t('cluster-overview.statistics.namespaces-health')}
+            />
+          }
+        >
+          <div style={spacing.sapUiSmallMargin}>
+            {podsData && (
+              <ProgressIndicatorWithPercentage
+                title={t('cluster-overview.statistics.healthy-pods')}
+                value={calculatePercents(healthyPods, podsData?.length)}
+                dataBarColor={'var(--sapIndicationColor_8)'}
+                remainingBarColor={'var(--sapIndicationColor_8b)'}
+                tooltip={{
+                  content: t('cluster-overview.tooltips.healthy-pods', {
+                    value: healthyPods,
+                    max: podsData?.length,
+                  }),
+                  position: 'bottom',
+                }}
+              />
             )}
-            dataBarColor={'var(--sapIndicationColor_6)'}
-            remainingBarColor={'var(--sapIndicationColor_6b)'}
-            tooltip={{
-              content: t('cluster-overview.tooltips.healthy-deployments', {
-                value: healthyDeployments,
-                max: deploymentsData?.length,
-              }),
-              position: 'bottom',
-            }}
-          />
-        )}
-      </div>
-    </UI5Panel>
+            {deploymentsData && (
+              <ProgressIndicatorWithPercentage
+                title={t('cluster-overview.statistics.healthy-deployments')}
+                value={calculatePercents(
+                  healthyDeployments,
+                  deploymentsData?.length,
+                )}
+                dataBarColor={'var(--sapIndicationColor_6)'}
+                remainingBarColor={'var(--sapIndicationColor_6b)'}
+                tooltip={{
+                  content: t('cluster-overview.tooltips.healthy-deployments', {
+                    value: healthyDeployments,
+                    max: deploymentsData?.length,
+                  }),
+                  position: 'bottom',
+                }}
+              />
+            )}
+          </div>
+        </Card>
+      )}
+    </>
   );
 }

--- a/src/resources/Namespaces/ResourcesUsage.js
+++ b/src/resources/Namespaces/ResourcesUsage.js
@@ -140,30 +140,26 @@ export const ResourcesUsage = ({ namespace }) => {
 
   return (
     <>
-      <div className="resources-usage__body">
-        <Card
-          header={
-            <CardHeader
-              titleText={t('namespaces.overview.resources.requests')}
-            />
-          }
-        >
-          <MemoryRequestsCircle
-            resourceQuotas={resourceQuotas}
-            isLoading={loading}
-          />
-        </Card>
-        <Card
-          header={
-            <CardHeader titleText={t('namespaces.overview.resources.limits')} />
-          }
-        >
-          <MemoryLimitsCircle
-            resourceQuotas={resourceQuotas}
-            isLoading={loading}
-          />
-        </Card>
-      </div>
+      <Card
+        header={
+          <CardHeader titleText={t('namespaces.overview.resources.requests')} />
+        }
+      >
+        <MemoryRequestsCircle
+          resourceQuotas={resourceQuotas}
+          isLoading={loading}
+        />
+      </Card>
+      <Card
+        header={
+          <CardHeader titleText={t('namespaces.overview.resources.limits')} />
+        }
+      >
+        <MemoryLimitsCircle
+          resourceQuotas={resourceQuotas}
+          isLoading={loading}
+        />
+      </Card>
     </>
   );
 };

--- a/src/resources/Namespaces/ResourcesUsage.js
+++ b/src/resources/Namespaces/ResourcesUsage.js
@@ -4,8 +4,7 @@ import { Spinner } from 'shared/components/Spinner/Spinner';
 import { useTranslation } from 'react-i18next';
 
 import { getSIPrefix } from 'shared/helpers/siPrefixes';
-import { Icon } from '@ui5/webcomponents-react';
-import { UI5Panel } from 'shared/components/UI5Panel/UI5Panel';
+import { Card, CardHeader } from '@ui5/webcomponents-react';
 
 const MEMORY_SUFFIX_POWER = {
   // must be sorted from the smallest to the largest; it is case sensitive; more info: https://medium.com/swlh/understanding-kubernetes-resource-cpu-and-memory-units-30284b3cc866
@@ -77,10 +76,9 @@ const MemoryRequestsCircle = ({ resourceQuotas, isLoading }) => {
 
   return (
     <UI5RadialChart
-      color="var(--sapIndicationColor_7)"
+      color="var(--sapChart_Bad)"
       value={totalUsage}
       max={totalRequests}
-      title={t('namespaces.overview.resources.requests')}
       tooltip={{
         content: t('namespaces.tooltips.usage-of-memory-requests', {
           valueText: valueText,
@@ -115,10 +113,9 @@ const MemoryLimitsCircle = ({ resourceQuotas, isLoading }) => {
 
   return (
     <UI5RadialChart
-      color="var(--sapIndicationColor_8)"
+      color="var(--sapChart_Good)"
       value={totalUsage}
       max={totalLimits}
-      title={t('namespaces.overview.resources.limits')}
       tooltip={{
         content: t('namespaces.tooltips.usage-of-memory-limits', {
           valueText: valueText,
@@ -142,27 +139,31 @@ export const ResourcesUsage = ({ namespace }) => {
   );
 
   return (
-    <UI5Panel
-      disableMargin
-      icon={
-        <Icon
-          className="bsl-icon-m"
-          name="it-host"
-          aria-label="Resource icon"
-        />
-      }
-      title={t('namespaces.overview.resources.title')}
-    >
+    <>
       <div className="resources-usage__body">
-        <MemoryRequestsCircle
-          resourceQuotas={resourceQuotas}
-          isLoading={loading}
-        />
-        <MemoryLimitsCircle
-          resourceQuotas={resourceQuotas}
-          isLoading={loading}
-        />
+        <Card
+          header={
+            <CardHeader
+              titleText={t('namespaces.overview.resources.requests')}
+            />
+          }
+        >
+          <MemoryRequestsCircle
+            resourceQuotas={resourceQuotas}
+            isLoading={loading}
+          />
+        </Card>
+        <Card
+          header={
+            <CardHeader titleText={t('namespaces.overview.resources.limits')} />
+          }
+        >
+          <MemoryLimitsCircle
+            resourceQuotas={resourceQuotas}
+            isLoading={loading}
+          />
+        </Card>
       </div>
-    </UI5Panel>
+    </>
   );
 };

--- a/src/shared/components/ProgressIndicatorWithPercentage/ProgressIndicatorWithPercentage.js
+++ b/src/shared/components/ProgressIndicatorWithPercentage/ProgressIndicatorWithPercentage.js
@@ -31,7 +31,9 @@ export const ProgressIndicatorWithPercentage = ({
   return (
     <TooltipWrapper tooltipProps={tooltip}>
       <div className="progress-indicator-percentage">
-        <p className="progress-indicator-percentage__percents">{value}%</p>
+        <p className="progress-indicator-percentage__percents">
+          {!isNaN(value) ? value : 0}%
+        </p>
         <ProgressIndicator
           displayValue={title}
           value={value}

--- a/tests/integration/tests/namespace/test-namespace-overview.spec.js
+++ b/tests/integration/tests/namespace/test-namespace-overview.spec.js
@@ -21,9 +21,11 @@ context(
 
       cy.contains('b', QUOTA_NAME).should('be.visible');
 
-      cy.contains('Healthy Resources').should('be.visible');
+      cy.contains('Namespaces Health').should('be.visible');
 
-      cy.contains('Resource Consumption').should('be.visible');
+      cy.contains('Memory Requests').should('be.visible');
+
+      cy.contains('Memory Limits').should('be.visible');
 
       cy.contains('Events').should('be.visible');
     });


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- changed widgets look in NamespaceOverview
- removed tooltips for Pods and Deployments card

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
