### PR TITLE
fix: Show exec command with args in AuthForm for copy-paste

### DIFF
--- a/src/components/Clusters/components/AuthForm.tsx
+++ b/src/components/Clusters/components/AuthForm.tsx
@@ -122,7 +122,7 @@ const TokenForm = ({
         <ResourceForm.FormField
           label={t('clusters.wizard.auth.exec-command')}
           input={Inputs.Text}
-          value={exec.command}
+          value={[exec.command, ...(exec.args || [])].join(' ')}
           readOnly
         />
       )}


### PR DESCRIPTION
## Summary

- Display the full exec command (command + args) in the AuthForm read-only field so users can directly copy-paste it into a terminal.

## Details

When a kubeconfig uses a generic exec-based authentication (e.g. `kubelogin`), the AuthForm previously only showed `user.exec.command` without the arguments. This made it inconvenient to copy the command for manual execution.

Now the field shows the complete command including all args. For example, a kubeconfig with:

```yaml
user:
  exec:
    command: kubelogin
    args:
      - get-token
      - --oidc-issuer-url=https://example.com
      - --oidc-client-id=my-client
```

will display:

```
kubelogin get-token --oidc-issuer-url=https://example.com --oidc-client-id=my-client
```

This is directly copy-pasteable into a terminal to manually obtain a token.