### PR TITLE
feat: Add tooltip to code preview of monaco editor

### DIFF
--- a/public/i18n/en.yaml
+++ b/public/i18n/en.yaml
@@ -226,6 +226,7 @@ command-palette:
     remove-ns-context: Remove Namespace context
 common:
   ariaLabel:
+    code-preview: Code Preview
     editor: editor
     new-tab-link: This link will be opened in a new tab.
   buttons:

--- a/src/shared/components/MonacoEditorESM/hooks/useCreateEditor.js
+++ b/src/shared/components/MonacoEditorESM/hooks/useCreateEditor.js
@@ -61,6 +61,16 @@ export const useCreateEditor = ({
       ...options,
     });
 
+    if (divRef.current) {
+      const minimapElement = divRef.current.querySelector('.minimap');
+      if (minimapElement) {
+        minimapElement.setAttribute(
+          'title',
+          t('common.ariaLabel.code-preview'),
+        );
+      }
+    }
+
     setEditorInstance(instance);
 
     return () => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- the code preview feature of the monaco editor now displays the tooltip "Code Preview" on mouse over
- the preview area is internally intentionally set to aria-hidden="true" because it provides no benefit to visually disabled users to make it navigatable and access it, so apart from the tooltip it remains as is
- ...

**Related issue(s)**
#3213
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
