### PR TITLE
fix: Popover not closing after opening create form on mobile

### DIFF
--- a/src/resources/LimitRanges/LimitRangesList.jsx
+++ b/src/resources/LimitRanges/LimitRangesList.jsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { ResourcesList } from 'shared/components/ResourcesList/ResourcesList';
 import LimitRangeCreate from './LimitRangeCreate';
 import LimitRangeSpecification from './LimitRangeSpecification';
-import { Button } from '@ui5/webcomponents-react';
+import { ToolbarButton } from '@ui5/webcomponents-react';
 import { useNavigate } from 'react-router';
 import { useSetAtom } from 'jotai';
 import { columnLayoutAtom } from 'state/columnLayoutAtom';
@@ -51,14 +51,13 @@ export function LimitRangesList(props) {
   };
 
   const createButton = (
-    <Button
+    <ToolbarButton
       key={`create-limit-ranges`}
       data-testid={`create-limit-ranges`}
       design="Emphasized"
       onClick={handleShowCreate}
-    >
-      {t('components.resources-list.create')}
-    </Button>
+      text={t('components.resources-list.create')}
+    />
   );
 
   return (

--- a/src/shared/components/GenericList/SortModalPanel.jsx
+++ b/src/shared/components/GenericList/SortModalPanel.jsx
@@ -6,6 +6,7 @@ import {
   List,
   RadioButton,
   Text,
+  ToolbarButton,
 } from '@ui5/webcomponents-react';
 import { Modal } from '../Modal/Modal';
 import { useTranslation } from 'react-i18next';
@@ -24,7 +25,7 @@ export const SortModalPanel = ({
   const { i18n, t } = useTranslation();
 
   const sortOpeningComponent = (
-    <Button
+    <ToolbarButton
       disabled={disabled}
       design="Transparent"
       icon="sort"

--- a/src/shared/components/ResourcesList/ResourcesList.jsx
+++ b/src/shared/components/ResourcesList/ResourcesList.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import PropTypes from 'prop-types';
-import { Button, Text } from '@ui5/webcomponents-react';
+import { Text, ToolbarButton } from '@ui5/webcomponents-react';
 import { cloneDeep } from 'lodash';
 import jp from 'jsonpath';
 import pluralize from 'pluralize';
@@ -552,14 +552,13 @@ export function ResourceListRenderer({
 
   const extraHeaderContent = listHeaderActions || [
     CreateResourceForm && !disableCreate && !isNamespaceAll && (
-      <Button
+      <ToolbarButton
         key={`create-${resourceType}`}
         data-testid={`create-${resourceType}`}
         design="Emphasized"
         onClick={handleShowCreate}
-      >
-        {createActionLabel || t('components.resources-list.create')}
-      </Button>
+        text={createActionLabel || t('components.resources-list.create')}
+      />
     ),
   ];
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixed popover with toolbar hidden actions not disappearing when entering resource creation form after clicking "Create". 
After changes in this PR the popover disappears shortly after create form opens - previously it didn't disappear at all. The bug could be reproduced in Extensions list.

**Related issue(s)**
Resolves #4260 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
