### PR TITLE
feat: Move banner slot in the Resource components

### DIFF
--- a/docs/extensibility/70-widget-injection.md
+++ b/docs/extensibility/70-widget-injection.md
@@ -23,7 +23,7 @@ These are the available **injections** widget parameters:
 - **details-bottom** - At the bottom of the resource view
 - **details-header** - In the header of the details view
 - **details-top** - At the top of the resource view
-- **banner** - At the top of the resource view. This slot should be only used with `location: ClusterOverview` and [`widget: FeaturedCard`](./50-list-and-details-widgets.md#featuredcard).
+- **banner** - At the top of the resource view. This slot should be only used with [`widget: FeaturedCard`](./50-list-and-details-widgets.md#featuredcard).
 - **health** - At the top of the resource view. This slot should be only used with `location: ClusterOverview` and [`widget: StatisticalCard`](./50-list-and-details-widgets.md#statisticalcard).
 - **list-header** - In the header of the list view
 

--- a/src/shared/components/ResourceDetails/ResourceDetails.js
+++ b/src/shared/components/ResourceDetails/ResourceDetails.js
@@ -214,15 +214,6 @@ function Resource({
   const actions = readOnly ? null : (
     <>
       <Suspense fallback={<Spinner />}>
-        <BannerCarousel
-          children={
-            <Injections
-              destination={resourceType}
-              slot="banner"
-              root={resource}
-            />
-          }
-        />
         <Injections
           destination={resourceType}
           slot="details-header"
@@ -444,6 +435,15 @@ function Resource({
         protectedResourceWarning={protectedResourceWarning(resource)}
         content={
           <>
+            <BannerCarousel
+              children={
+                <Injections
+                  destination={resourceType}
+                  slot="banner"
+                  root={resource}
+                />
+              }
+            />
             {!disableResourceDetailsCard && (
               <>
                 <Title

--- a/src/shared/components/ResourcesList/ResourcesList.js
+++ b/src/shared/components/ResourcesList/ResourcesList.js
@@ -25,6 +25,7 @@ import YamlUploadDialog from 'resources/Namespaces/YamlUpload/YamlUploadDialog';
 import { createPortal } from 'react-dom';
 import BannerCarousel from 'components/Extensibility/components/FeaturedCard/BannerCarousel';
 import { isFormOpenState } from 'state/formOpenAtom';
+import { useGetInjections } from 'components/Extensibility/useGetInjection';
 
 const Injections = React.lazy(() =>
   import('../../../components/Extensibility/ExtensibilityInjections'),
@@ -91,6 +92,7 @@ ResourcesList.defaultProps = {
 };
 
 export function ResourcesList(props) {
+  const headerInjections = useGetInjections(props.resourceType, 'list-header');
   if (!props.resourceUrl) {
     return <></>; // wait for the context update
   }
@@ -117,22 +119,26 @@ export function ResourcesList(props) {
     </>
   );
 
+  const headerActions = headerInjections.length ? (
+    <>
+      <Injections
+        destination={props.resourceType}
+        slot="list-header"
+        root={props.resources}
+      />
+      {props.customHeaderActions}
+    </>
+  ) : (
+    props.customHeaderActions
+  );
+
   return (
     <>
       {!props.isCompact ? (
         <DynamicPageComponent
           layoutNumber={props.layoutNumber}
           title={prettifyNamePlural(props.resourceTitle, props.resourceType)}
-          actions={
-            <>
-              <Injections
-                destination={props.resourceType}
-                slot="list-header"
-                root={props.resources}
-              />
-              {props.customHeaderActions}
-            </>
-          }
+          actions={headerActions}
           description={props.description}
           content={content}
         />

--- a/src/shared/components/ResourcesList/ResourcesList.js
+++ b/src/shared/components/ResourcesList/ResourcesList.js
@@ -95,13 +95,26 @@ export function ResourcesList(props) {
     return <></>; // wait for the context update
   }
 
-  const content = props.resources ? (
-    <ResourceListRenderer
-      resources={(props.resources || []).filter(props.filterFn)}
-      {...props}
-    />
-  ) : (
-    <Resources {...props} />
+  const content = (
+    <>
+      <BannerCarousel
+        children={
+          <Injections
+            destination={props.resourceType}
+            slot="banner"
+            root={props.resources}
+          />
+        }
+      />
+      {props.resources ? (
+        <ResourceListRenderer
+          resources={(props.resources || []).filter(props.filterFn)}
+          {...props}
+        />
+      ) : (
+        <Resources {...props} />
+      )}
+    </>
   );
 
   return (
@@ -112,15 +125,6 @@ export function ResourcesList(props) {
           title={prettifyNamePlural(props.resourceTitle, props.resourceType)}
           actions={
             <>
-              <BannerCarousel
-                children={
-                  <Injections
-                    destination={props.resourceType}
-                    slot="banner"
-                    root={props.resources}
-                  />
-                }
-              />
               <Injections
                 destination={props.resourceType}
                 slot="list-header"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
As part of the issue https://github.com/kyma-project/api-gateway/issues/1423 the information for deprecation of APIRule v1beta1 in the API Gateway module must be displayed to the UI.
It was decided by the team that the FeatureCard is the best option to display this information. To limit the scope of this information we decided to display this only on the list view of the v1beta1 APIRules.
Using the `header-list` or `banner` injection slot in the ResourcesList resulted in a UI that wasn't very well-formatted.
So we want to propose to move the `banner` slot in the ResourcesList component just above the resources.

Changes proposed in this pull request:

- Move `banner` injection slot above the listed resources
- Move `banner` slot in the resource details

**Related issue(s)**
- https://github.com/kyma-project/api-gateway/issues/1423
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [ ] All necessary steps are delivered, for example, tests, documentation, merging
