### PR TITLE
fix: Do not display Global account and Subaccount id if not present

### DIFF
--- a/src/components/Clusters/views/ClusterOverview/ClusterDetails.jsx
+++ b/src/components/Clusters/views/ClusterOverview/ClusterDetails.jsx
@@ -84,14 +84,14 @@ export default function ClusterDetails({ currentCluster }) {
                 </Text>
               </DynamicPageComponent.Column>
               <GardenerProvider />
-              {!!kymaResourceLabels['kyma-project.io/global-account-id'] && (
+              {!!kymaResourceLabels?.['kyma-project.io/global-account-id'] && (
                 <DynamicPageComponent.Column
                   title={t('clusters.overview.global-account-id')}
                 >
                   {kymaResourceLabels['kyma-project.io/global-account-id']}
                 </DynamicPageComponent.Column>
               )}
-              {!!kymaResourceLabels['kyma-project.io/subaccount-id'] && (
+              {!!kymaResourceLabels?.['kyma-project.io/subaccount-id'] && (
                 <DynamicPageComponent.Column
                   title={t('clusters.overview.subaccount-id')}
                 >

--- a/src/components/Clusters/views/ClusterOverview/ClusterDetails.jsx
+++ b/src/components/Clusters/views/ClusterOverview/ClusterDetails.jsx
@@ -84,25 +84,19 @@ export default function ClusterDetails({ currentCluster }) {
                 </Text>
               </DynamicPageComponent.Column>
               <GardenerProvider />
-              {kymaResourceLabels && (
-                <>
-                  {!!kymaResourceLabels[
-                    'kyma-project.io/global-account-id'
-                  ] && (
-                    <DynamicPageComponent.Column
-                      title={t('clusters.overview.global-account-id')}
-                    >
-                      {kymaResourceLabels['kyma-project.io/global-account-id']}
-                    </DynamicPageComponent.Column>
-                  )}
-                  {!!kymaResourceLabels['kyma-project.io/subaccount-id'] && (
-                    <DynamicPageComponent.Column
-                      title={t('clusters.overview.subaccount-id')}
-                    >
-                      {kymaResourceLabels['kyma-project.io/subaccount-id']}
-                    </DynamicPageComponent.Column>
-                  )}
-                </>
+              {!!kymaResourceLabels['kyma-project.io/global-account-id'] && (
+                <DynamicPageComponent.Column
+                  title={t('clusters.overview.global-account-id')}
+                >
+                  {kymaResourceLabels['kyma-project.io/global-account-id']}
+                </DynamicPageComponent.Column>
+              )}
+              {!!kymaResourceLabels['kyma-project.io/subaccount-id'] && (
+                <DynamicPageComponent.Column
+                  title={t('clusters.overview.subaccount-id')}
+                >
+                  {kymaResourceLabels['kyma-project.io/subaccount-id']}
+                </DynamicPageComponent.Column>
               )}
               {!environmentParametersLoading && !!natGatewayIps && (
                 <DynamicPageComponent.Column

--- a/src/components/Clusters/views/ClusterOverview/ClusterDetails.jsx
+++ b/src/components/Clusters/views/ClusterOverview/ClusterDetails.jsx
@@ -11,7 +11,6 @@ import { DynamicPageComponent } from 'shared/components/DynamicPageComponent/Dyn
 import ResourceDetailsCard from 'shared/components/ResourceDetails/ResourceDetailsCard';
 import ClusterModulesCard from './ClusterModulesCard';
 import { ClusterStorageType } from '../ClusterStorageType';
-import { EMPTY_TEXT_PLACEHOLDER } from 'shared/constants';
 import { CommunityModuleContextProvider } from 'components/Modules/community/providers/CommunityModuleProvider';
 import { ModuleTemplatesContextProvider } from 'components/Modules/providers/ModuleTemplatesProvider';
 import { useGetEnvironmentParameters } from './useGetEnvironmentParameters';
@@ -87,18 +86,22 @@ export default function ClusterDetails({ currentCluster }) {
               <GardenerProvider />
               {kymaResourceLabels && (
                 <>
-                  <DynamicPageComponent.Column
-                    title={t('clusters.overview.global-account-id')}
-                  >
-                    {kymaResourceLabels['kyma-project.io/global-account-id'] ??
-                      EMPTY_TEXT_PLACEHOLDER}
-                  </DynamicPageComponent.Column>
-                  <DynamicPageComponent.Column
-                    title={t('clusters.overview.subaccount-id')}
-                  >
-                    {kymaResourceLabels['kyma-project.io/subaccount-id'] ??
-                      EMPTY_TEXT_PLACEHOLDER}
-                  </DynamicPageComponent.Column>
+                  {!!kymaResourceLabels[
+                    'kyma-project.io/global-account-id'
+                  ] && (
+                    <DynamicPageComponent.Column
+                      title={t('clusters.overview.global-account-id')}
+                    >
+                      {kymaResourceLabels['kyma-project.io/global-account-id']}
+                    </DynamicPageComponent.Column>
+                  )}
+                  {!!kymaResourceLabels['kyma-project.io/subaccount-id'] && (
+                    <DynamicPageComponent.Column
+                      title={t('clusters.overview.subaccount-id')}
+                    >
+                      {kymaResourceLabels['kyma-project.io/subaccount-id']}
+                    </DynamicPageComponent.Column>
+                  )}
                 </>
               )}
               {!environmentParametersLoading && !!natGatewayIps && (

--- a/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
@@ -20,10 +20,13 @@ context('Test Kyma Modules views', () => {
   });
 
   it('Check if edit is empty', () => {
-    cy.wait(500);
+    cy.wait(1000);
+
     cy.inspectTab('Edit');
 
     cy.contains('No modules installed').should('be.visible');
+
+    cy.wait(1000);
 
     cy.inspectTab('View');
   });

--- a/tests/integration/tests/kyma-namespace/test-oauth2.spec.js
+++ b/tests/integration/tests/kyma-namespace/test-oauth2.spec.js
@@ -106,6 +106,8 @@ context('Test OAuth2 Clients', () => {
     cy.contains('Ory Hydra Deprecation').should('be.visible');
 
     cy.contains('ui5-panel', 'OAuth2Clients').within((_$genericList) => {
+      cy.wait(1000);
+
       cy.typeInSearch(AUTH2_NAME);
 
       cy.contains('ui5-link', AUTH2_NAME).should('be.visible');

--- a/tests/integration/tests/namespace/test-reduced-permissions--configuration.spec.js
+++ b/tests/integration/tests/namespace/test-reduced-permissions--configuration.spec.js
@@ -95,7 +95,9 @@ context('Test reduced permissions 2', () => {
       .contains('Namespaces')
       .click();
 
-    cy.wait(500).typeInSearch('kube-public');
+    cy.wait(1000);
+
+    cy.typeInSearch('kube-public');
 
     cy.clickListLink('kube-public');
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- 'Global account' and 'Subaccount ID' values are now not displayed if they are not present

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
