### PR TITLE
fix: Loading custom script from blob

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="font-src 'self' https://sdk.openui5.org/; script-src 'self'; object-src 'self';"
+      content="font-src 'self' https://sdk.openui5.org/; script-src 'self' blob:; object-src 'self';"
     />
     <title>Busola</title>
   </head>

--- a/src/components/Extensibility/ExtensibilityList.js
+++ b/src/components/Extensibility/ExtensibilityList.js
@@ -162,7 +162,17 @@ const ExtensibilityList = ({ overrideResMetadata, ...props }) => {
     ) {
       const script = document.createElement('script');
       script.type = 'module';
-      script.textContent = customScript;
+      const scriptBlob = new Blob([customScript], {
+        type: 'application/javascript',
+      });
+      const blobURL = URL.createObjectURL(scriptBlob);
+      script.src = blobURL;
+
+      // Clean up the Blob URL after the script loads
+      script.onload = () => {
+        URL.revokeObjectURL(blobURL);
+      };
+
       script.onerror = e => {
         console.error('Script loading or execution error:', e);
       };


### PR DESCRIPTION
**Description**
Currently custom extension cannot be loaded due to CSP:

> Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-XdJSyn1l8eeFeZ6L+DF4Ke18+VkBZcTCtFdVf75F4zc='), or a nonce ('nonce-...') is required to enable inline execution.


Changes proposed in this pull request:

- Load custom script from blob


