### PR TITLE
fix(oidc): client secret may contain equal signs

### DIFF
--- a/src/components/Clusters/components/oidc-params.ts
+++ b/src/components/Clusters/components/oidc-params.ts
@@ -12,7 +12,22 @@ export function parseOIDCparams({ exec: commandData }: KubeconfigOIDCAuth) {
   let output: any = {};
 
   commandData.args.forEach(arg => {
-    const regex = new RegExp('^(?<key>[^=\\s]+)(?:=(?<value>.*$))');
+    /**
+     * The regular expression defined below is tailored to parse command line arguments, capturing both arguments that
+     * include values and those without values. The regex facilitates the extraction of both the keys and optionally
+     * associated values in a reliable manner.
+     *
+     * Examples of command line arguments that this regex will match:
+     * - With value: `--param-with-value=abc`
+     * - Without value: `--param-without-value`
+     *
+     * The regular expression uses named groups (`key` for the argument and `value` for its associated value, if any)
+     * to provide clear and convenient access to parts of the matched text.
+     *
+     * For an interactive example that demonstrates this regex pattern with various inputs and explains each part of the
+     * expression in detail, visit the provided link: https://regex101.com/r/3hc8qX/2
+     */
+    const regex = new RegExp('^(?<key>[^=]+)(?:=(?<value>.*$))');
     const match = arg.match(regex);
 
     if (!match) {

--- a/src/components/Clusters/components/oidc-params.ts
+++ b/src/components/Clusters/components/oidc-params.ts
@@ -12,7 +12,16 @@ export function parseOIDCparams({ exec: commandData }: KubeconfigOIDCAuth) {
   let output: any = {};
 
   commandData.args.forEach(arg => {
-    const [argKey, argValue] = arg.split('=');
+    const regex = new RegExp('^(?<key>[^=\\s]+)(?:=(?<value>.*$))');
+    const match = arg.match(regex);
+
+    if (!match) {
+      return;
+    }
+
+    const argKey: string = match.groups?.key || '';
+    const argValue: string = match.groups?.value || '';
+
     if (!OIDC_PARAM_NAMES.has(argKey)) return;
 
     const outputKey = OIDC_PARAM_NAMES.get(argKey)!;

--- a/src/components/Clusters/components/test/oidc-params.test.js
+++ b/src/components/Clusters/components/test/oidc-params.test.js
@@ -25,6 +25,25 @@ describe('parseOIDCparams', () => {
     });
   });
 
+  it('Parses params with equal sign in the value properly', () => {
+    const input = {
+      exec: {
+        args: [
+          '--oidc-issuer-url=https://coastguard.gov.us',
+          '--oidc-client-id=hasselhoff',
+          '--oidc-client-secret=hasselhoff=secret',
+          '--oidc-extra-scope=peach',
+        ],
+      },
+    };
+    expect(parseOIDCparams(input)).toMatchObject({
+      clientId: 'hasselhoff',
+      clientSecret: 'hasselhoff=secret',
+      issuerUrl: 'https://coastguard.gov.us',
+      scope: 'peach',
+    });
+  });
+
   it('Concatinates params', () => {
     const input = {
       exec: {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR addresses an isssue with the current handling of the `client_secret` in busola. It does not support equal signs (`=`) within the value, leading to the failure of the oidc flow. 

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
