### PR TITLE
fix: Don't compare Kyma CR and Manager statuses for unmanaged modules

### DIFF
--- a/src/components/KymaModules/components/ModuleStatus.tsx
+++ b/src/components/KymaModules/components/ModuleStatus.tsx
@@ -9,14 +9,15 @@ export const resolveType = (status: string) => {
   switch (status) {
     case 'Initial':
     case 'Pending':
-    case 'Available':
     case 'Released':
       return 'Information';
+    case 'Available':
     case 'Ready':
     case 'Bound':
     case 'Running':
     case 'Success':
     case 'Succeeded':
+    case 'Progressing':
     case 'Ok':
       return 'Positive';
     case 'Processing':

--- a/src/components/KymaModules/components/ModulesListRows.tsx
+++ b/src/components/KymaModules/components/ModulesListRows.tsx
@@ -90,10 +90,10 @@ export const ModulesListRows = ({
       return kymaResourceModule?.name === resource?.name;
     }) ?? -1;
 
-  const { data: managerResourceState } = useGetManagerStatus(
-    currentModuleTemplate?.spec?.manager,
-  );
-
+  const {
+    data: managerResourceState,
+    error: managerResourceStateError,
+  } = useGetManagerStatus(currentModuleTemplate?.spec?.manager);
   if (
     moduleStatus &&
     !moduleStatus.resource &&
@@ -118,6 +118,12 @@ export const ModulesListRows = ({
     ];
 
   const currentModuleReleaseMeta = findModuleReleaseMeta(resource.name);
+  const resolvedInstallationStateName = resolveInstallationStateName(
+    moduleStatus?.state,
+    !!currentModuleTemplate?.spec?.manager,
+    managerResourceState?.state,
+    !!managerResourceStateError,
+  );
 
   const isChannelOverridden = moduleIndex
     ? kymaResource?.spec?.modules?.[moduleIndex]?.channel !== undefined
@@ -186,18 +192,18 @@ export const ModulesListRows = ({
       key="installation-state"
       resourceKind="kymas"
       type={resolveType(
-        kymaResource ? moduleStatus?.state : managerResourceState?.state ?? '',
+        kymaResource
+          ? resolvedInstallationStateName
+          : managerResourceState?.state ?? '',
       )}
       tooltipContent={
-        kymaResource ? moduleStatus?.message : managerResourceState?.message
+        kymaResource
+          ? moduleStatus?.message ?? managerResourceState?.message
+          : managerResourceState?.message
       }
     >
       {kymaResource
-        ? resolveInstallationStateName(
-            moduleStatus?.state,
-            !!currentModuleTemplate?.spec?.manager,
-            managerResourceState?.state,
-          )
+        ? resolvedInstallationStateName
         : managerResourceState?.state}
     </StatusBadge>,
     // Documentation

--- a/src/components/KymaModules/support.ts
+++ b/src/components/KymaModules/support.ts
@@ -298,16 +298,23 @@ export const resolveInstallationStateName = (
   state?: string,
   managerExists?: boolean,
   managerResourceState?: string,
+  managerError?: boolean,
 ) => {
   if (state === ModuleTemplateStatus.Unmanaged && !managerExists) {
     return ModuleTemplateStatus.NotInstalled;
   }
 
   if (state === ModuleTemplateStatus.Unmanaged && managerExists) {
-    if (resolveType(state) !== resolveType(managerResourceState ?? '')) {
-      return ModuleTemplateStatus.Processing;
-    }
     return managerResourceState || ModuleTemplateStatus.Unknown;
+  }
+
+  if (
+    state &&
+    managerExists &&
+    !managerError &&
+    resolveType(state) !== resolveType(managerResourceState ?? '')
+  ) {
+    return ModuleTemplateStatus.Processing;
   }
 
   return state || ModuleTemplateStatus.Unknown;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixed comparing Kyma CR and Manager statuses for unmanaged modules, which always resulted in "Processing" status

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [ ] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [ ] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [ ] Explain clearly why you created the PR and what changes it introduces
- [ ] All necessary steps are delivered, for example, tests, documentation, merging
