### PR TITLE
feat: Pass fallback namespace to datasources

### DIFF
--- a/src/components/Extensibility/contexts/DataSources.tsx
+++ b/src/components/Extensibility/contexts/DataSources.tsx
@@ -1,9 +1,12 @@
 import pluralize from 'pluralize';
 import { createContext, useEffect, useRef, FC } from 'react';
+import { useRecoilValue } from 'recoil';
+
 import { useFetch } from 'shared/hooks/BackendAPI/useFetch';
 import { useObjectState } from 'shared/useObjectState';
 import * as jp from 'jsonpath';
 import { jsonataWrapper } from '../helpers/jsonataWrapper';
+import { activeNamespaceIdState } from 'state/activeNamespaceIdAtom';
 
 export interface Resource {
   metadata: {
@@ -79,6 +82,7 @@ export const DataSourcesContextProvider: FC<Props> = ({
   const dataSourcesDict = useRef<DataSourcesDict>({});
   // refetch intervals
   const intervals = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const fallbackNamespace = useRecoilValue(activeNamespaceIdState);
 
   // clear timeouts on component unmount
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -93,7 +97,7 @@ export const DataSourcesContextProvider: FC<Props> = ({
       ownerLabelSelectorPath,
     } = dataSource;
     if (typeof namespace === 'undefined') {
-      namespace = resource?.metadata?.namespace;
+      namespace = resource?.metadata?.namespace || fallbackNamespace;
     }
 
     const namespacePart = namespace ? `/namespaces/${namespace}` : '';


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Pass fallback namespace to datasources so on extensibility lists datasources can be filtered by current namespace

**Related issue(s)**
https://github.com/kyma-project/busola/issues/2574
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
