### PR TITLE
feat: Show illustrated message if there are no modules

### DIFF
--- a/src/components/Modules/KymaModulesAddModule.tsx
+++ b/src/components/Modules/KymaModulesAddModule.tsx
@@ -337,18 +337,16 @@ export default function KymaModulesAddModule(props: ResourceFormProps) {
           design="Scene"
           key="all-modules-added"
           titleText={t('kyma-modules.all-modules-added')}
-          subtitleText=" "
           className="emptyListComponent"
-        ></IllustratedMessage>
+        />
       ) : (
         <IllustratedMessage
           name="tnt/Components"
           design="Scene"
           key="all-modules-added"
           titleText={t('kyma-modules.no-modules')}
-          subtitleText=" "
           className="emptyListComponent"
-        ></IllustratedMessage>
+        />
       )}
     </ResourceForm>
   );

--- a/src/components/Modules/KymaModulesAddModule.tsx
+++ b/src/components/Modules/KymaModulesAddModule.tsx
@@ -1,5 +1,12 @@
-import { ReactNode, useCallback, useContext, useEffect, useState } from 'react';
-import { MessageStrip } from '@ui5/webcomponents-react';
+import {
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { IllustratedMessage, MessageStrip } from '@ui5/webcomponents-react';
 import { useTranslation } from 'react-i18next';
 import { ResourceForm } from 'shared/ResourceForm';
 import { Spinner } from 'shared/components/Spinner/Spinner';
@@ -112,6 +119,103 @@ export default function KymaModulesAddModule(props: ResourceFormProps) {
       }
     };
   }, [cardsContainerRef, calculateColumns]);
+  const modulesAddData = useMemo(
+    () =>
+      moduleTemplates?.items.reduce((acc: ModulesAddData[], moduleTpl) => {
+        const name =
+          moduleTpl.metadata.labels['operator.kyma-project.io/module-name'];
+        const existingModule = acc.find((item) => item.name === name);
+        const isAlreadyInstalled =
+          initialUnchangedResource?.spec?.modules?.find(
+            (installedModule) => installedModule.name === name,
+          );
+        const moduleReleaseMeta = moduleReleaseMetas?.items.find(
+          (item) => item.spec.moduleName === name,
+        );
+
+        const isModuleMetaRelease = acc.find(
+          (item: any) => item.name === moduleReleaseMeta?.spec?.moduleName,
+        );
+
+        if (moduleTpl.spec.channel && !isModuleMetaRelease) {
+          if (!existingModule && !isAlreadyInstalled) {
+            acc.push({
+              name: name,
+              channels: [
+                {
+                  channel: moduleTpl.spec.channel,
+                  version: moduleTpl.spec.descriptor.component.version,
+                  isBeta:
+                    moduleTpl.metadata.labels[
+                      'operator.kyma-project.io/beta'
+                    ] === 'true',
+                },
+              ],
+              docsUrl:
+                moduleTpl.metadata.annotations[
+                  'operator.kyma-project.io/doc-url'
+                ],
+              icon: {
+                link: moduleTpl.spec?.info?.icons?.[0]?.link,
+                name: moduleTpl.spec?.info?.icons?.[0]?.name,
+              },
+              isMetaRelease: false,
+            });
+          } else if (existingModule) {
+            existingModule.channels?.push({
+              channel: moduleTpl.spec.channel,
+              version: moduleTpl.spec.descriptor.component.version,
+              isBeta:
+                moduleTpl.metadata.labels['operator.kyma-project.io/beta'] ===
+                'true',
+              isMetaRelease: false,
+            });
+          }
+        } else {
+          if (!existingModule && !isAlreadyInstalled) {
+            moduleReleaseMeta?.spec.channels.forEach((channel) => {
+              if (!acc.find((item) => item.name === name)) {
+                acc.push({
+                  name: name,
+                  channels: [
+                    {
+                      channel: channel.channel,
+                      version: channel.version,
+                      isBeta: moduleReleaseMeta.spec.beta ?? false,
+                      isMetaRelease: true,
+                    },
+                  ],
+                  docsUrl: moduleTpl.spec.info?.documentation,
+                  icon: {
+                    link: moduleTpl.spec?.info?.icons?.[0]?.link,
+                    name: moduleTpl.spec?.info?.icons?.[0]?.name,
+                  },
+                });
+              } else {
+                acc
+                  ?.find((item) => item?.name === name)
+                  ?.channels.push({
+                    channel: channel.channel,
+                    version: channel.version,
+                    isBeta: moduleReleaseMeta.spec.beta ?? false,
+                    isMetaRelease: true,
+                  });
+              }
+            });
+          }
+        }
+
+        return acc ?? [];
+      }, []),
+    [moduleTemplates, moduleReleaseMetas, initialUnchangedResource],
+  );
+
+  useEffect(() => {
+    props.setIsAddDisabled?.(
+      modulesAddData?.length === 0 && !!kymaResource?.spec?.modules,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modulesAddData, kymaResource?.spec?.modules]);
 
   if (loading || !kymaResource) {
     return (
@@ -120,94 +224,6 @@ export default function KymaModulesAddModule(props: ResourceFormProps) {
       </div>
     );
   }
-
-  const modulesAddData = moduleTemplates?.items.reduce(
-    (acc: ModulesAddData[], moduleTpl) => {
-      const name =
-        moduleTpl.metadata.labels['operator.kyma-project.io/module-name'];
-      const existingModule = acc.find((item) => item.name === name);
-      const isAlreadyInstalled = initialUnchangedResource?.spec?.modules?.find(
-        (installedModule) => installedModule.name === name,
-      );
-      const moduleReleaseMeta = moduleReleaseMetas?.items.find(
-        (item) => item.spec.moduleName === name,
-      );
-
-      const isModuleMetaRelease = acc.find(
-        (item: any) => item.name === moduleReleaseMeta?.spec?.moduleName,
-      );
-
-      if (moduleTpl.spec.channel && !isModuleMetaRelease) {
-        if (!existingModule && !isAlreadyInstalled) {
-          acc.push({
-            name: name,
-            channels: [
-              {
-                channel: moduleTpl.spec.channel,
-                version: moduleTpl.spec.descriptor.component.version,
-                isBeta:
-                  moduleTpl.metadata.labels['operator.kyma-project.io/beta'] ===
-                  'true',
-              },
-            ],
-            docsUrl:
-              moduleTpl.metadata.annotations[
-                'operator.kyma-project.io/doc-url'
-              ],
-            icon: {
-              link: moduleTpl.spec?.info?.icons?.[0]?.link,
-              name: moduleTpl.spec?.info?.icons?.[0]?.name,
-            },
-            isMetaRelease: false,
-          });
-        } else if (existingModule) {
-          existingModule.channels?.push({
-            channel: moduleTpl.spec.channel,
-            version: moduleTpl.spec.descriptor.component.version,
-            isBeta:
-              moduleTpl.metadata.labels['operator.kyma-project.io/beta'] ===
-              'true',
-            isMetaRelease: false,
-          });
-        }
-      } else {
-        if (!existingModule && !isAlreadyInstalled) {
-          moduleReleaseMeta?.spec.channels.forEach((channel) => {
-            if (!acc.find((item) => item.name === name)) {
-              acc.push({
-                name: name,
-                channels: [
-                  {
-                    channel: channel.channel,
-                    version: channel.version,
-                    isBeta: moduleReleaseMeta.spec.beta ?? false,
-                    isMetaRelease: true,
-                  },
-                ],
-                docsUrl: moduleTpl.spec.info?.documentation,
-                icon: {
-                  link: moduleTpl.spec?.info?.icons?.[0]?.link,
-                  name: moduleTpl.spec?.info?.icons?.[0]?.name,
-                },
-              });
-            } else {
-              acc
-                ?.find((item) => item?.name === name)
-                ?.channels.push({
-                  channel: channel.channel,
-                  version: channel.version,
-                  isBeta: moduleReleaseMeta.spec.beta ?? false,
-                  isMetaRelease: true,
-                });
-            }
-          });
-        }
-      }
-
-      return acc ?? [];
-    },
-    [],
-  );
 
   const isChecked = (name?: string) => {
     return !!selectedModules?.find((module) => module.name === name);
@@ -323,21 +339,23 @@ export default function KymaModulesAddModule(props: ResourceFormProps) {
           {renderCards()}
         </>
       ) : kymaResource?.spec?.modules ? (
-        <MessageStrip
-          design="Information"
-          hideCloseButton
-          className="sap-margin-top-small"
-        >
-          {t('kyma-modules.all-modules-added')}
-        </MessageStrip>
+        <IllustratedMessage
+          name="tnt/Components"
+          design="Scene"
+          key="all-modules-added"
+          titleText={t('kyma-modules.all-modules-added')}
+          subtitleText=" "
+          className="emptyListComponent"
+        ></IllustratedMessage>
       ) : (
-        <MessageStrip
-          design="Critical"
-          hideCloseButton
-          className="sap-margin-top-small"
-        >
-          {t('kyma-modules.no-modules')}
-        </MessageStrip>
+        <IllustratedMessage
+          name="tnt/Components"
+          design="Scene"
+          key="all-modules-added"
+          titleText={t('kyma-modules.no-modules')}
+          subtitleText=" "
+          className="emptyListComponent"
+        ></IllustratedMessage>
       )}
     </ResourceForm>
   );

--- a/src/components/Modules/KymaModulesAddModule.tsx
+++ b/src/components/Modules/KymaModulesAddModule.tsx
@@ -119,6 +119,7 @@ export default function KymaModulesAddModule(props: ResourceFormProps) {
       }
     };
   }, [cardsContainerRef, calculateColumns]);
+
   const modulesAddData = useMemo(
     () =>
       moduleTemplates?.items.reduce((acc: ModulesAddData[], moduleTpl) => {
@@ -207,7 +208,13 @@ export default function KymaModulesAddModule(props: ResourceFormProps) {
 
         return acc ?? [];
       }, []),
-    [moduleTemplates, moduleReleaseMetas, initialUnchangedResource],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      kymaResource?.spec?.modules,
+      moduleTemplates,
+      moduleReleaseMetas,
+      initialUnchangedResource,
+    ],
   );
 
   useEffect(() => {

--- a/src/components/Modules/KymaModulesAddModule.tsx
+++ b/src/components/Modules/KymaModulesAddModule.tsx
@@ -1,11 +1,4 @@
-import {
-  ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 import { IllustratedMessage, MessageStrip } from '@ui5/webcomponents-react';
 import { useTranslation } from 'react-i18next';
 import { ResourceForm } from 'shared/ResourceForm';
@@ -120,107 +113,100 @@ export default function KymaModulesAddModule(props: ResourceFormProps) {
     };
   }, [cardsContainerRef, calculateColumns]);
 
-  const modulesAddData = useMemo(
-    () =>
-      moduleTemplates?.items.reduce((acc: ModulesAddData[], moduleTpl) => {
-        const name =
-          moduleTpl.metadata.labels['operator.kyma-project.io/module-name'];
-        const existingModule = acc.find((item) => item.name === name);
-        const isAlreadyInstalled =
-          initialUnchangedResource?.spec?.modules?.find(
-            (installedModule) => installedModule.name === name,
-          );
-        const moduleReleaseMeta = moduleReleaseMetas?.items.find(
-          (item) => item.spec.moduleName === name,
-        );
+  const modulesAddData = moduleTemplates?.items.reduce(
+    (acc: ModulesAddData[], moduleTpl) => {
+      const name =
+        moduleTpl.metadata.labels['operator.kyma-project.io/module-name'];
+      const existingModule = acc.find((item) => item.name === name);
+      const isAlreadyInstalled = initialUnchangedResource?.spec?.modules?.find(
+        (installedModule) => installedModule.name === name,
+      );
+      const moduleReleaseMeta = moduleReleaseMetas?.items.find(
+        (item) => item.spec.moduleName === name,
+      );
 
-        const isModuleMetaRelease = acc.find(
-          (item: any) => item.name === moduleReleaseMeta?.spec?.moduleName,
-        );
+      const isModuleMetaRelease = acc.find(
+        (item: any) => item.name === moduleReleaseMeta?.spec?.moduleName,
+      );
 
-        if (moduleTpl.spec.channel && !isModuleMetaRelease) {
-          if (!existingModule && !isAlreadyInstalled) {
-            acc.push({
-              name: name,
-              channels: [
-                {
-                  channel: moduleTpl.spec.channel,
-                  version: moduleTpl.spec.descriptor.component.version,
-                  isBeta:
-                    moduleTpl.metadata.labels[
-                      'operator.kyma-project.io/beta'
-                    ] === 'true',
-                },
-              ],
-              docsUrl:
-                moduleTpl.metadata.annotations[
-                  'operator.kyma-project.io/doc-url'
-                ],
-              icon: {
-                link: moduleTpl.spec?.info?.icons?.[0]?.link,
-                name: moduleTpl.spec?.info?.icons?.[0]?.name,
+      if (moduleTpl.spec.channel && !isModuleMetaRelease) {
+        if (!existingModule && !isAlreadyInstalled) {
+          acc.push({
+            name: name,
+            channels: [
+              {
+                channel: moduleTpl.spec.channel,
+                version: moduleTpl.spec.descriptor.component.version,
+                isBeta:
+                  moduleTpl.metadata.labels['operator.kyma-project.io/beta'] ===
+                  'true',
               },
-              isMetaRelease: false,
-            });
-          } else if (existingModule) {
-            existingModule.channels?.push({
-              channel: moduleTpl.spec.channel,
-              version: moduleTpl.spec.descriptor.component.version,
-              isBeta:
-                moduleTpl.metadata.labels['operator.kyma-project.io/beta'] ===
-                'true',
-              isMetaRelease: false,
-            });
-          }
-        } else {
-          if (!existingModule && !isAlreadyInstalled) {
-            moduleReleaseMeta?.spec.channels.forEach((channel) => {
-              if (!acc.find((item) => item.name === name)) {
-                acc.push({
-                  name: name,
-                  channels: [
-                    {
-                      channel: channel.channel,
-                      version: channel.version,
-                      isBeta: moduleReleaseMeta.spec.beta ?? false,
-                      isMetaRelease: true,
-                    },
-                  ],
-                  docsUrl: moduleTpl.spec.info?.documentation,
-                  icon: {
-                    link: moduleTpl.spec?.info?.icons?.[0]?.link,
-                    name: moduleTpl.spec?.info?.icons?.[0]?.name,
-                  },
-                });
-              } else {
-                acc
-                  ?.find((item) => item?.name === name)
-                  ?.channels.push({
+            ],
+            docsUrl:
+              moduleTpl.metadata.annotations[
+                'operator.kyma-project.io/doc-url'
+              ],
+            icon: {
+              link: moduleTpl.spec?.info?.icons?.[0]?.link,
+              name: moduleTpl.spec?.info?.icons?.[0]?.name,
+            },
+            isMetaRelease: false,
+          });
+        } else if (existingModule) {
+          existingModule.channels?.push({
+            channel: moduleTpl.spec.channel,
+            version: moduleTpl.spec.descriptor.component.version,
+            isBeta:
+              moduleTpl.metadata.labels['operator.kyma-project.io/beta'] ===
+              'true',
+            isMetaRelease: false,
+          });
+        }
+      } else {
+        if (!existingModule && !isAlreadyInstalled) {
+          moduleReleaseMeta?.spec.channels.forEach((channel) => {
+            if (!acc.find((item) => item.name === name)) {
+              acc.push({
+                name: name,
+                channels: [
+                  {
                     channel: channel.channel,
                     version: channel.version,
                     isBeta: moduleReleaseMeta.spec.beta ?? false,
                     isMetaRelease: true,
-                  });
-              }
-            });
-          }
+                  },
+                ],
+                docsUrl: moduleTpl.spec.info?.documentation,
+                icon: {
+                  link: moduleTpl.spec?.info?.icons?.[0]?.link,
+                  name: moduleTpl.spec?.info?.icons?.[0]?.name,
+                },
+              });
+            } else {
+              acc
+                ?.find((item) => item?.name === name)
+                ?.channels.push({
+                  channel: channel.channel,
+                  version: channel.version,
+                  isBeta: moduleReleaseMeta.spec.beta ?? false,
+                  isMetaRelease: true,
+                });
+            }
+          });
         }
+      }
 
-        return acc ?? [];
-      }, []),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      kymaResource?.spec?.modules,
-      moduleTemplates,
-      moduleReleaseMetas,
-      initialUnchangedResource,
-    ],
+      return acc ?? [];
+    },
+    [],
   );
 
   useEffect(() => {
-    props.setIsAddDisabled?.(
-      modulesAddData?.length === 0 && !!kymaResource?.spec?.modules,
-    );
+    if (!loading && kymaResource) {
+      props.setIsAddDisabled?.(
+        modulesAddData?.length === 0 && !!kymaResource?.spec?.modules,
+      );
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modulesAddData, kymaResource?.spec?.modules]);
 

--- a/src/components/Modules/community/CommunityModulesAddModule.tsx
+++ b/src/components/Modules/community/CommunityModulesAddModule.tsx
@@ -418,9 +418,8 @@ export default function CommunityModulesAddModule(props: any) {
                   design="Scene"
                   key="all-modules-added"
                   titleText={t('modules.community.no-modules')}
-                  subtitleText=" "
                   className="emptyListComponent"
-                ></IllustratedMessage>
+                />
               </>
             )}
           </>

--- a/src/components/Modules/community/CommunityModulesAddModule.tsx
+++ b/src/components/Modules/community/CommunityModulesAddModule.tsx
@@ -4,7 +4,7 @@ import { SetStateAction, useAtom, useSetAtom } from 'jotai';
 import { useFeature } from 'hooks/useFeature';
 import { columnLayoutAtom } from 'state/columnLayoutAtom';
 import { ResourceForm } from 'shared/ResourceForm';
-import { MessageStrip } from '@ui5/webcomponents-react';
+import { IllustratedMessage, MessageStrip } from '@ui5/webcomponents-react';
 import { Spinner } from 'shared/components/Spinner/Spinner';
 import {
   getAvailableCommunityModules,
@@ -412,13 +412,16 @@ export default function CommunityModulesAddModule(props: any) {
             {communityModulesToDisplay?.length !== 0 ? (
               renderCards()
             ) : (
-              <MessageStrip
-                design="Critical"
-                hideCloseButton
-                className="sap-margin-top-small"
-              >
-                {t('modules.community.no-modules')}
-              </MessageStrip>
+              <>
+                <IllustratedMessage
+                  name="tnt/Components"
+                  design="Scene"
+                  key="all-modules-added"
+                  titleText={t('modules.community.no-modules')}
+                  subtitleText=" "
+                  className="emptyListComponent"
+                ></IllustratedMessage>
+              </>
             )}
           </>
         </ResourceForm>

--- a/src/components/Modules/community/CommunityModulesAddModule.tsx
+++ b/src/components/Modules/community/CommunityModulesAddModule.tsx
@@ -412,15 +412,13 @@ export default function CommunityModulesAddModule(props: any) {
             {communityModulesToDisplay?.length !== 0 ? (
               renderCards()
             ) : (
-              <>
-                <IllustratedMessage
-                  name="tnt/Components"
-                  design="Scene"
-                  key="all-modules-added"
-                  titleText={t('modules.community.no-modules')}
-                  className="emptyListComponent"
-                />
-              </>
+              <IllustratedMessage
+                name="tnt/Components"
+                design="Scene"
+                key="all-modules-added"
+                titleText={t('modules.community.no-modules')}
+                className="emptyListComponent"
+              />
             )}
           </>
         </ResourceForm>

--- a/src/resources/other/kymaModules.routes.tsx
+++ b/src/resources/other/kymaModules.routes.tsx
@@ -69,6 +69,7 @@ const ColumnWrapper = ({
       ? searchParams.get('resourceNamespace')
       : rawNamespace;
   const [resMetadata, setResMetadata] = useState<any>(null);
+  const [isAddDisabled, setIsAddDisabled] = useState(false);
 
   useEffect(() => {
     setLayoutColumn((prev: any) => {
@@ -170,10 +171,14 @@ const ColumnWrapper = ({
                 title={t('kyma-modules.add-module')}
                 confirmText={t('common.buttons.add')}
                 layoutCloseCreateUrl={url}
+                disableEdit={isAddDisabled}
                 renderForm={(renderProps: any) => {
                   return (
                     <ErrorBoundary>
-                      <KymaModulesAddModule {...renderProps} />
+                      <KymaModulesAddModule
+                        {...renderProps}
+                        setIsAddDisabled={setIsAddDisabled}
+                      />
                     </ErrorBoundary>
                   );
                 }}

--- a/src/shared/ResourceForm/components/ResourceForm.tsx
+++ b/src/shared/ResourceForm/components/ResourceForm.tsx
@@ -56,6 +56,7 @@ export type ResourceFormProps = {
   updateInitialResource?: (res: any) => void;
   setResource?: (res: any) => void;
   setCustomValid?: (isValid: boolean) => void;
+  setIsAddDisabled?: (isValid: boolean) => void;
   onChange?: FormEventHandler<HTMLElement>;
   formElementRef?: RefObject<HTMLFormElement | null>;
   children?: ReactNode;

--- a/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
@@ -57,6 +57,7 @@ context('Test Kyma Modules views', () => {
 
     cy.get('[data-testid="create-form-footer-bar"]')
       .contains('ui5-button:visible', 'Add')
+      .should('not.be.disabled')
       .click();
 
     // Check if already installed module is not visible
@@ -75,6 +76,7 @@ context('Test Kyma Modules views', () => {
 
     cy.get('[data-testid="create-form-footer-bar"]')
       .contains('ui5-button:visible', 'Add')
+      .should('not.be.disabled')
       .click();
 
     cy.wait(7000);
@@ -82,6 +84,15 @@ context('Test Kyma Modules views', () => {
     cy.get('ui5-table-row').contains('eventing').should('be.visible');
 
     cy.get('ui5-table-row').contains('api-gateway').should('be.visible');
+
+    // Check if "You have added all the modules" is  visible
+    cy.get('ui5-panel[data-testid="kyma-modules-list"]')
+      .contains('ui5-button', 'Add')
+      .click();
+
+    cy.find('ui5-illustrated-message')
+      .find('ui5-title', 'You have added all the modules')
+      .should('be.visible');
   });
 
   it('Test number of Modules in Modules Overview card', () => {

--- a/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
@@ -55,6 +55,8 @@ context('Test Kyma Modules views', () => {
 
     cy.get('ui5-title').contains('api-gateway').click();
 
+    cy.wait(1000);
+
     cy.get('[data-testid="create-form-footer-bar"]')
       .contains('ui5-button:visible', 'Add')
       .should('not.be.disabled')
@@ -71,6 +73,7 @@ context('Test Kyma Modules views', () => {
 
     cy.get('ui5-card').contains('eventing').should('be.visible');
 
+    cy.wait(1000);
     // Add second module
     cy.get('ui5-title').contains('eventing').click();
 

--- a/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
@@ -55,12 +55,12 @@ context('Test Kyma Modules views', () => {
 
     cy.get('ui5-title').contains('api-gateway').click();
 
-    cy.wait(1000);
-
     cy.get('[data-testid="create-form-footer-bar"]')
       .contains('ui5-button:visible', 'Add')
       .should('not.be.disabled')
       .click();
+
+    cy.wait(7000);
 
     // Check if already installed module is not visible
     cy.get('ui5-panel[data-testid="kyma-modules-list"]')
@@ -73,16 +73,15 @@ context('Test Kyma Modules views', () => {
 
     cy.get('ui5-card').contains('eventing').should('be.visible');
 
-    cy.wait(1000);
     // Add second module
     cy.get('ui5-title').contains('eventing').click();
+
+    cy.wait(1000);
 
     cy.get('[data-testid="create-form-footer-bar"]')
       .contains('ui5-button:visible', 'Add')
       .should('not.be.disabled')
       .click();
-
-    cy.wait(7000);
 
     cy.get('ui5-table-row').contains('eventing').should('be.visible');
 
@@ -93,7 +92,8 @@ context('Test Kyma Modules views', () => {
       .contains('ui5-button', 'Add')
       .click();
 
-    cy.find('ui5-illustrated-message')
+    cy.getMidColumn()
+      .get('ui5-illustrated-message')
       .find('ui5-title', 'You have added all the modules')
       .should('be.visible');
   });

--- a/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
+++ b/tests/integration/tests/kyma-cluster/test-kyma-modules.spec.js
@@ -87,7 +87,7 @@ context('Test Kyma Modules views', () => {
 
     cy.get('ui5-table-row').contains('api-gateway').should('be.visible');
 
-    // Check if "You have added all the modules" is  visible
+    // Check if illustrated message is visible if there are no modules
     cy.get('ui5-panel[data-testid="kyma-modules-list"]')
       .contains('ui5-button', 'Add')
       .click();
@@ -96,6 +96,10 @@ context('Test Kyma Modules views', () => {
       .get('ui5-illustrated-message')
       .find('ui5-title', 'You have added all the modules')
       .should('be.visible');
+
+    cy.get('[data-testid="create-form-footer-bar"]')
+      .contains('ui5-button:visible', 'Add')
+      .should('be.disabled');
   });
 
   it('Test number of Modules in Modules Overview card', () => {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace `MessageStrip` components with `IllustratedMessage` in the Kyma modules and community modules "Add Module" views to improve the empty-state UX
- Disable the **Add** button when no modules are available 
- Refactor `modulesAddData` computation in `KymaModulesAddModule` to use `useMemo` so the empty-state check is reactive
- Add a `setIsAddDisabled` callback prop to `ResourceFormProps` and wire it through the column wrapper

**Related issue(s)**

Resolves #4968

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
