### PR TITLE
chore: Fix refs warn and setState warn in cluster wizard

### DIFF
--- a/src/components/Clusters/components/AddClusterDialog.tsx
+++ b/src/components/Clusters/components/AddClusterDialog.tsx
@@ -1,4 +1,3 @@
-import { useRef, useState } from 'react';
 import { Dialog } from '@ui5/webcomponents-react';
 import { useTranslation } from 'react-i18next';
 import { ErrorBoundary } from 'shared/components/ErrorBoundary/ErrorBoundary';
@@ -9,12 +8,9 @@ import { showAddClusterWizardAtom } from 'state/showAddClusterWizardAtom';
 export function AddClusterDialog() {
   const { t } = useTranslation();
   const [showWizard, setShowWizard] = useAtom(showAddClusterWizardAtom);
-  const [kubeconfig, setKubeconfig] = useState(undefined);
-  const dialogRef = useRef(null);
 
   const handleCloseDialog = () => {
     setShowWizard(false);
-    setKubeconfig(undefined);
   };
 
   return (
@@ -24,16 +20,7 @@ export function AddClusterDialog() {
       headerText={t('clusters.add.title')}
       onClose={handleCloseDialog}
     >
-      <ErrorBoundary>
-        {showWizard ? (
-          <AddClusterWizard
-            kubeconfig={kubeconfig}
-            setKubeconfig={setKubeconfig}
-            dialogRef={dialogRef}
-          />
-        ) : null}
-        <div ref={dialogRef}></div>
-      </ErrorBoundary>
+      <ErrorBoundary>{showWizard ? <AddClusterWizard /> : null}</ErrorBoundary>
     </Dialog>
   );
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fix react refs warns 
- fix set state in useEffect

**Related issue(s)**
https://github.com/kyma-project/busola/issues/4396

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
