### PR TITLE
fix: Return focus to previus element when error modal is displayed

### DIFF
--- a/src/shared/ResourceForm/tests/useCreateResource.test.js
+++ b/src/shared/ResourceForm/tests/useCreateResource.test.js
@@ -122,6 +122,7 @@ describe('useCreateResource', () => {
     await waitFor(() => {
       expect(mockNotifySuccess).not.toHaveBeenCalled();
       expect(mockNotifyError).toHaveBeenCalledWith({
+        actions: expect.any(Function),
         content: 'common.create-form.messages.create-failure',
       });
     });

--- a/src/shared/ResourceForm/useCreateResource.js
+++ b/src/shared/ResourceForm/useCreateResource.js
@@ -119,7 +119,15 @@ export function useCreateResource({
 
   const showError = error => {
     console.error(error);
+    const previousActiveElement = document.activeElement;
     notification.notifyError({
+      actions: (close, defaultCloseButton) => {
+        const closeWrapper = () => {
+          close();
+          previousActiveElement.focus();
+        };
+        return defaultCloseButton(closeWrapper);
+      },
       content: t(
         isEdit
           ? 'common.create-form.messages.patch-failure'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Return focus to previus element when error modal is displayed.

**Related issue(s)**
https://github.com/kyma-project/busola/issues/3201

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
