### PR TITLE
fix: infinite loop on hidden namespace

### DIFF
--- a/src/hooks/useAvailableNamespaces.ts
+++ b/src/hooks/useAvailableNamespaces.ts
@@ -11,7 +11,7 @@ export function useAvailableNamespaces() {
   const hiddenNamespaces = useGetHiddenNamespaces();
   const [namespaces, setNamespaces] = useRecoilState(namespacesState);
 
-  const { data, error, refetch, silentRefetch } = useGetList()(
+  const { data: allNamespaces, error, refetch, silentRefetch } = useGetList()(
     '/api/v1/namespaces',
     {
       skip: false,
@@ -31,7 +31,7 @@ export function useAvailableNamespaces() {
       setNamespaces([]);
       return;
     }
-    const filteredNamespaces = data
+    const filteredNamespaces = allNamespaces
       ?.map(n => n.metadata?.name)
       ?.filter(n => {
         if (showHiddenNamespaces) return true;
@@ -40,7 +40,13 @@ export function useAvailableNamespaces() {
     if (filteredNamespaces) {
       setNamespaces(filteredNamespaces);
     }
-  }, [data, error, hiddenNamespaces, setNamespaces, showHiddenNamespaces]);
+  }, [
+    allNamespaces,
+    error,
+    hiddenNamespaces,
+    setNamespaces,
+    showHiddenNamespaces,
+  ]);
 
   return { namespaces, refetch, silentRefetch, setNamespaces };
 }

--- a/src/shared/hooks/useGetHiddenNamespaces.ts
+++ b/src/shared/hooks/useGetHiddenNamespaces.ts
@@ -1,5 +1,6 @@
 import { useFeature } from 'hooks/useFeature';
 import { ConfigFeature } from 'state/types';
+import { useMemo } from 'react';
 
 interface HiddenNamespacesFeature extends ConfigFeature {
   config?: {
@@ -12,9 +13,13 @@ export const useGetHiddenNamespaces = (): string[] => {
     'HIDDEN_NAMESPACES',
   );
 
-  const isValidAndEnabled =
-    hiddenNamespacesConfig?.isEnabled &&
-    Array.isArray(hiddenNamespacesConfig?.config?.namespaces);
+  const hiddenNamespaces = useMemo(() => {
+    const isValidAndEnabled =
+      hiddenNamespacesConfig?.isEnabled &&
+      Array.isArray(hiddenNamespacesConfig?.config?.namespaces);
 
-  return isValidAndEnabled ? hiddenNamespacesConfig!.config!.namespaces! : [];
+    return isValidAndEnabled ? hiddenNamespacesConfig!.config!.namespaces! : [];
+  }, [hiddenNamespacesConfig]);
+
+  return hiddenNamespaces;
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
When feature `HIDDEN_NAMESPACES` is disabled, the busola goes into infinite loop. The problem is that we return simple `[]` value as dependency to useEffect instead of reactive value.

Changes proposed in this pull request:

- use memo to cache hidden namespace and wrap the value into reactive value.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [ ] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
