### PR TITLE
feat: Set k8s probes

### DIFF
--- a/resources/base/busola/deployment.yaml
+++ b/resources/base/busola/deployment.yaml
@@ -38,6 +38,17 @@ spec:
             httpGet:
               port: 3001
               path: /
+          readinessProbe:
+            initialDelaySeconds: 5
+            httpGet:
+              port: 3001
+              path: /
+          livenessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            httpGet:
+              port: 3001
+              path: /
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- setup liveness and readiness probes in following way: readiness will fail after 3 tries every 10s consequent failures. So the pod will be cut from incoming network. The liveness prob will kill busola pod after 3 tries every 30s consequent failures.

**Related issue(s)**
https://github.com/kyma-project/busola/issues/4371

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
