### PR TITLE
fix: Edit mode and highlighted rows for Modules

### DIFF
--- a/src/components/Modules/ModulesList.tsx
+++ b/src/components/Modules/ModulesList.tsx
@@ -70,8 +70,17 @@ export default function ModulesList({ namespaced }: { namespaced: boolean }) {
     m?.resource?.kind === midColumn?.rawResourceTypeName &&
     m?.resource?.metadata?.name === midColumn?.resourceName &&
     (m?.resource?.metadata?.namespace ?? '') === (midColumn?.namespaceId ?? '');
+
+  const matchesTemplateData = (t: any) =>
+    t?.spec?.data?.kind === midColumn?.rawResourceTypeName &&
+    t?.spec?.data?.metadata?.name === midColumn?.resourceName;
+  const templateModuleName = (items?: any[]) =>
+    items?.find(matchesTemplateData)?.metadata?.labels?.[
+      'operator.kyma-project.io/module-name'
+    ];
   const layoutMatchedKyma = midColumn?.rawResourceTypeName
-    ? kymaResource?.status?.modules?.find(matchesLayout)?.name
+    ? (kymaResource?.status?.modules?.find(matchesLayout)?.name ??
+      templateModuleName(moduleTemplates?.items))
     : undefined;
   const layoutMatchedCommunity = midColumn?.rawResourceTypeName
     ? installedCommunityModules?.find(matchesLayout)?.name

--- a/src/components/Modules/ModulesList.tsx
+++ b/src/components/Modules/ModulesList.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useContext, useEffect, useMemo, useState } from 'react';
+import { RefObject, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Create, ResourceDescription } from 'components/Modules';
@@ -12,10 +12,10 @@ import { useProtectedResources } from 'shared/hooks/useProtectedResources';
 import { CommunityModulesList } from 'components/Modules/community/CommunityModulesList';
 import { CommunityModuleContext } from 'components/Modules/community/providers/CommunityModuleProvider';
 import { ModuleTemplatesContext } from './providers/ModuleTemplatesProvider';
-import { checkSelectedModule } from './support';
 import { useAtomValue } from 'jotai';
 import { columnLayoutAtom } from 'state/columnLayoutAtom';
 import { useFeature } from 'hooks/useFeature';
+import { useUrl } from 'hooks/useUrl';
 import { configFeaturesNames } from 'state/types';
 import { CommunityModulesDeleteBoxContext } from 'components/Modules/community/components/CommunityModulesDeleteBox';
 import { ProtectedResourceWarning } from 'shared/components/ProtectedResourcesButton';
@@ -26,6 +26,10 @@ export default function ModulesList({ namespaced }: { namespaced: boolean }) {
   useWindowTitle(t('kyma-modules.title'));
 
   const layoutState = useAtomValue(columnLayoutAtom);
+  const { clusterUrl, namespaceUrl } = useUrl();
+  const modulesListUrl = namespaced
+    ? namespaceUrl('kymamodules')
+    : clusterUrl('kymamodules');
   const { isEnabled: isCommunityModulesEnabled } = useFeature(
     configFeaturesNames.COMMUNITY_MODULES,
   );
@@ -59,26 +63,27 @@ export default function ModulesList({ namespaced }: { namespaced: boolean }) {
   >(undefined);
   const { isProtected, isProtectedResource } = useProtectedResources();
 
-  useEffect(() => {
-    if (
-      !installedCommunityModulesLoading &&
-      installedCommunityModules?.length
-    ) {
-      const timeoutId = setTimeout(() => {
-        const match = installedCommunityModules.find((moduleTemplate) =>
-          checkSelectedModule(moduleTemplate, layoutState),
-        );
-        // Only set, never clear — polling would otherwise wipe click selections.
-        if (match?.name) setSelectedCommunityEntry(match.name);
-      }, 0);
+  // Match on full CR identity — modules can share a kind, so matching on
+  // kind alone would cross-highlight unrelated rows.
+  const midColumn = layoutState?.midColumn;
+  const matchesLayout = (m: any) =>
+    m?.resource?.kind === midColumn?.rawResourceTypeName &&
+    m?.resource?.metadata?.name === midColumn?.resourceName &&
+    (m?.resource?.metadata?.namespace ?? '') === (midColumn?.namespaceId ?? '');
+  const layoutMatchedKyma = midColumn?.rawResourceTypeName
+    ? kymaResource?.status?.modules?.find(matchesLayout)?.name
+    : undefined;
+  const layoutMatchedCommunity = midColumn?.rawResourceTypeName
+    ? installedCommunityModules?.find(matchesLayout)?.name
+    : undefined;
 
-      return () => clearTimeout(timeoutId);
-    }
-  }, [
-    installedCommunityModulesLoading,
-    installedCommunityModules,
-    layoutState,
-  ]);
+  const isDetailsOpen = !!layoutState?.midColumn;
+  const displayedKymaEntry = isDetailsOpen
+    ? (layoutMatchedKyma ?? selectedKymaEntry)
+    : undefined;
+  const displayedCommunityEntry = isDetailsOpen
+    ? (layoutMatchedCommunity ?? selectedCommunityEntry)
+    : undefined;
 
   const filteredCommunityModules = useMemo(() => {
     if (!installedCommunityModules?.length) return [];
@@ -107,6 +112,7 @@ export default function ModulesList({ namespaced }: { namespaced: boolean }) {
       title={t('kyma-modules.title')}
       description={ResourceDescription}
       isFirstColumnWithEdit={true}
+      layoutCloseUrl={modulesListUrl}
       content={
         <>
           {kymaResource && (
@@ -122,7 +128,7 @@ export default function ModulesList({ namespaced }: { namespaced: boolean }) {
               protectedResource={showProtectedResourceWarning}
               setOpenedModuleIndex={setOpenedManagedModuleIndex}
               handleResourceDelete={handleResourceDelete}
-              customSelectedEntry={selectedKymaEntry}
+              customSelectedEntry={displayedKymaEntry}
               setSelectedEntry={(name) => {
                 setSelectedKymaEntry(name);
                 setSelectedCommunityEntry(undefined);
@@ -139,7 +145,7 @@ export default function ModulesList({ namespaced }: { namespaced: boolean }) {
               namespaced={namespaced}
               setOpenedModuleIndex={setOpenedCommunityModuleIndex}
               handleResourceDelete={handleCommunityModuleDelete}
-              customSelectedEntry={selectedCommunityEntry}
+              customSelectedEntry={displayedCommunityEntry}
               setSelectedEntry={(name) => {
                 setSelectedCommunityEntry(name);
                 setSelectedKymaEntry(undefined);

--- a/src/components/Modules/components/ModulesListRows.tsx
+++ b/src/components/Modules/components/ModulesListRows.tsx
@@ -97,14 +97,16 @@ export const ModulesListRows = ({
 
   useEffect(() => {
     const checkIfNamespaceIsMissing = async () => {
-      if (currentModuleTemplate?.spec?.data?.metadata?.namespace) {
-        setModuleResourceWithNamespace(currentModuleTemplate?.spec.data);
-      } else {
-        const newModuleResource = await populateWithNamespace(
-          currentModuleTemplate?.spec.data,
-        );
-        setModuleResourceWithNamespace(newModuleResource);
+      const data = currentModuleTemplate?.spec?.data;
+      if (!data) {
+        setModuleResourceWithNamespace(null);
+        return;
       }
+      if (data.metadata?.namespace) {
+        setModuleResourceWithNamespace(data);
+        return;
+      }
+      setModuleResourceWithNamespace(await populateWithNamespace(data));
     };
     checkIfNamespaceIsMissing();
   }, [currentModuleTemplate]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/components/Modules/hooks/useModuleNavigation.ts
+++ b/src/components/Modules/hooks/useModuleNavigation.ts
@@ -117,9 +117,9 @@ export function useModuleNavigation({
     }
 
     const kind = resource.kind;
-    if (!findExtension(kind, extensions) && !findCrd(kind, crds)) {
-      return;
-    }
+    const hasExtension = !!findExtension(kind, extensions);
+    const moduleCrd = findCrd(kind, crds);
+    if (!hasExtension && !moduleCrd) return;
 
     const { group, version } = extractApiGroupVersion(resource.apiVersion);
 
@@ -151,11 +151,8 @@ export function useModuleNavigation({
           liveResource.metadata?.namespace ?? resource.metadata.namespace;
       }
     } catch {
-      // Fetch failed — fall through with template data
+      // best-effort enrichment — continue with template metadata
     }
-
-    const hasExtension = !!findExtension(kind, extensions);
-    const moduleCrd = findCrd(kind, crds);
 
     const partialPath = createModulePartialPath(
       hasExtension,

--- a/src/components/Modules/hooks/useModuleNavigation.ts
+++ b/src/components/Modules/hooks/useModuleNavigation.ts
@@ -60,14 +60,19 @@ export function useModuleNavigation({
   const getScope = useGetScope();
   const fetch = useFetch();
 
-  const hasDetailsLink = (resource: {
-    name: string;
-    resource?: { kind: string };
-  }) => {
-    const kind = resource?.resource?.kind ?? '';
-    const hasExtension = !!findExtension(kind, extensions);
-    const hasCrd = !!findCrd(kind, crds);
-    return hasExtension || hasCrd;
+  const hasDetailsLink = (resource: ModuleEntry) => {
+    const kind =
+      resource?.resource?.kind ??
+      findModuleTemplate(
+        moduleTemplates,
+        resource?.name,
+        resource?.channel ?? '',
+        resource?.version ?? '',
+        resource?.template,
+        resource?.namespace,
+      )?.spec?.data?.kind ??
+      '';
+    return !!findExtension(kind, extensions) || !!findCrd(kind, crds);
   };
 
   const customColumnLayout = (resource: ModuleEntry) => {

--- a/src/components/Modules/support.ts
+++ b/src/components/Modules/support.ts
@@ -236,8 +236,10 @@ export const findModuleTemplate = (
         moduleTemplate.metadata.labels[
           'operator.kyma-project.io/module-name'
         ] &&
-      !moduleTemplate.spec.channel &&
-      moduleTemplate.spec.version === version &&
+      (!channel ||
+        !moduleTemplate.spec.channel ||
+        moduleTemplate.spec.channel === channel) &&
+      (!version || moduleTemplate.spec.version === version) &&
       (!namespace || moduleTemplate.metadata.namespace === namespace),
   );
 };

--- a/src/shared/components/DynamicPageComponent/DynamicPageComponent.tsx
+++ b/src/shared/components/DynamicPageComponent/DynamicPageComponent.tsx
@@ -432,6 +432,8 @@ export const DynamicPageComponent = ({
 
               const params = new URLSearchParams(window.location.search);
               let showEdit = null;
+              let targetPath = window.location.pathname;
+              let closeSideColumns = false;
 
               if (newTabName === 'edit') {
                 showEdit = { resource: null } as ShowEdit;
@@ -439,9 +441,13 @@ export const DynamicPageComponent = ({
                 if (layoutColumn.layout !== 'OneColumn') {
                   if (isFirstColumnWithEdit) {
                     params.set('editColumn', 'startColumn');
-                    showEdit = layoutColumn?.showEdit;
+                    params.set('showEdit', 'true');
+                    params.delete('layout');
+                    showEdit = layoutColumn?.showEdit ?? showEdit;
+                    closeSideColumns = true;
+                    if (layoutCloseUrl) targetPath = layoutCloseUrl;
                   } else {
-                    params.set('editColumn', 'startColumn');
+                    params.delete('editColumn');
                     params.set('showEdit', 'true');
                   }
                 } else {
@@ -454,8 +460,14 @@ export const DynamicPageComponent = ({
               setLayoutColumn({
                 ...layoutColumn,
                 showEdit,
+                ...(closeSideColumns && {
+                  midColumn: null,
+                  endColumn: null,
+                  layout: 'OneColumn',
+                  showCreate: null,
+                }),
               });
-              navigate(`${window.location.pathname}?${params.toString()}`);
+              navigate(`${targetPath}?${params.toString()}`);
             });
           }}
         >

--- a/src/shared/components/GenericList/components/TableBody.tsx
+++ b/src/shared/components/GenericList/components/TableBody.tsx
@@ -120,7 +120,7 @@ export const TableBody = ({
   }
 
   return pagedItems.map((e: FilteredEntriesType, index: number) => {
-    // Module entries use `.name` instead of `.metadata.name`
+    // Module entries match on `.name` since they lack `.metadata.name`.
     let isModuleSelected;
     if (e?.name && entrySelected) {
       const namespaceMatches =
@@ -137,6 +137,7 @@ export const TableBody = ({
       entrySelected instanceof Array
         ? entrySelected.some((entry) => entry === e?.metadata?.name)
         : entrySelected === e?.metadata?.name;
+    const hasDetails = hasRowDetails?.(e) ?? true;
     return (
       <RowRenderer
         isSelected={
@@ -152,8 +153,8 @@ export const TableBody = ({
         entry={e}
         actions={actions}
         rowRenderer={rowRenderer}
-        displayArrow={displayArrow && (hasRowDetails?.(e) ?? true)}
-        hasDetails={hasRowDetails?.(e) ?? true}
+        displayArrow={displayArrow && hasDetails}
+        hasDetails={hasDetails}
         enableColumnLayout={enableColumnLayout}
       />
     );

--- a/tests/integration/fixtures/community-modules/busola-0-11.yaml
+++ b/tests/integration/fixtures/community-modules/busola-0-11.yaml
@@ -8,6 +8,14 @@ metadata:
   name: busola-0-11
   namespace: kyma-system
 spec:
+  data:
+    apiVersion: operator.kyma-project.io/v1beta2
+    kind: Kyma
+    metadata:
+      name: default
+      namespace: kyma-system
+    spec:
+      channel: regular
   descriptor:
     component:
       componentReferences: []

--- a/tests/integration/fixtures/community-modules/busola-0-12.yaml
+++ b/tests/integration/fixtures/community-modules/busola-0-12.yaml
@@ -8,6 +8,14 @@ metadata:
   name: busola-0-12
   namespace: kyma-system
 spec:
+  data:
+    apiVersion: operator.kyma-project.io/v1beta2
+    kind: Kyma
+    metadata:
+      name: default
+      namespace: kyma-system
+    spec:
+      channel: regular
   descriptor:
     component:
       componentReferences: []

--- a/tests/integration/support/commands.js
+++ b/tests/integration/support/commands.js
@@ -145,7 +145,10 @@ Cypress.Commands.add('getEndColumn', () => {
 
 Cypress.Commands.add(
   'deleteInDetails',
-  (resourceType, resourceName, columnLayout = false) => {
+  (resourceType, resourceName, columnLayout = false, options = {}) => {
+    const { customHeaderText = null } = options;
+    const headerText = customHeaderText || `Delete ${resourceType}`;
+
     if (columnLayout) {
       cy.wait(1000); //wait for button
 
@@ -157,9 +160,9 @@ Cypress.Commands.add(
       cy.get('ui5-button').contains('Delete').should('be.visible').click();
     }
 
-    cy.contains(`Delete ${resourceType} ${resourceName}`);
+    cy.contains(customHeaderText || `Delete ${resourceType} ${resourceName}`);
 
-    cy.get(`[header-text="Delete ${resourceType}"]:visible`)
+    cy.get(`[header-text="${headerText}"]:visible`)
       .find('[data-testid="delete-confirmation"]')
       .click();
 
@@ -216,7 +219,13 @@ Cypress.Commands.add(
       cy.checkItemOnGenericListLink(resourceName);
     }
 
-    cy.get('ui5-button[data-testid="delete"]').click();
+    if (parentSelector) {
+      cy.get(parentSelector)
+        .find('ui5-button[data-testid="delete"]:visible')
+        .click();
+    } else {
+      cy.get('ui5-button[data-testid="delete"]').click();
+    }
 
     if (confirmationEnabled) {
       const headerText = customHeaderText || `Delete ${resourceType}`;

--- a/tests/integration/tests/kyma-cluster/test-community-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-community-modules.spec.js
@@ -150,6 +150,21 @@ context('Test Community Modules views', () => {
       .should('be.visible');
   });
 
+  it('Opens module details with the correct resource when a row is clicked', () => {
+    cy.wait(1000);
+
+    cy.get('.community-modules-list')
+      .find('ui5-table-row')
+      .contains('busola')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+    cy.getMidColumn().contains('Kyma').should('be.visible');
+    cy.getMidColumn().contains('default').should('be.visible');
+
+    cy.closeMidColumn();
+  });
+
   it('Retains row highlight and details after refresh', () => {
     cy.get('.community-modules-list')
       .find('ui5-table-row')
@@ -195,7 +210,14 @@ context('Test Community Modules views', () => {
 
     cy.getMidColumn().should('be.visible');
 
-    cy.get('.kyma-modules > ui5-tabcontainer').inspectTab('Edit');
+    // Pick the outer page's tabcontainer (first one), not the midColumn's.
+    cy.get('.kyma-modules ui5-tabcontainer')
+      .first()
+      .find('[role="tablist"]')
+      .find('[role="tab"]')
+      .contains('Edit')
+      .should('be.visible')
+      .click();
 
     cy.getMidColumn().should('not.be.visible');
 

--- a/tests/integration/tests/kyma-cluster/test-community-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-community-modules.spec.js
@@ -150,6 +150,58 @@ context('Test Community Modules views', () => {
       .should('be.visible');
   });
 
+  it('Retains row highlight and details after refresh', () => {
+    cy.get('.community-modules-list')
+      .find('ui5-table-row')
+      .contains('busola')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+
+    cy.reload();
+    cy.wait(2000);
+
+    cy.getMidColumn().should('be.visible');
+    cy.get('.community-modules-list')
+      .find('ui5-table-row.row-selected')
+      .contains('busola')
+      .should('be.visible');
+
+    cy.closeMidColumn();
+  });
+
+  it('Edit inside module details keeps the list in View mode', () => {
+    cy.get('.community-modules-list')
+      .find('ui5-table-row')
+      .contains('busola')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+    cy.getMidColumn().inspectTab('Edit');
+
+    cy.get('.community-modules-list')
+      .find('ui5-table-row')
+      .contains('busola')
+      .should('be.visible');
+
+    cy.closeMidColumn();
+  });
+
+  it('Entering Edit mode on the list closes open details', () => {
+    cy.get('.community-modules-list')
+      .find('ui5-table-row')
+      .contains('busola')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+
+    cy.get('.kyma-modules > ui5-tabcontainer').inspectTab('Edit');
+
+    cy.getMidColumn().should('not.be.visible');
+
+    cy.inspectTab('View');
+  });
+
   it('Test changing Community Module version', () => {
     cy.inspectTab('Edit');
 

--- a/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
@@ -135,6 +135,79 @@ context('Test Kyma Modules views', () => {
     cy.inspectTab('View');
   });
 
+  it('Opens module details with the correct resource when a row is clicked', () => {
+    cy.wait(1000);
+
+    cy.get('.modules-list')
+      .find('ui5-table-row')
+      .contains('api-gateway')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+    cy.getMidColumn().contains('APIGateway').should('be.visible');
+    cy.getMidColumn().contains('default').should('be.visible');
+
+    cy.closeMidColumn();
+  });
+
+  it('Retains row highlight and details after refresh', () => {
+    cy.get('.modules-list')
+      .find('ui5-table-row')
+      .contains('api-gateway')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+
+    cy.reload();
+    cy.wait(2000);
+
+    cy.getMidColumn().should('be.visible');
+    cy.get('.modules-list')
+      .find('ui5-table-row.row-selected')
+      .contains('api-gateway')
+      .should('be.visible');
+
+    cy.closeMidColumn();
+  });
+
+  it('Edit inside module details keeps the list in View mode', () => {
+    cy.get('.modules-list')
+      .find('ui5-table-row')
+      .contains('api-gateway')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+    cy.getMidColumn().inspectTab('Edit');
+
+    cy.get('.modules-list')
+      .find('ui5-table-row')
+      .contains('api-gateway')
+      .should('be.visible');
+
+    cy.closeMidColumn();
+  });
+
+  it('Entering Edit mode on the list closes open details', () => {
+    cy.get('.modules-list')
+      .find('ui5-table-row')
+      .contains('api-gateway')
+      .click();
+
+    cy.getMidColumn().should('be.visible');
+
+    cy.get('.kyma-modules ui5-tabcontainer')
+      .first()
+      .find('[role="tablist"]')
+      .find('[role="tab"]')
+      .contains('Edit')
+      .should('be.visible')
+      .click();
+
+    cy.getMidColumn().should('not.be.visible');
+
+    cy.inspectTab('View');
+  });
+
   it('Test changing Module Channel', () => {
     cy.inspectTab('Edit');
 
@@ -162,13 +235,15 @@ context('Test Kyma Modules views', () => {
 
     cy.inspectTab('View');
 
-    cy.wait(10000);
-
-    cy.get('ui5-table-row').contains('eventing').should('be.visible');
-
-    cy.get('ui5-table-row').contains('fast').should('be.visible');
-
-    cy.get('ui5-table-row').contains('Overridden').should('be.visible');
+    cy.get('ui5-table-row', { timeout: 15000 })
+      .contains('eventing')
+      .should('be.visible');
+    cy.get('ui5-table-row', { timeout: 15000 })
+      .contains('fast')
+      .should('be.visible');
+    cy.get('ui5-table-row', { timeout: 15000 })
+      .contains('Overridden')
+      .should('be.visible');
   });
 
   it('Test changing Module Channel to Predefined', () => {
@@ -196,11 +271,12 @@ context('Test Kyma Modules views', () => {
 
     cy.inspectTab('View');
 
-    cy.wait(10000);
-
-    cy.get('ui5-table-row').contains('eventing').should('be.visible');
-
-    cy.get('ui5-table-row').contains('Overridden').should('not.be.exist');
+    cy.get('ui5-table-row', { timeout: 15000 })
+      .contains('eventing')
+      .should('be.visible');
+    cy.contains('ui5-table-row', 'Overridden', { timeout: 15000 }).should(
+      'not.exist',
+    );
   });
 
   it('Test deleting Modules from List and Details', { retries: 3 }, () => {
@@ -210,23 +286,28 @@ context('Test Kyma Modules views', () => {
       customHeaderText: 'Delete Module',
     });
 
-    // Uncomment after adding local KLM
-    // cy.typeInSearch('api-gateway');
-    //
-    // cy.get('ui5-table-row')
-    //   .contains('api-gateway')
-    //   .click();
-    //
-    // cy.deleteInDetails('Module', 'api-gateway', true);
-    //
-    // cy.wait(20000);
-    //
-    // cy.get('ui5-input[id^=search-]:visible')
-    //   .find('input')
-    //   .clear();
-    //
-    // cy.get('ui5-table')
-    //   .contains('ui5-illustrated-message', 'No modules')
-    //   .should('be.visible');
+    cy.get('.modules-list')
+      .find('ui5-input[id^=search-]:visible')
+      .find('input')
+      .type('api-gateway');
+
+    cy.get('.modules-list')
+      .find('ui5-table-row')
+      .contains('api-gateway')
+      .click();
+
+    cy.deleteInDetails('Module', 'api-gateway', true, {
+      customHeaderText: 'Delete Module',
+    });
+
+    cy.get('.modules-list')
+      .find('ui5-input[id^=search-]:visible')
+      .find('input')
+      .clear();
+
+    cy.get('.modules-list', { timeout: 15000 })
+      .find('ui5-illustrated-message')
+      .contains('No modules')
+      .should('be.visible');
   });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
1. Edit-mode bugs are fixed:
- Clicking Edit inside module details no longer switches the modules list
  into Edit mode (independent split-pane views).
- Clicking Edit on the modules list closes any open module details panel.
2. Row-highlight bugs are fixed:
- Refreshing the page while module details are open retains the highlight
  on the corresponding row (both Kyma and community modules).
- The row highlight is no longer incorrectly carried over to a different
  module when multiple modules share a CR kind (matching now uses full
  CR identity: kind + name + namespace).
3. Other module fixes carried along while investigating the above:
- `findModuleTemplate` now actually uses its `channel` argument; previously
  Kyma module templates with a channel couldn't be found via the fallback
  match path.
- `hasDetailsLink` now mirrors `handleClickResource`'s template fallback,
  so a module's row visually matches its clickability.
- Community modules without `spec.data` (manager-only modules) no longer
  crash with a `useGetScope` TypeError on the modules list page.
4. Integration tests:
- Added coverage for the edit-mode and refresh-highlight behaviors in
  both `test-kyma-modules.spec.js` and `test-community-modules.spec.js`.

**Related issue(s)**
#4828
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
