### PR TITLE
fix: Cluster data form changes no longer reset kubeconfig

### DIFF
--- a/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.jsx
+++ b/src/components/Clusters/components/KubeconfigUpload/KubeconfigUpload.jsx
@@ -46,7 +46,6 @@ export function KubeconfigUpload({ kubeconfig, setKubeconfig, formRef }) {
         setResource={(modified) => {
           if (modified) setKubeconfig({ ...modified });
         }}
-        onChange={updateKubeconfig}
         formElementRef={formRef}
         modeSelectorDisabled={
           kubeconfig ? !Object.keys(kubeconfig)?.length : !kubeconfig

--- a/src/components/Clusters/views/EditCluster/EditCluster.jsx
+++ b/src/components/Clusters/views/EditCluster/EditCluster.jsx
@@ -107,7 +107,6 @@ export const ClusterDataForm = ({
         label={t('clusters.token')}
         input={Inputs.Text}
         required
-        onChange={onChange}
         inputInfo={
           isGenericExec ? t('clusters.wizard.auth.exec-info') : undefined
         }
@@ -149,7 +148,6 @@ export const ClusterDataForm = ({
         input={Inputs.Text}
         required
         value={issuerUrl}
-        onChange={onChange}
         setValue={(val) => {
           createOIDC('issuerUrl', val);
         }}
@@ -159,7 +157,6 @@ export const ClusterDataForm = ({
         input={Inputs.Text}
         required
         value={clientId}
-        onChange={onChange}
         setValue={(val) => {
           createOIDC('clientId', val);
         }}
@@ -177,7 +174,6 @@ export const ClusterDataForm = ({
         defaultOpen
         title={t('clusters.labels.scopes')}
         value={scopes}
-        toExternal={onChange}
         setValue={(val) => {
           createOIDC('scopes', val);
         }}
@@ -235,7 +231,7 @@ export const ClusterDataForm = ({
                   { name: context },
                 ]);
               }
-              onChange();
+              onChange?.();
               setChosenContext(context);
               setResource({ ...kubeconfig });
             }}
@@ -256,7 +252,7 @@ export const ClusterDataForm = ({
           required
           value={authenticationType}
           setValue={(type) => {
-            onChange();
+            onChange?.();
             if (type === 'token') {
               delete kubeconfig?.users?.[userIndex]?.user?.exec;
               jp.value(kubeconfig, `$.users[${userIndex}].user.token`, null);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Cluster data form changes no longer reset kubeconfig
- ...
- ...

**Related issue(s)**
#4652
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
