### PR TITLE
fix: Display correct value for resource quota when spec is not in `requests`

### DIFF
--- a/src/resources/Namespaces/ResourcesUsage.js
+++ b/src/resources/Namespaces/ResourcesUsage.js
@@ -66,7 +66,7 @@ const MemoryRequestsCircle = ({ resourceQuotas, isLoading }) => {
     (sum, quota) =>
       sum +
       getBytes(
-        quota.status?.used?.['requests.memory'] || quota.status?.used?.cpu,
+        quota.status?.used?.['requests.memory'] || quota.status?.used?.memory,
       ),
     0,
   );

--- a/src/resources/Namespaces/ResourcesUsage.js
+++ b/src/resources/Namespaces/ResourcesUsage.js
@@ -58,7 +58,7 @@ const MemoryRequestsCircle = ({ resourceQuotas, isLoading }) => {
     (sum, quota) =>
       sum +
       getBytes(
-        quota.status?.hard?.['requests.memory'] || quota.status?.hard?.cpu,
+        quota.status?.hard?.['requests.memory'] || quota.status?.hard?.memory,
       ),
     0,
   );
@@ -94,11 +94,11 @@ const MemoryLimitsCircle = ({ resourceQuotas, isLoading }) => {
   }
 
   const totalLimits = resourceQuotas.reduce(
-    (sum, quota) => sum + getBytes(quota.status?.hard?.['limits.memory']), //should we sum it or take the max number?
+    (sum, quota) => sum + getBytes(quota.status?.hard?.['limits.memory']),
     0,
   );
   const totalUsage = resourceQuotas.reduce(
-    (sum, quota) => sum + getBytes(quota.status?.used?.['limits.memory']), //should we sum it or take the max number?
+    (sum, quota) => sum + getBytes(quota.status?.used?.['limits.memory']),
     0,
   );
 

--- a/src/resources/ResourceQuotas/ResourceQuotaList.js
+++ b/src/resources/ResourceQuotas/ResourceQuotaList.js
@@ -11,29 +11,28 @@ export function ResourceQuotaList(props) {
     {
       header: t('resource-quotas.headers.limits.cpu'),
       value: quota =>
-        (quota.spec?.hard && quota.spec?.hard['limits.cpu']) ||
-        EMPTY_TEXT_PLACEHOLDER,
+        quota.spec?.hard?.['limits.cpu'] || EMPTY_TEXT_PLACEHOLDER,
     },
     {
       header: t('resource-quotas.headers.limits.memory'),
       value: quota =>
-        (quota.spec?.hard && quota.spec?.hard['limits.memory']) ||
-        EMPTY_TEXT_PLACEHOLDER,
+        quota.spec?.hard?.['limits.memory'] || EMPTY_TEXT_PLACEHOLDER,
     },
     {
       header: t('resource-quotas.headers.requests.cpu'),
       value: quota =>
-        (quota.spec?.hard && quota.spec?.hard['requests.cpu']) ||
+        quota.spec?.hard?.['requests.cpu'] ||
+        quota.spec?.hard?.cpu ||
         EMPTY_TEXT_PLACEHOLDER,
     },
     {
       header: t('resource-quotas.headers.requests.memory'),
       value: quota =>
-        (quota.spec?.hard && quota.spec?.hard['requests.memory']) ||
+        quota.spec?.hard?.['requests.memory'] ||
+        quota.spec?.hard?.memory ||
         EMPTY_TEXT_PLACEHOLDER,
     },
   ];
-
   return (
     <ResourcesList
       disableHiding={true}
@@ -46,4 +45,5 @@ export function ResourceQuotaList(props) {
     />
   );
 }
+
 export default ResourceQuotaList;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- According to the docs: https://kubernetes.io/docs/concepts/policy/resource-quotas/#compute-resource-quota, the request.cpu and request.memory can be also put just in cpu and memory. Cover this scenario

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
