### PR TITLE
fix: UI5v2 styling issues in cluster wizard

### DIFF
--- a/src/components/Clusters/components/AddClusterDialog.js
+++ b/src/components/Clusters/components/AddClusterDialog.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Dialog } from '@ui5/webcomponents-react';
 import { useTranslation } from 'react-i18next';
 import { ErrorBoundary } from 'shared/components/ErrorBoundary/ErrorBoundary';
@@ -6,7 +6,7 @@ import { AddClusterWizard } from './AddClusterWizard';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { showAddClusterWizard } from 'state/showAddClusterWizard';
 
-function AddClusterDialogComponent() {
+function AddClusterDialogComponent({ dialogRef }) {
   const [kubeconfig, setKubeconfig] = useState(undefined);
   const showWizard = useRecoilValue(showAddClusterWizard);
 
@@ -17,12 +17,17 @@ function AddClusterDialogComponent() {
   }, [showWizard]);
 
   return showWizard ? (
-    <AddClusterWizard kubeconfig={kubeconfig} setKubeconfig={setKubeconfig} />
+    <AddClusterWizard
+      kubeconfig={kubeconfig}
+      setKubeconfig={setKubeconfig}
+      dialogRef={dialogRef}
+    />
   ) : null;
 }
 export function AddClusterDialog() {
   const { t } = useTranslation();
   const [showWizard, setShowWizard] = useRecoilState(showAddClusterWizard);
+  const dialogRef = useRef(null);
 
   return (
     <Dialog
@@ -30,9 +35,10 @@ export function AddClusterDialog() {
       className="add-cluster-wizard-dialog"
       headerText={t('clusters.add.title')}
       onClose={() => setShowWizard(false)}
+      ref={dialogRef}
     >
       <ErrorBoundary>
-        <AddClusterDialogComponent />
+        <AddClusterDialogComponent dialogRef={dialogRef} />
       </ErrorBoundary>
     </Dialog>
   );

--- a/src/components/Clusters/components/AddClusterWizard.js
+++ b/src/components/Clusters/components/AddClusterWizard.js
@@ -216,7 +216,7 @@ export function AddClusterWizard({ kubeconfig, setKubeconfig, config }) {
         data-step={!hasAuth || !hasOneContext ? '3' : '2'}
       >
         <div className="add-cluster__content-container">
-          <Title level="H5" className="sap-margin-small">
+          <Title level="H5" className="sap-margin-bottom-small">
             {t('clusters.storage.choose-storage.label')}
             <>
               <Button

--- a/src/components/Clusters/components/AddClusterWizard.scss
+++ b/src/components/Clusters/components/AddClusterWizard.scss
@@ -2,6 +2,28 @@
   height: 90vh;
 }
 
+.add-cluster-wizard-dialog {
+  .cluster-wizard-buttons {
+    z-index: 5;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 2rem;
+    margin: 0 2rem;
+    display: flex;
+    justify-content: flex-end;
+    box-sizing: border-box;
+    padding: 0.5rem;
+    border: 1px solid var(--sapGroup_TitleBorderColor);
+    border-radius: var(--sapElement_BorderCornerRadius);
+    background-color: var(--sapGroup_TitleBackground);
+    box-shadow: 0 0 0.125rem 0
+        color-mix(in srgb, var(--sapContent_ShadowColor) 16%, transparent),
+      0 0.5rem 1rem 0
+        color-mix(in srgb, var(--sapContent_ShadowColor) 16%, transparent);
+  }
+}
+
 .add-cluster {
   &__content-container {
     background-color: var(--sapGroup_TitleBackground);
@@ -24,39 +46,6 @@ ui5-wizard {
   width: 75vw;
 
   .cluster-wizard {
-    @mixin cluster-wizard-buttons-style {
-      z-index: 100;
-      bottom: 1rem;
-      display: flex;
-      justify-content: flex-end;
-      box-sizing: border-box;
-      padding: 0.5rem;
-      border: 1px solid var(--sapGroup_TitleBorderColor);
-      border-radius: var(--sapElement_BorderCornerRadius);
-      background-color: var(--sapGroup_TitleBackground);
-      box-shadow: 0 0 0.125rem 0
-          color-mix(in srgb, var(--sapContent_ShadowColor) 16%, transparent),
-        0 0.5rem 1rem 0
-          color-mix(in srgb, var(--sapContent_ShadowColor) 16%, transparent);
-    }
-
-    &__buttons {
-      &__sticky {
-        position: sticky;
-        width: calc(100% + 32px);
-        margin: 0 -16px;
-        @include cluster-wizard-buttons-style;
-      }
-
-      &__absolute {
-        position: absolute;
-        left: 0;
-        width: calc(100% - 32px);
-        margin: 0 16px;
-        @include cluster-wizard-buttons-style;
-      }
-    }
-
     &__token-info,
     &__storage-preference {
       color: var(--sapContent_LabelColor);
@@ -67,6 +56,7 @@ ui5-wizard {
       display: flex;
       flex-flow: column;
       overflow: auto;
+      margin-bottom: 4rem;
 
       .cluster-wizard__auth-form {
         height: unset;

--- a/src/components/Clusters/components/AddClusterWizard.scss
+++ b/src/components/Clusters/components/AddClusterWizard.scss
@@ -14,6 +14,11 @@
   }
 }
 
+ui5-wizard::part(step-content) {
+  --_ui5-v2-7-0_wiz_content_item_wrapper_padding: 0;
+  --_ui5-v2-7-0_wiz_content_item_wrapper_bg: transparent;
+}
+
 ui5-wizard {
   height: 100%;
   width: 75vw;

--- a/src/components/Clusters/components/ClusterPreview.scss
+++ b/src/components/Clusters/components/ClusterPreview.scss
@@ -1,9 +1,6 @@
 .cluster-preview {
-  overflow-y: scroll;
   overflow-x: hidden;
-  height: 100%;
-  min-height: calc(90vh - 11.85rem);
-  margin-bottom: 1rem;
+  margin-bottom: 4rem;
 
   &__subtitle {
     padding-bottom: 1rem;

--- a/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.scss
+++ b/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.scss
@@ -3,8 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: calc(90vh - 11.85rem);
-  margin-bottom: 1rem;
+  margin-bottom: 4rem;
 
   .editor-label {
     text-align: center;

--- a/src/components/Extensibility/ExtensibilityWizard.js
+++ b/src/components/Extensibility/ExtensibilityWizard.js
@@ -215,8 +215,8 @@ export function ExtensibilityWizardCore({
                 </UIStoreProvider>
               </section>
               <WizardButtons
-                selected={selected}
-                setSelected={setSelected}
+                selectedStep={selected}
+                setSelectedStep={setSelected}
                 firstStep={selectedIndex === 1}
                 onCancel={onCancel}
               />
@@ -241,8 +241,8 @@ export function ExtensibilityWizardCore({
             </div>
           </div>
           <WizardButtons
-            selected={selected}
-            setSelected={setSelected}
+            selectedStep={selected}
+            setSelectedStep={setSelected}
             lastStep={true}
             customFinish={
               uploadState === OPERATION_STATE_SUCCEEDED

--- a/src/shared/ResourceForm/components/ResourceForm.scss
+++ b/src/shared/ResourceForm/components/ResourceForm.scss
@@ -35,10 +35,6 @@ form .resource-form {
     width: 100%;
   }
 
-  ui5-switch {
-    margin-top: -0.5rem;
-  }
-
   .form-field,
   .simple-list,
   .flexbox-gap {

--- a/src/shared/components/WizardButtons/WizardButtons.js
+++ b/src/shared/components/WizardButtons/WizardButtons.js
@@ -2,24 +2,24 @@ import { Button } from '@ui5/webcomponents-react';
 import { useTranslation } from 'react-i18next';
 
 export function WizardButtons({
-  selected,
-  setSelected,
+  selectedStep,
+  setSelectedStep,
   firstStep = false,
   customFinish,
   lastStep = false,
   onComplete,
   onCancel,
-  validation,
+  invalid,
   className,
 }) {
   const { t } = useTranslation();
 
   const goToNextStep = () => {
-    setSelected(selected + 1);
+    setSelectedStep(selectedStep + 1);
   };
 
   const goToPreviousStep = () => {
-    setSelected(selected - 1);
+    setSelectedStep(selectedStep - 1);
   };
 
   return (
@@ -37,7 +37,7 @@ export function WizardButtons({
       <Button
         design="Emphasized"
         onClick={lastStep ? onComplete : goToNextStep}
-        disabled={validation}
+        disabled={invalid}
         className="sap-margin-end-tiny"
         accessibleName={lastStep ? 'last-step' : 'next-step'}
       >


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- reset ui5 variables for wizard step content padding and background
- adjusted margin of "Storage type configuration" - title
- fixed margin of OIDC switch in authentication form

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
