### PR TITLE
feat(Modules): modules version adjustments to moduleCatalog changes

### DIFF
--- a/src/components/KymaModules/KymaModulesAddModule.js
+++ b/src/components/KymaModules/KymaModulesAddModule.js
@@ -30,6 +30,7 @@ export default function KymaModulesAddModule({
     pollingInterval: 3000,
     skip: !resourceName,
   });
+
   const { data: moduleReleaseMetas } = useGet(modulesReleaseMetaResourceUrl, {
     pollingInterval: 3000,
     skip: !resourceName,

--- a/src/components/KymaModules/KymaModulesAddModule.js
+++ b/src/components/KymaModules/KymaModulesAddModule.js
@@ -24,7 +24,13 @@ export default function KymaModulesAddModule({
 
   const modulesResourceUrl = `/apis/operator.kyma-project.io/v1beta2/moduletemplates`;
 
+  const modulesReleaseMetaResourceUrl = `/apis/operator.kyma-project.io/v1beta2/modulereleasemetas`;
+
   const { data: modules } = useGet(modulesResourceUrl, {
+    pollingInterval: 3000,
+    skip: !resourceName,
+  });
+  const { data: moduleReleaseMetas } = useGet(modulesReleaseMetaResourceUrl, {
     pollingInterval: 3000,
     skip: !resourceName,
   });
@@ -76,29 +82,65 @@ export default function KymaModulesAddModule({
     const isAlreadyInstalled = initialUnchangedResource?.spec?.modules?.find(
       installedModule => installedModule.name === name,
     );
+    const moduleMetaRelase = moduleReleaseMetas?.items.find(
+      item => item.spec.moduleName === name,
+    );
 
-    if (!existingModule && !isAlreadyInstalled) {
-      acc.push({
-        name: name,
-        channels: [
-          {
-            channel: module.spec.channel,
-            version: module.spec.descriptor.component.version,
-            isBeta:
-              module.metadata.labels['operator.kyma-project.io/beta'] ===
-              'true',
-          },
-        ],
-        docsUrl:
-          module.metadata.annotations['operator.kyma-project.io/doc-url'],
-      });
-    } else if (existingModule) {
-      existingModule.channels?.push({
-        channel: module.spec.channel,
-        version: module.spec.descriptor.component.version,
-        isBeta:
-          module.metadata.labels['operator.kyma-project.io/beta'] === 'true',
-      });
+    if (module.spec.channel) {
+      if (!existingModule && !isAlreadyInstalled) {
+        acc.push({
+          name: name,
+          channels: [
+            {
+              channel: module.spec.channel,
+              version: module.spec.descriptor.component.version,
+              isBeta:
+                module.metadata.labels['operator.kyma-project.io/beta'] ===
+                'true',
+            },
+          ],
+          docsUrl:
+            module.metadata.annotations['operator.kyma-project.io/doc-url'],
+        });
+      } else if (existingModule) {
+        existingModule.channels?.push({
+          channel: module.spec.channel,
+          version: module.spec.descriptor.component.version,
+          isBeta:
+            module.metadata.labels['operator.kyma-project.io/beta'] === 'true',
+        });
+      }
+    } else {
+      if (!existingModule && !isAlreadyInstalled) {
+        moduleMetaRelase?.spec.channels.forEach(channel => {
+          if (!acc.find(item => item.name === name)) {
+            acc.push({
+              name: name,
+              channels: [
+                {
+                  channel: channel.channel,
+                  version: channel.version,
+                  isBeta:
+                    module.metadata.labels['operator.kyma-project.io/beta'] ===
+                    'true',
+                },
+              ],
+              docsUrl:
+                module.metadata.annotations['operator.kyma-project.io/doc-url'],
+            });
+          } else {
+            acc
+              .find(item => item.name === name)
+              .channels.push({
+                channel: channel.channel,
+                version: channel.version,
+                isBeta:
+                  module.metadata.labels['operator.kyma-project.io/beta'] ===
+                  'true',
+              });
+          }
+        });
+      }
     }
 
     return acc ?? [];

--- a/src/components/KymaModules/KymaModulesCreate.js
+++ b/src/components/KymaModules/KymaModulesCreate.js
@@ -45,7 +45,17 @@ export default function KymaModulesCreate({ resource, ...props }) {
   const resourceName = kymaResource?.metadata.name;
   const modulesResourceUrl = `/apis/operator.kyma-project.io/v1beta2/moduletemplates`;
 
-  const { data: modules, loading } = useGet(modulesResourceUrl, {
+  const modulesReleaseMetaResourceUrl = `/apis/operator.kyma-project.io/v1beta2/modulereleasemetas`;
+
+  const { data: modules, loading: lodingModules } = useGet(modulesResourceUrl, {
+    pollingInterval: 3000,
+    skip: !resourceName,
+  });
+
+  const {
+    data: moduleReleaseMetas,
+    loading: loadingModulesReleaseMetas,
+  } = useGet(modulesReleaseMetaResourceUrl, {
     pollingInterval: 3000,
     skip: !resourceName,
   });
@@ -69,7 +79,7 @@ export default function KymaModulesCreate({ resource, ...props }) {
     onSave: false,
   });
 
-  if (loading) {
+  if (lodingModules || loadingModulesReleaseMetas) {
     return (
       <div style={{ height: 'calc(100vh - 14rem)' }}>
         <Spinner />
@@ -132,29 +142,65 @@ export default function KymaModulesCreate({ resource, ...props }) {
     const name =
       module.metadata?.labels['operator.kyma-project.io/module-name'];
     const existingModule = acc.find(item => item.name === name);
+    const moduleMetaRelase = moduleReleaseMetas?.items.find(
+      item => item.spec.moduleName === name,
+    );
 
-    if (!existingModule) {
-      acc.push({
-        name: name,
-        channels: [
-          {
-            channel: module.spec.channel,
-            version: module.spec.descriptor.component.version,
-            isBeta:
-              module.metadata.labels['operator.kyma-project.io/beta'] ===
-              'true',
-          },
-        ],
-        docsUrl:
-          module.metadata.annotations['operator.kyma-project.io/doc-url'],
-      });
+    if (module.spec.channel) {
+      if (!existingModule) {
+        acc.push({
+          name: name,
+          channels: [
+            {
+              channel: module.spec.channel,
+              version: module.spec.descriptor.component.version,
+              isBeta:
+                module.metadata.labels['operator.kyma-project.io/beta'] ===
+                'true',
+            },
+          ],
+          docsUrl:
+            module.metadata.annotations['operator.kyma-project.io/doc-url'],
+        });
+      } else if (existingModule) {
+        existingModule.channels?.push({
+          channel: module.spec.channel,
+          version: module.spec.descriptor.component.version,
+          isBeta:
+            module.metadata.labels['operator.kyma-project.io/beta'] === 'true',
+        });
+      }
     } else {
-      existingModule.channels?.push({
-        channel: module.spec.channel,
-        version: module.spec.descriptor.component.version,
-        isBeta:
-          module.metadata.labels['operator.kyma-project.io/beta'] === 'true',
-      });
+      if (!existingModule) {
+        moduleMetaRelase?.spec.channels.forEach(channel => {
+          if (!acc.find(item => item.name === name)) {
+            acc.push({
+              name: name,
+              channels: [
+                {
+                  channel: channel.channel,
+                  version: channel.version,
+                  isBeta:
+                    module.metadata.labels['operator.kyma-project.io/beta'] ===
+                    'true',
+                },
+              ],
+              docsUrl:
+                module.metadata.annotations['operator.kyma-project.io/doc-url'],
+            });
+          } else {
+            acc
+              .find(item => item.name === name)
+              .channels.push({
+                channel: channel.channel,
+                version: channel.version,
+                isBeta:
+                  module.metadata.labels['operator.kyma-project.io/beta'] ===
+                  'true',
+              });
+          }
+        });
+      }
     }
     return acc;
   }, []);
@@ -237,9 +283,11 @@ export default function KymaModulesCreate({ resource, ...props }) {
                 value={channel.channel}
                 additionalText={channel?.isBeta ? 'Beta' : ''}
               >
-                {`${channel.channel[0].toUpperCase()}${channel.channel.slice(
-                  1,
-                )} (v${channel.version})`}{' '}
+                {`${(
+                  channel?.channel[0] || ''
+                ).toUpperCase()}${channel.channel.slice(1)} (v${
+                  channel.version
+                })`}{' '}
               </Option>
             ))}
           </Select>

--- a/src/components/KymaModules/KymaModulesList.js
+++ b/src/components/KymaModules/KymaModulesList.js
@@ -202,7 +202,7 @@ export default function KymaModulesList({
         <>
           {moduleStatus?.channel
             ? moduleStatus?.channel
-            : EMPTY_TEXT_PLACEHOLDER}
+            : kymaResource?.spec?.modules?.[moduleIndex]?.channel}
           {isChannelOverriden ? (
             <Badge
               hideStateIcon

--- a/src/components/KymaModules/ModulesCard.js
+++ b/src/components/KymaModules/ModulesCard.js
@@ -115,9 +115,11 @@ export default function ModulesCard({
                 value={channel.channel}
                 additionalText={channel?.isBeta ? 'Beta' : ''}
               >
-                {`${channel.channel[0].toUpperCase()}${channel.channel.slice(
-                  1,
-                )} (v${channel.version})`}{' '}
+                {`${(
+                  channel?.channel[0] || ''
+                ).toUpperCase()}${channel.channel.slice(1)} (v${
+                  channel.version
+                })`}{' '}
               </Option>
             ))}
           </Select>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- adjust `Add Modules` view to take data for modules from `ModuleMetaRelease` if `ModuleTemplate` is not available
- adjust `Edit Modules` view to take data for modules from `ModuleMetaRelease` if `ModuleTemplate` is not available 
- adjust `List` view of the modules, to take channel from `KymaCR.spec.[modules].channel` is `KymaCR.status.[modules].channel` is not avaibale

**Related issue(s)**
Closes #3459
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
