### PR TITLE
fix: Associated header not being read out

### DIFF
--- a/src/shared/components/EmptyListComponent/EmptyListComponent.scss
+++ b/src/shared/components/EmptyListComponent/EmptyListComponent.scss
@@ -12,3 +12,7 @@ div[slot='noData'] {
   width: 100%;
   text-align: center;
 }
+
+section {
+  height: 100%;
+}

--- a/src/shared/components/EmptyListComponent/EmptyListComponent.tsx
+++ b/src/shared/components/EmptyListComponent/EmptyListComponent.tsx
@@ -43,33 +43,35 @@ export const EmptyListComponent = ({
   }
 
   return (
-    <IllustratedMessage
-      className="emptyListComponent"
-      name={image}
-      design="Auto"
-      title={
-        <Title level="H2" size="H2">
-          {titleText}
-        </Title>
-      }
-      subtitle={<span className="sap-margin-top-small">{subtitle}</span>}
-    >
-      <div className="emptyListComponent__buttons">
-        {showButton && (
-          <Button design="Emphasized" onClick={onClick}>
-            {buttonText}
-          </Button>
-        )}
-        {url && (
-          <ExternalLink
-            text="Learn More"
-            url={url}
-            buttonDesign="Transparent"
-            type="button"
-          />
-        )}
-      </div>
-      {children}
-    </IllustratedMessage>
+    <section aria-labelledby="empty-list-title">
+      <IllustratedMessage
+        className="emptyListComponent"
+        name={image}
+        design="Auto"
+        title={
+          <Title level="H2" size="H2" id="empty-list-title">
+            {titleText}
+          </Title>
+        }
+        subtitle={<span className="sap-margin-top-small">{subtitle}</span>}
+      >
+        <div className="emptyListComponent__buttons">
+          {showButton && (
+            <Button design="Emphasized" onClick={onClick}>
+              {buttonText}
+            </Button>
+          )}
+          {url && (
+            <ExternalLink
+              text="Learn More"
+              url={url}
+              buttonDesign="Transparent"
+              type="button"
+            />
+          )}
+        </div>
+        {children}
+      </IllustratedMessage>
+    </section>
   );
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fixed associated header ('There are no clusters yet') not being read out when accessing button `Connect` and link `Learn more`

**Related issue(s)**
Resolves #3231
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
