### PR TITLE
fix: incorrect permissions for restricted users

### DIFF
--- a/src/components/Clusters/views/ClusterOverview/ClusterValidation/Scan.ts
+++ b/src/components/Clusters/views/ClusterOverview/ClusterValidation/Scan.ts
@@ -208,7 +208,7 @@ export class Scan {
         ['list'],
         {
           resourceGroupAndVersion: '',
-          resourceKind: resource.kind.toLowerCase(),
+          resourceKind: resource.kind,
         },
         scope.permissionSets,
       );

--- a/src/components/Extensibility/helpers/jsonataWrapper.ts
+++ b/src/components/Extensibility/helpers/jsonataWrapper.ts
@@ -43,7 +43,7 @@ export function jsonataWrapper(expression: string) {
 
     const isPermitted = doesUserHavePermission(
       ['list'],
-      { resourceGroupAndVersion, resourceKind: resourceKind.toLowerCase() },
+      { resourceGroupAndVersion, resourceKind: resourceKind },
       permissionSet,
     );
 

--- a/src/state/navigation/extensionsAtom.ts
+++ b/src/state/navigation/extensionsAtom.ts
@@ -92,16 +92,17 @@ async function getConfigMapsWithSelector(
   const namespacedCMUrl = `/api/v1/namespaces/${currentNamespace ??
     kubeconfigNamespace}/configmaps?labelSelector=${selector}`;
 
+  const hasAccessToClusterCMList = doesUserHavePermission(
+    ['list'],
+    { resourceGroupAndVersion: '', resourceKind: 'ConfigMap' },
+    permissionSet,
+  );
+  console.log(hasAccessToClusterCMList);
+
+  // if user has no access to clusterwide namespace listing, fall back to namespaced listing
+  const url = hasAccessToClusterCMList ? clusterCMUrl : namespacedCMUrl;
+
   if (!currentNamespace) {
-    const hasAccessToClusterCMList = doesUserHavePermission(
-      ['list'],
-      { resourceGroupAndVersion: '', resourceKind: 'ConfigMap' },
-      permissionSet,
-    );
-
-    // user has no access to clusterwide namespace listing, fall back to namespaced listing
-    const url = hasAccessToClusterCMList ? clusterCMUrl : namespacedCMUrl;
-
     try {
       const response = await fetchFn({ relativeUrl: url });
       const configMapResponse: ConfigMapListResponse = await response.json();
@@ -111,14 +112,6 @@ async function getConfigMapsWithSelector(
       return [];
     }
   } else {
-    const hasAccessToClusterCMList = doesUserHavePermission(
-      ['list'],
-      { resourceGroupAndVersion: '', resourceKind: 'ConfigMap' },
-      permissionSet,
-    );
-
-    const url = hasAccessToClusterCMList ? clusterCMUrl : namespacedCMUrl;
-
     try {
       const response = await fetchFn({ relativeUrl: url });
       const configMapResponse: ConfigMapListResponse = await response.json();

--- a/src/state/navigation/filters/permissions.ts
+++ b/src/state/navigation/filters/permissions.ts
@@ -28,7 +28,7 @@ export const doesUserHavePermission = (
 ) => {
   const { resourceGroupAndVersion, resourceKind } = resource;
 
-  const resourceKindPlural = pluralize(resourceKind);
+  const resourceKindPlural = pluralize(resourceKind).toLocaleLowerCase();
   const resourceGroup = getResourceGroup(resourceGroupAndVersion);
 
   const isPermitted = permissionSet.find(set => {

--- a/src/state/permissionSetsSelector.ts
+++ b/src/state/permissionSetsSelector.ts
@@ -37,8 +37,9 @@ export function hasAnyRoleBound(permissionSet: PermissionSetState) {
 export async function getPermissionResourceRules(
   postFn: PostFn,
   namespaceId?: string,
+  clusterWide?: boolean,
 ) {
-  const namespaceName = namespaceId ? namespaceId : '*';
+  const namespaceName = clusterWide || !namespaceId ? '*' : namespaceId;
   const path = '/apis/authorization.k8s.io/v1/selfsubjectrulesreviews';
   const ssrr = {
     typeMeta: {

--- a/tests/integration/tests/namespace/test-reduced-permissions--configuration.spec.js
+++ b/tests/integration/tests/namespace/test-reduced-permissions--configuration.spec.js
@@ -23,8 +23,7 @@ function mockPermissionsCall2(namespacePermissions, clusterPermissions) {
       url: '/backend/apis/authorization.k8s.io/v1/selfsubjectrulesreviews',
     },
     req => {
-      const ns = req.body.spec.namespace;
-      if (ns !== '*') {
+      if (req.body.spec.namespace !== '*') {
         req.reply({
           kind: 'SelfSubjectRulesReview',
           apiVersion: 'authorization.k8s.io/v1',


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- restricted users with cluster-wide access to Config Maps, fetched on a cluster level
- restricted user with no cluster-wide access to Config Maps, but full access on namespace level, fetch namespace-wide config maps

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
