### PR TITLE
fix: Show "Modules updated" toast after saving Kyma modules

### DIFF
--- a/public/i18n/en.yaml
+++ b/public/i18n/en.yaml
@@ -935,6 +935,7 @@ kyma-modules:
     modules-update-failed: Modules update failed
     modules-updated: Modules updated
     success: '{{resourceType}} installed'
+    updated: Modules updated
   modify-modules: Modify Modules
   module-state: Module State
   modules-channel: Modules Channel

--- a/src/components/Modules/KymaModulesEdit.tsx
+++ b/src/components/Modules/KymaModulesEdit.tsx
@@ -338,9 +338,7 @@ export default function KymaModulesEdit({
 
   const onSuccess = () => {
     notification.notifySuccess({
-      content: t('common.create-form.messages.patch-success', {
-        resourceType: t('kyma-modules.kyma'),
-      }),
+      content: t('kyma-modules.updated'),
     });
 
     setIsResourceEdited({

--- a/src/components/Modules/KymaModulesEdit.tsx
+++ b/src/components/Modules/KymaModulesEdit.tsx
@@ -338,7 +338,7 @@ export default function KymaModulesEdit({
 
   const onSuccess = () => {
     notification.notifySuccess({
-      content: t('kyma-modules.updated'),
+      content: t('kyma-modules.messages.updated'),
     });
 
     setIsResourceEdited({

--- a/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
@@ -231,7 +231,7 @@ context('Test Kyma Modules views', () => {
 
     cy.get('ui5-button').contains('Change').click();
 
-    cy.contains('Kyma updated').should('be.visible');
+    cy.contains('Modules updated').should('be.visible');
 
     cy.inspectTab('View');
 
@@ -267,7 +267,7 @@ context('Test Kyma Modules views', () => {
 
     cy.get('ui5-button').contains('Change').click();
 
-    cy.contains('Kyma updated').should('be.visible');
+    cy.contains('Modules updated').should('be.visible');
 
     cy.inspectTab('View');
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace the generic "Kyma updated" success toast with "Modules updated" message 
- Update integration tests to assert the new toast message text

**Related issue(s)**

Resolves #4957

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
