### PR TITLE
fix: Code scanning alert no. 59: Server-side request forgery

### DIFF
--- a/backend/modules/communityRouter.js
+++ b/backend/modules/communityRouter.js
@@ -20,7 +20,7 @@ async function handleGetCommunityResource(req, res) {
     const allowedDomains = ['githubusercontent.com', 'github.com', 'github.io'];
     const isAllowedHost = allowedDomains.some(
       (domain) =>
-        url.hostname === domain || url.hostname.endsWith(`.${domain}`)
+        url.hostname === domain || url.hostname.endsWith(`.${domain}`),
     );
     if (url.protocol !== 'https:' || !isAllowedHost) {
       return res.status(400).json({

--- a/backend/modules/communityRouter.js
+++ b/backend/modules/communityRouter.js
@@ -18,10 +18,11 @@ async function handleGetCommunityResource(req, res) {
     const url = new URL(link);
     // Only allow HTTPS protocol and restrict to specific trusted domains.
     const allowedDomains = ['githubusercontent.com', 'github.com', 'github.io'];
-    if (
-      url.protocol !== 'https:' ||
-      !allowedDomains.some((domain) => url.hostname.endsWith(domain))
-    ) {
+    const isAllowedHost = allowedDomains.some(
+      (domain) =>
+        url.hostname === domain || url.hostname.endsWith(`.${domain}`)
+    );
+    if (url.protocol !== 'https:' || !isAllowedHost) {
       return res.status(400).json({
         message: 'Invalid or untrusted link provided.',
       });


### PR DESCRIPTION
Potential fix for [https://github.com/kyma-project/busola/security/code-scanning/59](https://github.com/kyma-project/busola/security/code-scanning/59)

The best fix is to keep current functionality (accepting user-provided HTTPS links to trusted GitHub-related hosts) but make host validation strict and unambiguous:

1. Parse the URL as already done.
2. Enforce `https:`.
3. Validate hostnames using **exact match or subdomain match with a dot boundary**:
   - allow `hostname === domain`
   - or `hostname.endsWith('.' + domain)`
4. Reject everything else before calling `fetch`.

This removes the suffix-bypass problem (`evilgithub.com`) while preserving valid trusted domains and subdomains (`raw.githubusercontent.com`, etc.).

In `backend/modules/communityRouter.js`, update the validation block around lines 20–24 by introducing a helper predicate for trusted host matching and use it in the condition. No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
