### PR TITLE
chore: Enable PR jobs for merge queue

### DIFF
--- a/.github/workflows/busola-build.yml
+++ b/.github/workflows/busola-build.yml
@@ -35,6 +35,7 @@ on:
       - '.github/workflows/pull-kyma-intergation-tests.yml'
       - 'resources/**'
       - 'tests/integration/**'
+  merge_group:
 
 permissions:
   id-token: write # This is required for requesting the JWT token

--- a/.github/workflows/busola-build.yml
+++ b/.github/workflows/busola-build.yml
@@ -59,4 +59,4 @@ jobs:
       dockerfile: Dockerfile.fips
       tags: ${{ inputs.tag != '' && inputs.tag || 'latest' }}
       use-restricted-registry: true
-      build-args: BASE_IMAGE=europe-docker.pkg.dev/kyma-project/${{ github.event_name == 'pull_request_target' && 'dev' || 'prod' }}/busola@${{ needs.build-busola-image.outputs.digest }}
+      build-args: BASE_IMAGE=europe-docker.pkg.dev/kyma-project/${{ contains(['pull_request_target','merge_group'], github.event_name) && 'dev' || 'prod' }}/busola@${{ needs.build-busola-image.outputs.digest }}

--- a/.github/workflows/pull-integration-cluster-k3d.yml
+++ b/.github/workflows/pull-integration-cluster-k3d.yml
@@ -15,6 +15,7 @@ on:
       - 'nginx/**'
       - 'resources/**'
       - 'tests/integration/**'
+  merge_group:
   workflow_call:
     inputs:
       trigger_env:

--- a/.github/workflows/pull-integration-namespace-k3d.yml
+++ b/.github/workflows/pull-integration-namespace-k3d.yml
@@ -15,6 +15,7 @@ on:
       - 'nginx/**'
       - 'resources/**'
       - 'tests/integration/**'
+  merge_group:
   workflow_call:
     inputs:
       trigger_env:

--- a/.github/workflows/pull-kyma-integration-tests-dev.yml
+++ b/.github/workflows/pull-kyma-integration-tests-dev.yml
@@ -16,6 +16,7 @@ on:
       - 'nginx/**'
       - 'resources/**'
       - 'tests/integration/**'
+  merge_group:
   workflow_call:
     inputs:
       trigger_env:

--- a/.github/workflows/pull-unit-tests.yml
+++ b/.github/workflows/pull-unit-tests.yml
@@ -11,6 +11,7 @@ on:
       - 'package.json'
       - 'cypress/**'
       - 'cypress.config.component.ts'
+  merge_group:
   workflow_call:
     inputs:
       trigger_env:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `merge_group` trigger to CI workflows so they run in GitHub's merge queue
- Fix FIPS build workflow to correctly detect `merge_group` event name when selecting the container registry (dev vs prod)

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked.
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
