### PR TITLE
fix: UI5 toast component

### DIFF
--- a/src/shared/contexts/NotificationContext.tsx
+++ b/src/shared/contexts/NotificationContext.tsx
@@ -1,5 +1,5 @@
-import { MessageStrip } from '@ui5/webcomponents-react';
-import { createContext, useContext, useState } from 'react';
+import { Toast, ToastDomRef } from '@ui5/webcomponents-react';
+import { createContext, useContext, useRef, useState } from 'react';
 import {
   ErrorModal,
   ErrorModalProps,
@@ -23,28 +23,23 @@ type NotificationContextArgs = {
 
 export const NotificationContext = createContext<NotificationContextArgs>({
   isOpen: false,
-  notifySuccess: props => {},
-  notifyError: props => {},
+  notifySuccess: () => {},
+  notifyError: () => {},
 });
 
 export const NotificationProvider = ({
   children,
-  defaultVisibilityTime = 5000,
+  defaultVisibilityTime = 3000,
 }: NotificationContextProps) => {
   const [toastProps, setToastProps] = useState<ToastProps | null>();
   const [errorProps, setErrorProps] = useState<ErrorModalProps | null>();
 
+  const toast = useRef<ToastDomRef | null>(null);
+
   const methods = {
-    notifySuccess: function(
-      notificationProps: ToastProps,
-      visibilityTime: number = defaultVisibilityTime,
-    ) {
-      if (visibilityTime !== 0) {
-        setTimeout(() => {
-          setToastProps(null);
-        }, visibilityTime);
-      }
+    notifySuccess: function(notificationProps: ToastProps) {
       setToastProps(notificationProps);
+      toast.current?.show();
     },
     notifyError: function(notificationProps: Omit<ErrorModalProps, 'close'>) {
       setErrorProps({
@@ -61,16 +56,9 @@ export const NotificationProvider = ({
         ...methods,
       }}
     >
-      {toastProps && (
-        <div
-          className="message-toast--wrapper"
-          onClick={() => setToastProps(null)}
-        >
-          <MessageStrip hideIcon hideCloseButton>
-            {toastProps.content}
-          </MessageStrip>
-        </div>
-      )}
+      <Toast ref={toast} duration={defaultVisibilityTime}>
+        {toastProps?.content}
+      </Toast>
       {errorProps &&
         createPortal(<ErrorModal {...errorProps} />, document.body)}
       {children}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -127,16 +127,6 @@ ui5-tabcontainer::part(content) {
   font-style: normal;
 }
 
-.message-toast--wrapper {
-  position: fixed;
-  transition: all ease-in-out 0.4s;
-  z-index: 1100;
-  cursor: pointer;
-  left: 50vw;
-  transform: translateX(-50%);
-  bottom: 50px;
-}
-
 .flexwrap {
   display: flex;
   flex-wrap: wrap;

--- a/tests/integration/support/commands.js
+++ b/tests/integration/support/commands.js
@@ -189,8 +189,6 @@ Cypress.Commands.add(
       cy.contains('ui5-link', resourceName).should('be.visible');
     }
 
-    cy.contains('ui5-message-strip', /created/).should('not.exist');
-
     cy.get('ui5-button[data-testid="delete"]').click();
 
     if (confirmationEnabled) {
@@ -201,7 +199,7 @@ Cypress.Commands.add(
         .click();
 
       if (deletedVisible) {
-        cy.contains('ui5-message-strip', /deleted/).should('be.visible');
+        cy.contains('ui5-toast', /deleted/).should('be.visible');
       }
 
       if (clearSearch) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
see related issue

Changes proposed in this pull request:

- switched toasts from UI5 messagestrip to UI5 toast

**Related issue(s)**
#3000 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [ ] All necessary steps are delivered, for example, tests, documentation, merging
