### PR TITLE
chore: Unify code card toolbars with edit section toolbars

### DIFF
--- a/src/shared/components/ReadonlyEditorPanel.tsx
+++ b/src/shared/components/ReadonlyEditorPanel.tsx
@@ -67,17 +67,21 @@ export function ReadonlyEditorPanel({
   return (
     <UI5Panel
       title={title}
-      headerActions={headerActions}
+      headerActions={
+        <>
+          {headerActions}
+          <EditorActions
+            val={valueState}
+            editor={editor}
+            title={title}
+            saveDisabled={true}
+          />
+        </>
+      }
       accessibleName={`${title} ${t('common.labels.read-only')} ${t(
         'common.ariaLabel.editor',
       )}`}
     >
-      <EditorActions
-        val={valueState}
-        editor={editor}
-        title={title}
-        saveDisabled={true}
-      />
       <Editor
         height="20em"
         value={valueState}

--- a/src/shared/contexts/YamlEditorContext/EditorActions.scss
+++ b/src/shared/contexts/YamlEditorContext/EditorActions.scss
@@ -1,3 +1,8 @@
 .action-button {
   margin-right: 4px;
 }
+
+.editor-actions-section {
+  display: flex;
+  align-items: center;
+}

--- a/src/shared/contexts/YamlEditorContext/EditorActions.tsx
+++ b/src/shared/contexts/YamlEditorContext/EditorActions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button } from '@ui5/webcomponents-react';
+import { Button, Icon, ObjectStatus } from '@ui5/webcomponents-react';
 import { saveAs } from 'file-saver';
 import { useTranslation } from 'react-i18next';
 
@@ -125,7 +125,17 @@ export function EditorActions({
   const { t } = useTranslation();
 
   return (
-    <section>
+    <section className="editor-actions-section">
+      {readOnly && (
+        <ObjectStatus
+          icon={<Icon name="locked" />}
+          showDefaultIcon
+          state="Critical"
+          style={{ textOverflow: 'ellipsis', marginRight: '0.5rem' }}
+        >
+          {t('common.labels.read-only')}
+        </ObjectStatus>
+      )}
       {!revertHidden && (
         <Button
           onClick={() => {
@@ -179,11 +189,6 @@ export function EditorActions({
           }
           disabled={saveDisabled || !editor}
         />
-      )}
-      {readOnly && (
-        <span style={{ color: 'var(--sapNeutralTextColor,#6a6d70)' }}>
-          {t('common.labels.read-only')}
-        </span>
       )}
     </section>
   );


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Unified toolbars on read-only code cards with the ones present in edit section of resource pages
- Changed `Read-only mode` text to orange ObjectStatus

**Related issue(s)**
Resolves #4807
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
