### PR TITLE
fix: Focus on file name after uploading a kubeconfig

### DIFF
--- a/src/shared/components/FileInput/FileInput.js
+++ b/src/shared/components/FileInput/FileInput.js
@@ -110,12 +110,7 @@ export function FileInput({
           <p className="file-input__secondary">{availableFormatsMessage}</p>
         )}
 
-        <p
-          className="file-input__secondary"
-          id="file-input__uploaded-files"
-          ref={fileNameRef}
-          tabIndex={1}
-        >
+        <p className="file-input__secondary" ref={fileNameRef} tabIndex={1}>
           {fileNames.length
             ? `${fileNames.join(', ')} ${t('components.file-input.uploaded')}`
             : ''}

--- a/src/shared/components/FileInput/FileInput.js
+++ b/src/shared/components/FileInput/FileInput.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
@@ -31,6 +31,7 @@ export function FileInput({
   const openAddCluster = useRecoilValue(showAddClusterWizard);
   const [draggingOverCounter, setDraggingCounter] = useState(0);
   const { t } = useTranslation();
+  const fileNameRef = useRef(null);
 
   useEffect(() => {
     if (!openAdd && !openAddCluster) setFileNames([]);
@@ -46,6 +47,12 @@ export function FileInput({
     setFileNames([...files]?.map(file => file.name || ''));
     if (files.length) {
       fileInputChanged(files);
+    }
+
+    if (fileNameRef.current) {
+      setTimeout(() => {
+        fileNameRef.current?.focus();
+      }, 50); // Timeout to ensure the focus is set after the DOM update
     }
   }
 
@@ -102,11 +109,17 @@ export function FileInput({
         {availableFormatsMessage && (
           <p className="file-input__secondary">{availableFormatsMessage}</p>
         )}
-        {!!fileNames.length && (
-          <p className="file-input__secondary">
-            {`${fileNames.join(', ')} ${t('components.file-input.uploaded')}`}
-          </p>
-        )}
+
+        <p
+          className="file-input__secondary"
+          id="file-input__uploaded-files"
+          ref={fileNameRef}
+          tabIndex={1}
+        >
+          {fileNames.length
+            ? `${fileNames.join(', ')} ${t('components.file-input.uploaded')}`
+            : ''}
+        </p>
       </div>
     </label>
   );


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- After uploading the kubeconfig in the Connect YAML dialog, the file name is now read out by a screen reader

**Related issue(s)**
Closes #3233

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
