### PR TITLE
fix: correct state update after namespace edit

### DIFF
--- a/src/resources/Namespaces/NamespaceCreate.js
+++ b/src/resources/Namespaces/NamespaceCreate.js
@@ -110,9 +110,10 @@ export default function NamespaceCreate({
   }, [namespace.metadata?.name]);
 
   async function afterNamespaceCreated() {
-    setLayoutColumn({
+    setLayoutColumn(prevState => ({
       layout: 'OneColumn',
       showCreate: null,
+      showEdit: prevState.showEdit,
       startColumn: {
         resourceType: 'Namespace',
         resourceName: namespace.metadata?.name,
@@ -121,7 +122,7 @@ export default function NamespaceCreate({
       },
       midColumn: null,
       endColumn: null,
-    });
+    }));
 
     if (!initialUnchangedResource) {
       navigate(clusterUrl(`namespaces/${namespace.metadata?.name}`));

--- a/src/shared/components/DynamicPageComponent/DynamicPageComponent.js
+++ b/src/shared/components/DynamicPageComponent/DynamicPageComponent.js
@@ -370,20 +370,19 @@ export const DynamicPageComponent = ({
               return;
             }
 
+            const newTabName = e.detail.tab.getAttribute('data-mode');
             handleActionIfFormOpen(
               isResourceEdited,
               setIsResourceEdited,
               isFormOpen,
               setIsFormOpen,
               () => {
-                setSelectedSectionIdState(
-                  e.detail.tab.getAttribute('data-mode'),
-                );
+                setSelectedSectionIdState(newTabName);
                 setIsResourceEdited({
                   isEdited: false,
                 });
 
-                if (e.detail.tab.getAttribute('data-mode') === 'edit') {
+                if (newTabName === 'edit') {
                   const params = new URLSearchParams();
                   if (layoutColumn.layout !== 'OneColumn') {
                     params.set('layout', layoutColumn.layout);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- after editing a namespace, the columnLayout state now still contains the showEdit information (since the user remains in the edit tab
- ...
- ...

**Related issue(s)**
#3803
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [ ] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [ ] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [ ] Explain clearly why you created the PR and what changes it introduces
- [ ] All necessary steps are delivered, for example, tests, documentation, merging
