### PR TITLE
fix: Improve displaying of resource quota

### DIFF
--- a/src/shared/helpers/resources.js
+++ b/src/shared/helpers/resources.js
@@ -46,30 +46,30 @@ export function formatResourceUnit(
   const infix = withoutSpace ? '' : ' ';
 
   if (unit && prefixMap[unit]) {
-    const value = (amount / prefixMap[unit]).toFixed(fixed);
+    const value = Number((amount / prefixMap[unit]).toFixed(fixed));
     return {
-      string: `${value}${infix}${unit}`,
+      string: `${value.toString()}${infix}${unit}`,
       unit: unit,
-      value: Number(value),
+      value: value,
     };
   }
 
-  const coreValue = preciseRound(amount, 2).toFixed(fixed);
+  const coreValue = Number(preciseRound(amount, 2).toFixed(fixed));
 
   let output = {
-    string: `${coreValue}${infix}${unit}`,
+    string: `${coreValue.toString()}${infix}${unit}`,
     unit: unit,
-    value: Number(coreValue),
+    value: coreValue,
   };
 
   Object.entries(prefixMap).forEach(([prefix, power]) => {
     const tmpValue = amount / power;
     if (tmpValue >= 1) {
-      const value = preciseRound(tmpValue, 2).toFixed(fixed);
+      const value = Number(preciseRound(tmpValue, 2).toFixed(fixed));
       output = {
-        string: `${value}${infix}${prefix}${unit}`,
+        string: `${value.toString()}${infix}${prefix}${unit}`,
         unit: unit,
-        value: Number(value),
+        value: value,
       };
     }
   });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- When resource quota is set to 4GB and is utilized by 0,6Gb the view displayes 0% of usage. So I added decimal prefix to make it more precise.

**Related issue(s)**
https://github.com/kyma-project/busola/issues/2992

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
