### PR TITLE
feat: disableOnEdit Text widget

### DIFF
--- a/docs/extensibility/60-form-widgets.md
+++ b/docs/extensibility/60-form-widgets.md
@@ -37,6 +37,7 @@ These are the available `Text` widget parameters:
 | **readOnly**          | No       | boolean             | Specifies if a field is read-only. Defaults to `false`.                                                                                                                                                              |
 | **decodable**         | No       | boolean             | Specifies that the field is base64-encoded and can be decoded in the UI. It can't be used together with **enum**.                                                                                                    |
 | **decodedPlacehoder** | No       | string              | An optional alternative placeholder to use when the field is decoded.                                                                                                                                                |
+| **disableOnEdit**     | No       | boolean             | Disables a field in edit mode, defaults to `false`. Ignored if **readOnly** is set to `true`.                                                                                                                        |
 
 See the following examples:
 

--- a/public/schemas/schema-form.yaml
+++ b/public/schemas/schema-form.yaml
@@ -308,3 +308,7 @@ $widgets:
         decodedPlaceholder:
           type: string
           description: optional alternative placeholder to use when the field is decoded
+        disableOnEdit:
+          type: boolean
+          description: a boolean which specifies if field is disabled on edit.
+          default: false

--- a/src/components/Extensibility/components-form/StringRenderer.js
+++ b/src/components/Extensibility/components-form/StringRenderer.js
@@ -19,6 +19,7 @@ export function StringRenderer({
   required,
   placeholder,
   originalResource,
+  editMode,
   ...props
 }) {
   const { t } = useTranslation();
@@ -26,6 +27,7 @@ export function StringRenderer({
   const schemaPlaceholder = schema.get('placeholder');
   const readOnly = schema.get('readOnly') ?? false;
   const decodable = schema.get('decodable');
+  const disableOnEdit = schema.get('disableOnEdit');
   const [decoded, setDecoded] = useState(true);
 
   let decodeError = false;
@@ -142,7 +144,7 @@ export function StringRenderer({
               },
             });
         }}
-        disabled={readOnly}
+        disabled={readOnly || (disableOnEdit && editMode)}
         isListItem={props.isListItem}
         label={tFromStoreKeys(storeKeys, schema)}
         data-testid={storeKeys.join('.') || tFromStoreKeys(storeKeys, schema)}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Adds a `disableOnEdit` property for `Text` widgets. Similar to the `Name` widget. 


**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Fixes issue #3116 , raised by myself. Reasoning for the feature is in the issue.

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
