### PR TITLE
feat: Migrate extensibility Panel component to ui5 card

### DIFF
--- a/src/components/Extensibility/components/Panel.tsx
+++ b/src/components/Extensibility/components/Panel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Button, Title } from '@ui5/webcomponents-react';
+import { Button, Text, Title } from '@ui5/webcomponents-react';
+import { ToolbarSeparator } from '@ui5/webcomponents-react-compat/dist/components/ToolbarSeparator/index.js';
 import { useTranslation } from 'react-i18next';
 import { mapValues } from 'lodash';
 import classNames from 'classnames';
@@ -8,7 +9,7 @@ import { base64Decode } from 'shared/helpers';
 
 import { useCreateResourceDescription, useGetTranslation } from '../helpers';
 import { Widget, InlineWidget } from './Widget';
-import { UI5Panel } from 'shared/components/UI5Panel/UI5Panel';
+import { UI5Card } from 'shared/components/UI5Card/UI5Card';
 
 interface PanelProps {
   value: any;
@@ -46,11 +47,17 @@ export function Panel({
   }
 
   return (
-    <UI5Panel
+    <UI5Card
       accessibleName={`${widgetT(structure)} panel`}
       title={
         <>
           <Title level="H5">{widgetT(structure)}</Title>
+          {description && (
+            <>
+              <ToolbarSeparator />
+              <Text>{description as string}</Text>
+            </>
+          )}
           {Array.isArray(header)
             ? header.map((def: any, idx: number) => (
                 <Widget
@@ -75,7 +82,6 @@ export function Panel({
           </Button>
         )
       }
-      description={description as string}
     >
       {Array.isArray(structure?.children) && (
         <div className={bodyClassNames}>
@@ -94,6 +100,6 @@ export function Panel({
           ))}
         </div>
       )}
-    </UI5Panel>
+    </UI5Card>
   );
 }

--- a/src/components/Extensibility/components/Panel.tsx
+++ b/src/components/Extensibility/components/Panel.tsx
@@ -55,7 +55,7 @@ export function Panel({
           {description && (
             <>
               <ToolbarSeparator />
-              <Text>{description as string}</Text>
+              <Text>{description}</Text>
             </>
           )}
           {Array.isArray(header)

--- a/src/shared/ResourceForm/fields/DataField.tsx
+++ b/src/shared/ResourceForm/fields/DataField.tsx
@@ -15,8 +15,9 @@ export function DataField({ title, ...props }: DataFieldProps) {
         pattern: '([A-Za-z0-9.][-A-Za-z0-9_./]*)?[A-Za-z0-9]',
       }}
       input={{
-        value: ({ setValue, ...inputProps }) => (
+        value: ({ setValue, key, ...inputProps }) => (
           <TextArea
+            key={key}
             onChange={(e) => setValue(e.target.value)}
             growing
             growingMaxRows={10}

--- a/src/shared/components/GenericList/components/HeaderRenderer.tsx
+++ b/src/shared/components/GenericList/components/HeaderRenderer.tsx
@@ -73,7 +73,7 @@ export const HeaderRenderer = ({
         {headerRenderer()?.map((h: any, index: number) => {
           return (
             <TableHeaderCell
-              key={typeof h === 'object' ? index : h}
+              key={`${index}-${typeof h === 'object' ? '' : h}`}
               popinText={h === 'Popin' ? t('common.headers.specification') : h}
               popinHidden={h !== 'Popin' && !noHideFields?.includes(h)}
               importance={checkCellImportance(h)}

--- a/src/shared/components/UI5Card/UI5Card.cy.tsx
+++ b/src/shared/components/UI5Card/UI5Card.cy.tsx
@@ -11,7 +11,10 @@ describe('UI5Card', () => {
     );
 
     cy.get('ui5-card').should('exist');
-    cy.get('ui5-card-header').should('have.attr', 'title-text', 'Card title');
+    cy.get('.bsl-card-toolbar ui5-title')
+      .should('exist')
+      .and('have.attr', 'level', 'H4')
+      .and('contain.text', 'Card title');
     cy.get('[data-testid="content"]').should('contain.text', 'body');
   });
 

--- a/src/shared/components/UI5Card/UI5Card.test.tsx
+++ b/src/shared/components/UI5Card/UI5Card.test.tsx
@@ -15,18 +15,20 @@ describe('UI5Card', () => {
     expect(getByTestId('child')).toBeInTheDocument();
   });
 
-  it('uses the native CardHeader for a plain string title with no actions', () => {
+  it('uses the toolbar-style header for a plain string title (no native CardHeader path)', () => {
     const { container } = render(<UI5Card title="Simple">children</UI5Card>);
 
-    expect(container.querySelector('.bsl-card-toolbar')).toBeNull();
-    expect(container.querySelector('ui5-card-header')).not.toBeNull();
+    expect(container.querySelector('.bsl-card-toolbar')).not.toBeNull();
+    expect(container.querySelector('ui5-card-header')).toBeNull();
   });
 
-  it('renders the title text on the native CardHeader', () => {
+  it('wraps a string title in <Title level="H4"> inside the toolbar', () => {
     const { container } = render(<UI5Card title="Hello">x</UI5Card>);
 
-    const header = container.querySelector('ui5-card-header');
-    expect(header?.getAttribute('title-text')).toBe('Hello');
+    const title = container.querySelector('ui5-title');
+    expect(title).not.toBeNull();
+    expect(title?.getAttribute('level')).toBe('H4');
+    expect(title?.textContent).toBe('Hello');
   });
 
   it('uses the toolbar-style header when modeActions is provided alongside headerActions', () => {

--- a/src/shared/components/UI5Card/UI5Card.tsx
+++ b/src/shared/components/UI5Card/UI5Card.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, ReactNode, useContext } from 'react';
-import { Card, CardHeader, Title } from '@ui5/webcomponents-react';
+import { Card, Title } from '@ui5/webcomponents-react';
 import { Toolbar } from '@ui5/webcomponents-react-compat/dist/components/Toolbar/index.js';
 import { ToolbarSpacer } from '@ui5/webcomponents-react-compat/dist/components/ToolbarSpacer/index.js';
 import { NestedContainerContext } from './NestedContainerContext';
@@ -34,13 +34,6 @@ export const UI5Card = forwardRef<HTMLElement, UI5CardProps>(
   ) => {
     const isNested = useContext(NestedContainerContext);
     const shouldHaveMargin = isNested;
-
-    const useNativeHeader =
-      !modeActions && !headerActions && typeof title === 'string';
-
-    const nativeHeader = (
-      <CardHeader titleText={typeof title === 'string' ? title : undefined} />
-    );
 
     const toolbarHeader = (
       <Toolbar
@@ -78,7 +71,7 @@ export const UI5Card = forwardRef<HTMLElement, UI5CardProps>(
           key={keyComponent}
           className={`${className} ${shouldHaveMargin ? 'sap-margin-small bsl-card--nested' : ''}`}
           accessibleName={accessibleName}
-          header={useNativeHeader ? nativeHeader : toolbarHeader}
+          header={toolbarHeader}
         >
           {children}
         </Card>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Migrate Extensibility `Panel` widget from `UI5Panel` to `UI5Card`
- Force `UI5Card` to always use its toolbar header path; drop the dual-path / native `CardHeader` fork for visual consistency across all migrations
- Fixed two minor issues that were causing browser console errors along the way

**Related issue(s)**
#4877
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
