### PR TITLE
fix: Replace backend's per-IP rate limiting 

### DIFF
--- a/backend/companion/companionRouter.js
+++ b/backend/companion/companionRouter.js
@@ -5,6 +5,11 @@ import { TokenManager } from './TokenManager';
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
 import escape from 'lodash.escape';
+import {
+  getK8sCredentialFromBody,
+  hashCredential,
+  requireCredential,
+} from '../utils/rate-limit-key.js';
 
 const config = require('../config.js');
 
@@ -22,13 +27,15 @@ const COMPANION_PUBLIC_KEY_URL = companionApiBaseUrl
 const SKIP_AUTH = config.features?.KYMA_COMPANION?.config?.skipAuth ?? false;
 const router = express.Router();
 
-// Rate limiter: Max 200 requests per 1 minutes per IP
+const requireCompanionCredential = requireCredential(getK8sCredentialFromBody);
+
 const companionRateLimiter = rateLimit({
   windowMs: 1 * 60 * 1000,
   max: 200,
   message: 'Too many requests, please try again later.',
   standardHeaders: true,
   legacyHeaders: false,
+  keyGenerator: (req) => hashCredential(getK8sCredentialFromBody(req), 'cred'),
 });
 
 router.use(express.json());
@@ -297,9 +304,24 @@ async function handleFollowUpSuggestions(req, res) {
   }
 }
 
-router.post('/public-key', companionRateLimiter, handlePublicKey);
-router.post('/suggestions', companionRateLimiter, handlePromptSuggestions);
-router.post('/messages', companionRateLimiter, handleChatMessage);
-router.post('/followup', companionRateLimiter, handleFollowUpSuggestions);
+router.post('/public-key', handlePublicKey);
+router.post(
+  '/suggestions',
+  requireCompanionCredential,
+  companionRateLimiter,
+  handlePromptSuggestions,
+);
+router.post(
+  '/messages',
+  requireCompanionCredential,
+  companionRateLimiter,
+  handleChatMessage,
+);
+router.post(
+  '/followup',
+  requireCompanionCredential,
+  companionRateLimiter,
+  handleFollowUpSuggestions,
+);
 
 export default router;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,7 +1,10 @@
 /* global  require, process, __dirname */
-import { handleK8sRequests } from './kubernetes/handler';
-import { proxyHandler, proxyRateLimiter } from './proxy.js';
-import rateLimit from 'express-rate-limit';
+import {
+  handleK8sRequests,
+  k8sRateLimiter,
+  requireK8sCredential,
+} from './kubernetes/handler';
+import { proxyHandler } from './proxy.js';
 import companionRouter from './companion/companionRouter';
 import communityRouter from './modules/communityRouter';
 import { pinoMiddleware, createSlowRequestLogger } from './logging';
@@ -59,17 +62,9 @@ const SLOW_REQUEST_THRESHOLD_MS = parseInt(
 );
 app.use(createSlowRequestLogger(SLOW_REQUEST_THRESHOLD_MS));
 
-app.use('/proxy', proxyRateLimiter, proxyHandler);
+app.use('/proxy', proxyHandler);
 
-const kubeconfigRateLimiter = rateLimit({
-  windowMs: 1 * 60 * 1000,
-  max: 30,
-  message: 'Too many requests, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-app.get('/backend/kubeconfig', kubeconfigRateLimiter, (req, res) => {
+app.get('/backend/kubeconfig', (req, res) => {
   const kubeconfigDir = path.join(
     __dirname,
     process.env.IS_DOCKER ? '/core-ui/kubeconfig' : '../public/kubeconfig',
@@ -108,44 +103,19 @@ const port = process.env.PORT || 3001;
 const address = process.env.ADDRESS || 'localhost';
 const isDocker = process.env.IS_DOCKER === 'true';
 
-// TEMPORARY: proxy/IP topology diagnostic — remove after investigation
-app.get('/backend/_diagnostic-ip', (req, res) => {
-  const xff = req.headers['x-forwarded-for'] || '';
-  const xffEntries = xff
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const info = {
-    reqIp: req.ip,
-    reqIps: req.ips,
-    socketRemoteAddress: req.socket?.remoteAddress,
-    xForwardedFor: xff,
-    xForwardedForEntries: xffEntries,
-    xForwardedForCount: xffEntries.length,
-    xForwardedProto: req.headers['x-forwarded-proto'] || null,
-    xForwardedHost: req.headers['x-forwarded-host'] || null,
-    xRealIp: req.headers['x-real-ip'] || null,
-    via: req.headers['via'] || null,
-    forwarded: req.headers['forwarded'] || null,
-    trustProxySetting: app.get('trust proxy'),
-  };
-  req.log.info(info, 'ip-diagnostic');
-  res.json(info);
-});
-
 if (isDocker) {
   // Running in dev mode
   // yup, order matters here
   serveMonaco(app);
   app.use('/backend/ai-chat', companionRouter);
-  app.use('/backend/modules', communityRouter);
-  app.use('/backend', handleK8sRequests);
+  app.use('/backend/modules', requireK8sCredential, communityRouter);
+  app.use('/backend', requireK8sCredential, k8sRateLimiter, handleK8sRequests);
   serveStaticApp(app, '/', '/core-ui');
 } else {
   // Running in prod mode
   app.use('/backend/ai-chat', companionRouter);
-  app.use('/backend/modules', communityRouter);
-  app.use('/backend', handleK8sRequests);
+  app.use('/backend/modules', requireK8sCredential, communityRouter);
+  app.use('/backend', requireK8sCredential, k8sRateLimiter, handleK8sRequests);
 }
 
 process.on('SIGINT', function () {

--- a/backend/kubernetes/handler.js
+++ b/backend/kubernetes/handler.js
@@ -1,14 +1,34 @@
 /* global Buffer, require */
+import rateLimit from 'express-rate-limit';
 import { handleDockerDesktopSubsitution } from '../docker-desktop-substitution';
 import { filters } from '../request-filters';
 import { pipeline } from 'stream/promises';
 import { tokenAuthAgent } from '../utils/https-agent.js';
+import {
+  getK8sCredentialFromHeaders,
+  hashCredential,
+  requireCredential,
+} from '../utils/rate-limit-key.js';
 import { buildK8sRequestPath } from './path-utils.js';
 
 const https = require('https');
 const http = require('http');
 const fs = require('fs');
 const escape = require('lodash.escape');
+
+export const requireK8sCredential = requireCredential(
+  getK8sCredentialFromHeaders,
+);
+
+export const k8sRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000,
+  max: 2000,
+  message: 'Too many requests, please try again later.',
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) =>
+    hashCredential(getK8sCredentialFromHeaders(req), 'k8s'),
+});
 
 // https://github.tools.sap/sgs/SAP-Global-Trust-List/blob/master/approved.pem
 const certs = fs.readFileSync('certs.pem', 'utf8');

--- a/backend/proxy.js
+++ b/backend/proxy.js
@@ -1,18 +1,8 @@
 /* global Buffer */
-import rateLimit from 'express-rate-limit';
 import { request as httpsRequest } from 'https';
 import { URL } from 'url';
 import { pipeline } from 'stream/promises';
 import { isPrivateAddressCached, isValidHost } from './utils/network-utils.js';
-
-// Rate limiter: Max 100 requests per 1 minutes per IP
-const proxyRateLimiter = rateLimit({
-  windowMs: 1 * 60 * 1000,
-  max: 100,
-  message: 'Too many requests from this IP, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 async function proxyHandler(req, res) {
   const targetUrl = req.query.url;
@@ -77,4 +67,4 @@ async function proxyHandler(req, res) {
   }
 }
 
-export { proxyHandler, proxyRateLimiter };
+export { proxyHandler };

--- a/backend/statics.js
+++ b/backend/statics.js
@@ -1,20 +1,10 @@
 /* global __dirname */
-// Rate limiter: Max 200 requests per 1 minutes per IP
-import rateLimit from 'express-rate-limit';
 import express from 'express';
 import path from 'path';
 
-const limiter = rateLimit({
-  windowMs: 1 * 60 * 1000,
-  max: 200,
-  message: 'Too many requests from this IP, please try again later.',
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
 export const serveStaticApp = (app, requestPath, directoryPath) => {
   app.use(requestPath, express.static(path.join(__dirname, directoryPath)));
-  app.get(requestPath + '*splat', limiter, (_, res) =>
+  app.get(requestPath + '*splat', (_, res) =>
     res.sendFile(path.join(__dirname + directoryPath + '/index.html')),
   );
 };

--- a/backend/utils/rate-limit-key.js
+++ b/backend/utils/rate-limit-key.js
@@ -1,0 +1,47 @@
+import crypto from 'crypto';
+
+export function hashCredential(credential, prefix) {
+  return (
+    prefix +
+    ':' +
+    crypto.createHash('sha256').update(credential).digest('hex').slice(0, 32)
+  );
+}
+
+function tryParseBody(req) {
+  try {
+    if (typeof req.body === 'object' && !ArrayBuffer.isView(req.body)) {
+      return req.body;
+    }
+    if (req.body) {
+      return JSON.parse(req.body.toString());
+    }
+  } catch (_) {
+    // ignore — extractors must not throw
+  }
+  return null;
+}
+
+export function getK8sCredentialFromHeaders(req) {
+  return (
+    req.headers['x-k8s-authorization'] ||
+    req.headers['x-client-certificate-data']
+  );
+}
+
+export function getK8sCredentialFromBody(req) {
+  const parsed = tryParseBody(req);
+  return parsed?.clusterToken || parsed?.clientCertificateData;
+}
+
+// Reject before the rate limiter when no credential is present, so a missing
+// credential cannot fall back to req.ip and become a global throttle key.
+export function requireCredential(extractCredential) {
+  return function (req, res, next) {
+    if (!extractCredential(req)) {
+      res.status(400).json({ error: 'Missing K8s credentials.' });
+      return;
+    }
+    next();
+  };
+}

--- a/backend/utils/rate-limit-key.js
+++ b/backend/utils/rate-limit-key.js
@@ -16,8 +16,12 @@ function tryParseBody(req) {
     if (req.body) {
       return JSON.parse(req.body.toString());
     }
-  } catch (_) {
-    // ignore — extractors must not throw
+  } catch (err) {
+    // Don't rethrow — runs inside the rate-limit keyGenerator which must not throw.
+    req.log?.warn(
+      err,
+      'Failed to parse request body for credential extraction',
+    );
   }
   return null;
 }

--- a/backend/utils/rate-limit-key.js
+++ b/backend/utils/rate-limit-key.js
@@ -34,8 +34,8 @@ export function getK8sCredentialFromBody(req) {
   return parsed?.clusterToken || parsed?.clientCertificateData;
 }
 
-// Reject before the rate limiter when no credential is present, so a missing
-// credential cannot fall back to req.ip and become a global throttle key.
+// Reject before the rate limiter when no credential is present, so the
+// keyGenerator never has to handle a missing credential.
 export function requireCredential(extractCredential) {
   return function (req, res, next) {
     if (!extractCredential(req)) {

--- a/backend/utils/rate-limit-key.js
+++ b/backend/utils/rate-limit-key.js
@@ -17,7 +17,6 @@ function tryParseBody(req) {
       return JSON.parse(req.body.toString());
     }
   } catch (err) {
-    // Don't rethrow — runs inside the rate-limit keyGenerator which must not throw.
     req.log?.warn(
       err,
       'Failed to parse request body for credential extraction',

--- a/docs/user/01-40-deploy-access-kubernetes.md
+++ b/docs/user/01-40-deploy-access-kubernetes.md
@@ -7,6 +7,14 @@
 To expose Busola, you can use [APIRule](https://github.com/kyma-project/busola/tree/main/resources/istio), [Ingress](https://github.com/kyma-project/busola/tree/main/resources/ingress), or create your own exposing mechanism.
 For more details about environment configuration, see [Environment-Specific Settings](../user/technical-reference/configuration.md#environment-specific-settings).
 
+### Per-IP Rate Limiting
+
+The shipped Ingress sets per-IP limits for `ingress-nginx`: 50 RPS sustained (~250 burst) and 50 concurrent connections per source IP. Tune in `resources/ingress/ingress.yaml`.
+
+The annotations are nginx-specific and silently ignored by other controllers (Traefik, HAProxy, etc.) — for those, configure equivalent limits at your own edge. If you run ingress-nginx but it's not the cluster's default IngressClass, add `ingressClassName: nginx` to the Ingress so the annotations take effect.
+
+For APIRule (Istio) deployments, per-IP rate limiting is not configured by default — APIRule v2alpha1 has no native rate-limit field. Configure an `EnvoyFilter` at your gateway, or rely on an upstream WAF.
+
 ## Deploying Busola in a Kubernetes Cluster
 
 Follow these steps to deploy Busola in a Kubernetes cluster:

--- a/docs/user/01-40-deploy-access-kubernetes.md
+++ b/docs/user/01-40-deploy-access-kubernetes.md
@@ -9,7 +9,7 @@ For more details about environment configuration, see [Environment-Specific Sett
 
 ### Per-IP Rate Limiting
 
-For self-hosted deployments, there is no edge-level protection (such as Cloud Armor) in front of Busola, so per-IP rate limiting is handled at the ingress layer.
+For self-hosted deployments, there is no edge-level protection (such as Cloud Armor) in front of Busola. The shipped Ingress configuration includes per-IP rate limiting as a default security measure, but you can configure a different approach or skip it entirely.
 
 #### ingress-nginx (default)
 

--- a/docs/user/01-40-deploy-access-kubernetes.md
+++ b/docs/user/01-40-deploy-access-kubernetes.md
@@ -9,11 +9,21 @@ For more details about environment configuration, see [Environment-Specific Sett
 
 ### Per-IP Rate Limiting
 
-The shipped Ingress sets per-IP limits for `ingress-nginx`: 50 RPS sustained (~250 burst) and 50 concurrent connections per source IP. Tune in `resources/ingress/ingress.yaml`.
+For self-hosted deployments, there is no edge-level protection (such as Cloud Armor) in front of Busola, so per-IP rate limiting is handled at the ingress layer.
 
-The annotations are nginx-specific and silently ignored by other controllers (Traefik, HAProxy, etc.) — for those, configure equivalent limits at your own edge. If you run ingress-nginx but it's not the cluster's default IngressClass, add `ingressClassName: nginx` to the Ingress so the annotations take effect.
+#### ingress-nginx (default)
 
-For APIRule (Istio) deployments, per-IP rate limiting is not configured by default — APIRule v2alpha1 has no native rate-limit field. Configure an `EnvoyFilter` at your gateway, or rely on an upstream WAF.
+The shipped `resources/ingress/ingress.yaml` includes per-IP rate-limit annotations for `ingress-nginx`: 50 RPS sustained (~250 burst) and 50 concurrent connections per source IP. These defaults protect the instance out of the box. To tune them, edit the values directly in `resources/ingress/ingress.yaml`.
+
+If `ingress-nginx` is installed in your cluster but is not the default IngressClass, the annotations will have no effect. In that case, add `ingressClassName: nginx` to the Ingress manifest so the controller picks them up.
+
+#### Other Ingress Controllers (Traefik, HAProxy, etc.)
+
+The nginx-specific annotations are silently ignored by other controllers. If you use a different ingress controller, configure equivalent per-IP rate limits at your own edge.
+
+#### APIRule (Istio) Deployments
+
+Per-IP rate limiting is not configured by default for APIRule-based deployments. APIRule v2alpha1 has no native rate-limit field. To add per-IP throttling, configure an [`EnvoyFilter`](https://istio.io/latest/docs/reference/config/networking/envoy-filter/) at your Istio gateway, or rely on an upstream web application firewall (WAF).
 
 ## Deploying Busola in a Kubernetes Cluster
 

--- a/resources/ingress/ingress.yaml
+++ b/resources/ingress/ingress.yaml
@@ -2,6 +2,10 @@ kind: Ingress
 apiVersion: networking.k8s.io/v1
 metadata:
   name: busola
+  annotations:
+    # Per-IP rate limiting (ingress-nginx specific, no-op for other controllers); see deployment docs to tune.
+    nginx.ingress.kubernetes.io/limit-rps: '50'
+    nginx.ingress.kubernetes.io/limit-connections: '50'
 spec:
   rules:
     - http:

--- a/resources/istio/apirule.yaml
+++ b/resources/istio/apirule.yaml
@@ -1,3 +1,4 @@
+# Per-IP rate limiting is not configured here; see deployment docs for guidance.
 apiVersion: gateway.kyma-project.io/v2alpha1
 kind: APIRule
 metadata:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Removed per-IP rate limiting on all endpoints on the express app-level (confirmed to be broken, already covered by Cloud Armor)
- Replaced by per-K8s-credential rate limiting where applicable
- Added default per-IP rate limiting (50 RPS, 50 connections) on the shipped Ingress via ingress-nginx annotations
- Documented the rate-limiting model in the deployment guide

**Related issue(s)**
#4848
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
