### PR TITLE
fix: Reorder buttons in Cluster Wizard for screen reader

### DIFF
--- a/src/components/Clusters/components/AddClusterDialog.tsx
+++ b/src/components/Clusters/components/AddClusterDialog.tsx
@@ -10,7 +10,7 @@ export function AddClusterDialog() {
   const { t } = useTranslation();
   const [showWizard, setShowWizard] = useAtom(showAddClusterWizard);
   const [kubeconfig, setKubeconfig] = useState(undefined);
-  const buttonsContainerRef = useRef(null);
+  const dialogRef = useRef(null);
 
   useEffect(() => {
     if (!showWizard) {
@@ -30,10 +30,10 @@ export function AddClusterDialog() {
           <AddClusterWizard
             kubeconfig={kubeconfig}
             setKubeconfig={setKubeconfig}
-            buttonsContainerRef={buttonsContainerRef}
+            dialogRef={dialogRef}
           />
         ) : null}
-        <div ref={buttonsContainerRef}></div>
+        <div ref={dialogRef}></div>
       </ErrorBoundary>
     </Dialog>
   );

--- a/src/components/Clusters/components/AddClusterDialog.tsx
+++ b/src/components/Clusters/components/AddClusterDialog.tsx
@@ -10,7 +10,7 @@ export function AddClusterDialog() {
   const { t } = useTranslation();
   const [showWizard, setShowWizard] = useAtom(showAddClusterWizard);
   const [kubeconfig, setKubeconfig] = useState(undefined);
-  const dialogRef = useRef(null);
+  const buttonsContainerRef = useRef(null);
 
   useEffect(() => {
     if (!showWizard) {
@@ -24,16 +24,16 @@ export function AddClusterDialog() {
       className="add-cluster-wizard-dialog"
       headerText={t('clusters.add.title')}
       onClose={() => setShowWizard(false)}
-      ref={dialogRef}
     >
       <ErrorBoundary>
         {showWizard ? (
           <AddClusterWizard
             kubeconfig={kubeconfig}
             setKubeconfig={setKubeconfig}
-            dialogRef={dialogRef}
+            buttonsContainerRef={buttonsContainerRef}
           />
         ) : null}
+        <div ref={buttonsContainerRef}></div>
       </ErrorBoundary>
     </Dialog>
   );

--- a/src/components/Clusters/components/AddClusterWizard.js
+++ b/src/components/Clusters/components/AddClusterWizard.js
@@ -29,7 +29,7 @@ import { HintButton } from 'shared/components/DescriptionHint/DescriptionHint';
 export function AddClusterWizard({
   kubeconfig,
   setKubeconfig,
-  dialogRef,
+  buttonsContainerRef,
   config = {},
 }) {
   const busolaClusterParams = useRecoilValue(configurationAtom);
@@ -258,7 +258,7 @@ export function AddClusterWizard({
           />
         </WizardStep>
       </Wizard>
-      {dialogRef?.current &&
+      {buttonsContainerRef?.current &&
         createPortal(
           <WizardButtons
             className="cluster-wizard-buttons"
@@ -275,7 +275,7 @@ export function AddClusterWizard({
             onComplete={onComplete}
             invalid={isCurrentStepInvalid(selected)}
           />,
-          dialogRef.current,
+          buttonsContainerRef.current,
         )}
     </>
   );

--- a/src/components/Clusters/components/AddClusterWizard.js
+++ b/src/components/Clusters/components/AddClusterWizard.js
@@ -29,7 +29,7 @@ import { HintButton } from 'shared/components/DescriptionHint/DescriptionHint';
 export function AddClusterWizard({
   kubeconfig,
   setKubeconfig,
-  buttonsContainerRef,
+  dialogRef,
   config = {},
 }) {
   const busolaClusterParams = useRecoilValue(configurationAtom);
@@ -258,7 +258,7 @@ export function AddClusterWizard({
           />
         </WizardStep>
       </Wizard>
-      {buttonsContainerRef?.current &&
+      {dialogRef?.current &&
         createPortal(
           <WizardButtons
             className="cluster-wizard-buttons"
@@ -275,7 +275,7 @@ export function AddClusterWizard({
             onComplete={onComplete}
             invalid={isCurrentStepInvalid(selected)}
           />,
-          buttonsContainerRef.current,
+          dialogRef.current,
         )}
     </>
   );


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Changed the render order of buttons in the Cluster Wizard - it renders now after the form

**Related issue(s)**
Closes #3251 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
