### PR TITLE
feat: uxc tables improvements

### DIFF
--- a/src/components/Clusters/views/ClusterList.js
+++ b/src/components/Clusters/views/ClusterList.js
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import jsyaml from 'js-yaml';
 import { saveAs } from 'file-saver';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@ui5/webcomponents-react';
-import { Link } from 'shared/components/Link/Link';
+import { Button, Text } from '@ui5/webcomponents-react';
 
 import { useClustersInfo } from 'state/utils/getClustersInfo';
 
@@ -52,6 +51,10 @@ function ClusterList() {
 
   const { clusters, currentCluster } = clustersInfo;
 
+  const handleClickResource = (_, selectedEntry) => {
+    navigate(`/cluster/${selectedEntry.contextName}`);
+  };
+
   const isClusterActive = entry => {
     return (
       entry?.kubeconfig?.['current-context'] === currentCluster?.contextName
@@ -97,13 +100,14 @@ function ClusterList() {
   ];
 
   const rowRenderer = entry => [
-    <Link
-      design={isClusterActive(entry) ? 'Emphasized' : 'Default'}
-      url={`/cluster/${entry.contextName}`}
-      resetLayout={false}
+    <Text
+      style={{
+        fontWeight: isClusterActive(entry) ? 'bold' : 'normal',
+        color: 'var(--sapLinkColor)',
+      }}
     >
-      {entry.name}
-    </Link>,
+      {entry.contextName}
+    </Text>,
     entry.currentContext.cluster.cluster.server,
     <ClusterStorageType clusterConfig={entry.config} />,
     entry.config?.description || EMPTY_TEXT_PLACEHOLDER,
@@ -235,6 +239,8 @@ function ClusterList() {
                 showSearchSuggestion: false,
                 noSearchResultMessage: t('clusters.list.no-clusters-found'),
               }}
+              customRowClick={handleClickResource}
+              hasDetailsView
             />
             {createPortal(
               <DeleteMessageBox

--- a/src/components/Clusters/views/ClusterList.js
+++ b/src/components/Clusters/views/ClusterList.js
@@ -106,7 +106,7 @@ function ClusterList() {
         color: 'var(--sapLinkColor)',
       }}
     >
-      {entry.contextName}
+      {entry.name}
     </Text>,
     entry.currentContext.cluster.cluster.server,
     <ClusterStorageType clusterConfig={entry.config} />,

--- a/src/components/Extensibility/helpers/index.js
+++ b/src/components/Extensibility/helpers/index.js
@@ -180,7 +180,6 @@ export const getResourceDescAndUrl = descID => {
 
   if (typeof trans === 'string') {
     const links = extractLinks(trans);
-    console.log(links, trans);
 
     if (links?.length >= 1) {
       const matchedLink = links[0];

--- a/src/shared/components/GenericList/GenericList.js
+++ b/src/shared/components/GenericList/GenericList.js
@@ -386,8 +386,12 @@ export const GenericList = ({
         className={`ui5-generic-list ${
           hasDetailsView && filteredEntries.length ? 'cursor-pointer' : ''
         }`}
+        onMouseDown={() => {
+          window.getSelection().removeAllRanges();
+        }}
         onRowClick={e => {
-          if (!hasDetailsView) return;
+          const selection = window.getSelection().toString();
+          if (!hasDetailsView || selection.length > 0) return;
           handleActionIfFormOpen(
             isResourceEdited,
             setIsResourceEdited,

--- a/src/shared/components/GenericList/GenericList.scss
+++ b/src/shared/components/GenericList/GenericList.scss
@@ -1,4 +1,6 @@
 .ui5-generic-list {
+  display: block;
+
   .body-fallback {
     font-size: 18px;
     padding: 20px;

--- a/src/shared/components/GenericList/Pagination/Pagination.scss
+++ b/src/shared/components/GenericList/Pagination/Pagination.scss
@@ -1,4 +1,5 @@
 .pagination {
+  border-top: 1px solid var(--sapList_BorderColor);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -30,7 +31,7 @@
       font-size: var(--sapFontSize);
 
       i::before {
-        color: var(--sapBrandColor);
+        color: var(--sapLinkColor);
         font-size: 80%;
       }
 
@@ -39,7 +40,7 @@
       }
 
       &.interactable {
-        color: var(--sapBrandColor);
+        color: var(--sapLinkColor);
         cursor: pointer;
       }
     }

--- a/src/shared/components/ResourceDetails/ResourceDetails.js
+++ b/src/shared/components/ResourceDetails/ResourceDetails.js
@@ -185,7 +185,11 @@ function Resource({
 
   const pluralizedResourceKind = pluralize(prettifiedResourceKind);
   useWindowTitle(windowTitle || pluralizedResourceKind);
-  const { isProtected, protectedResourceWarning } = useProtectedResources();
+  const {
+    isProtected,
+    protectedResourceWarning,
+    protectedResourcePopover,
+  } = useProtectedResources();
 
   const [DeleteMessageBox, handleResourceDelete] = useDeleteResource({
     resourceTitle,
@@ -392,6 +396,7 @@ function Resource({
 
   return (
     <ResourceDetailContext.Provider value={true}>
+      {protectedResourcePopover()}
       <DynamicPageComponent
         className={className}
         headerContent={headerContent}

--- a/src/shared/components/ResourcesList/ResourcesList.js
+++ b/src/shared/components/ResourcesList/ResourcesList.js
@@ -221,7 +221,11 @@ export function ResourceListRenderer({
     resourceType,
   });
   const { t } = useTranslation();
-  const { isProtected, protectedResourceWarning } = useProtectedResources();
+  const {
+    isProtected,
+    protectedResourceWarning,
+    protectedResourcePopover,
+  } = useProtectedResources();
   const [layoutState, setLayoutColumn] = useRecoilState(columnLayoutState);
   const setIsFormOpen = useSetRecoilState(isFormOpenState);
 
@@ -491,46 +495,49 @@ export function ResourceListRenderer({
         document.body,
       )}
       {!(error && error.status === 'Definition not found') && (
-        <GenericList
-          displayArrow={displayArrow ?? true}
-          disableHiding={disableHiding ?? false}
-          hasDetailsView={hasDetailsView}
-          customUrl={customUrl}
-          resourceType={resourceType}
-          customColumnLayout={customColumnLayout}
-          columnLayout={columnLayout}
-          enableColumnLayout={enableColumnLayout}
-          disableMargin={disableMargin}
-          title={showTitle ? title || prettifiedResourceName : null}
-          actions={actions}
-          entries={resources || []}
-          headerRenderer={headerRenderer}
-          rowRenderer={rowRenderer}
-          serverDataError={error}
-          serverDataLoading={loading}
-          pagination={{ autoHide: true, ...pagination }}
-          extraHeaderContent={extraHeaderContent}
-          testid={testid}
-          sortBy={sortBy}
-          searchSettings={{
-            ...searchSettings,
-            textSearchProperties: textSearchProperties(),
-          }}
-          emptyListProps={
-            simpleEmptyListMessage
-              ? null
-              : {
-                  titleText: `${t('common.labels.no')} ${processTitle(
-                    prettifyNamePlural(resourceTitle, resourceType),
-                  )}`,
-                  onClick: handleShowCreate,
-                  showButton: !disableCreate && namespace !== '-all-',
-                  ...emptyListProps,
-                }
-          }
-          handleRedirect={handleRedirect}
-          nameColIndex={nameColIndex}
-        />
+        <>
+          {protectedResourcePopover()}
+          <GenericList
+            displayArrow={displayArrow ?? true}
+            disableHiding={disableHiding ?? false}
+            hasDetailsView={hasDetailsView}
+            customUrl={customUrl}
+            resourceType={resourceType}
+            customColumnLayout={customColumnLayout}
+            columnLayout={columnLayout}
+            enableColumnLayout={enableColumnLayout}
+            disableMargin={disableMargin}
+            title={showTitle ? title || prettifiedResourceName : null}
+            actions={actions}
+            entries={resources || []}
+            headerRenderer={headerRenderer}
+            rowRenderer={rowRenderer}
+            serverDataError={error}
+            serverDataLoading={loading}
+            pagination={{ autoHide: true, ...pagination }}
+            extraHeaderContent={extraHeaderContent}
+            testid={testid}
+            sortBy={sortBy}
+            searchSettings={{
+              ...searchSettings,
+              textSearchProperties: textSearchProperties(),
+            }}
+            emptyListProps={
+              simpleEmptyListMessage
+                ? null
+                : {
+                    titleText: `${t('common.labels.no')} ${processTitle(
+                      prettifyNamePlural(resourceTitle, resourceType),
+                    )}`,
+                    onClick: handleShowCreate,
+                    showButton: !disableCreate && namespace !== '-all-',
+                    ...emptyListProps,
+                  }
+            }
+            handleRedirect={handleRedirect}
+            nameColIndex={nameColIndex}
+          />
+        </>
       )}
       {!isCompact && createPortal(<YamlUploadDialog />, document.body)}
     </>

--- a/src/shared/components/ResourcesList/ResourcesList.js
+++ b/src/shared/components/ResourcesList/ResourcesList.js
@@ -391,16 +391,22 @@ export function ResourceListRenderer({
   const nameColIndex = customColumns.findIndex(col => col.id === 'name');
 
   const headerRenderer = () => {
-    const rowColumns = customColumns?.map(col => col?.header || null);
-    rowColumns.splice(nameColIndex + 1, 0, '');
-    return rowColumns;
+    return customColumns?.map(col => col?.header || null);
   };
 
   const rowRenderer = entry => {
-    const rowColumns = customColumns?.map(col =>
-      col?.value ? col.value(entry) : null,
-    );
-    rowColumns.splice(nameColIndex + 1, 0, protectedResourceWarning(entry));
+    const rowColumns = customColumns?.map((col, index) => {
+      if (col?.value && index === nameColIndex) {
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+            {col.value(entry)}
+            {protectedResourceWarning(entry)}
+          </div>
+        );
+      }
+      return col?.value ? col.value(entry) : null;
+    });
+
     return rowColumns;
   };
 

--- a/src/shared/helpers/linkExtractor.tsx
+++ b/src/shared/helpers/linkExtractor.tsx
@@ -84,7 +84,6 @@ const getI18nVarLink = (text: string) => {
   if (matches?.length) {
     links = matches.map(link => {
       const { links: mdLinks } = getMarkdownLinks(link);
-      console.log(mdLinks);
       if (mdLinks?.length) {
         const { url, urlText } = mdLinks[0];
         text = text.replace(link, coveredLinkSign);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -8,6 +8,7 @@
   --card-border: var(--_ui5-v1-24-0_card_border);
   --card-border-radius: var(--_ui5-v1-24-0_card_border-radius);
   --card-border: var(--_ui5-v1-24-0_card_border);
+  --ui5-v1-24-0_table_bottom_border: none !important;
 }
 
 html {

--- a/tests/integration/support/commands.js
+++ b/tests/integration/support/commands.js
@@ -165,7 +165,6 @@ Cypress.Commands.add(
       confirmationEnabled = true,
       deletedVisible = true,
       clearSearch = true,
-      isUI5Link = true,
       checkIfResourceIsRemoved = true,
       selectSearchResult = false,
     } = options;
@@ -183,11 +182,7 @@ Cypress.Commands.add(
         .click();
     }
 
-    if (isUI5Link) {
-      cy.checkItemOnGenericListLink(resourceName);
-    } else {
-      cy.contains('ui5-link', resourceName).should('be.visible');
-    }
+    cy.checkItemOnGenericListLink(resourceName);
 
     cy.get('ui5-button[data-testid="delete"]').click();
 

--- a/tests/integration/tests/namespace/test-reduced-permissions.spec.js
+++ b/tests/integration/tests/namespace/test-reduced-permissions.spec.js
@@ -246,7 +246,6 @@ context('Test reduced permissions', () => {
       confirmationEnabled: true,
       deletedVisible: false,
       clearSearch: false,
-      isUI5Link: false,
     });
 
     cy.contains(/No clusters found/).should('exist');


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Protected resource icon is clickable and opens a popover instead of the tooltip on hover interaction
- Protected resource icon in the table is now right next to the name instead of in a separate column
- removed spacing after last table item
- ClusterList: entire row is now navigateable, removed UI5link from name cell
- text in TableRows can now be selected without executing the onClick
- adjusted tests

**Related issue(s)**
#3011 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [ ] All necessary steps are delivered, for example, tests, documentation, merging
