### PR TITLE
fix: Command pallette covered by chat on smaller screens

### DIFF
--- a/src/command-pallette/CommandPalletteUI/CommandPaletteSearchBar.tsx
+++ b/src/command-pallette/CommandPalletteUI/CommandPaletteSearchBar.tsx
@@ -104,16 +104,11 @@ export function CommandPaletteSearchBar({
       '.ui5-shellbar-search-field',
     ) as HTMLElement;
 
-    if (
-      searchButton &&
-      searchField &&
-      shellbarWidth > SCREEN_SIZE_BREAKPOINT_M
-    ) {
+    if (searchButton && shellbarWidth > SCREEN_SIZE_BREAKPOINT_M) {
       searchButton.style.display = 'none';
 
       // search bar has to be always visible on big screen
       shellbarCurr?.setAttribute('show-search-field', '');
-      searchField.style.display = 'flex';
     } else if (searchButton && searchField) {
       searchButton.style.display = 'inline-block';
       shellbarCurr?.removeAttribute('show-search-field');

--- a/src/command-pallette/CommandPalletteUI/CommandPaletteUI.scss
+++ b/src/command-pallette/CommandPalletteUI/CommandPaletteUI.scss
@@ -17,6 +17,9 @@
     position: absolute;
     top: calc(var(--_ui5-v2-11-0_shellbar_root_height) * -1);
     opacity: 0%; //prevent visually jumping
+    @media (min-width: 1040px) {
+      opacity: 100%;
+    }
   }
 
   &__content {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixed command palette not being displayed (steps to reproduce: start from width e.g. 1200px, open AI chat and command palette, start expanding screen width -> command palette disappears)
- fixed command palette search button not getting replaced with search bar when the screen gets bigger or AI chat gets closed

**Related issue(s)**
Resolves #4098 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
