### PR TITLE
fix: create button on all namespaces list view

### DIFF
--- a/resources/web/deployment.yaml
+++ b/resources/web/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: busola
-          image: europe-docker.pkg.dev/kyma-project/dev/busola-web:PR-2760
+          image: europe-docker.pkg.dev/kyma-project/dev/busola-web:PR-2768
           imagePullPolicy: Always
           resources:
             requests:

--- a/src/resources/HorizontalPodAutoscalers/HPASubcomponent.js
+++ b/src/resources/HorizontalPodAutoscalers/HPASubcomponent.js
@@ -52,7 +52,7 @@ export const HPASubcomponent = props => {
       hasDetailsView
       resourceUrl={url}
       title={t('horizontal-pod-autoscalers')}
-      resourceType={'horizontalpodautoscalers'}
+      resourceType={'horizontalPodAutoscalers'}
       namespace={namespace}
       isCompact
       showTitle

--- a/src/shared/components/EmptyListComponent/EmptyListComponent.tsx
+++ b/src/shared/components/EmptyListComponent/EmptyListComponent.tsx
@@ -19,7 +19,7 @@ type EmptyListComponentProps = {
 export const EmptyListComponent = ({
   titleText,
   subtitleText,
-  showButton = true,
+  showButton,
   buttonText,
   url,
   onClick,
@@ -27,6 +27,10 @@ export const EmptyListComponent = ({
 }: EmptyListComponentProps) => {
   const { t } = useTranslation();
   const subtitle = <Trans i18nKey={subtitleText}></Trans>;
+
+  if (showButton === undefined) {
+    showButton = typeof onClick === 'function';
+  }
 
   if (!buttonText) {
     buttonText = t('common.buttons.create');

--- a/src/shared/components/ResourcesList/ResourcesList.js
+++ b/src/shared/components/ResourcesList/ResourcesList.js
@@ -655,6 +655,7 @@ export function ResourceListRenderer({
               setActiveResource(undefined);
               toggleFormFn(true);
             },
+            showButton: namespace !== '-all-',
           }}
         />
       )}

--- a/src/shared/components/ResourcesList/ResourcesList.js
+++ b/src/shared/components/ResourcesList/ResourcesList.js
@@ -647,7 +647,6 @@ export function ResourceListRenderer({
             textSearchProperties: textSearchProperties(),
           }}
           emptyListProps={{
-            ...emptyListProps,
             titleText: `${t('common.labels.no')} ${processTitle(
               prettifyNamePlural(resourceTitle, resourceType),
             )}`,
@@ -655,7 +654,8 @@ export function ResourceListRenderer({
               setActiveResource(undefined);
               toggleFormFn(true);
             },
-            showButton: namespace !== '-all-',
+            showButton: !disableCreate && namespace !== '-all-',
+            ...emptyListProps,
           }}
         />
       )}

--- a/tests/integration/tests/cluster/test-cluster-validation.spec.js
+++ b/tests/integration/tests/cluster/test-cluster-validation.spec.js
@@ -65,14 +65,14 @@ context('Test Cluster Validation Scan', () => {
 
     cy.get('@clusterValidationPanel').scrollIntoView();
 
-    cy.get('@clusterValidationPanel').should('be.visible');
+    cy.get('@clusterValidationPanel').should('exist');
 
     cy.contains('Scan Progress').should('not.exist');
     cy.contains('Scan Result').should('not.exist');
 
     cy.get('@clusterValidationPanel')
       .contains('Configure')
-      .click();
+      .click({ force: true });
 
     testAndSelectOptions('Namespaces', 'default');
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fixed displaying Create button on all namespaces list view
- fixed Horizontal Pod Autoscalers header

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
