### PR TITLE
feat: Apply background color to selected module card and fix card selection

### DIFF
--- a/src/components/Modules/KymaModulesAddModule.scss
+++ b/src/components/Modules/KymaModulesAddModule.scss
@@ -68,6 +68,7 @@
     &::part(content) {
       padding: 0 var(--left-spacing);
       padding-bottom: 5px;
+      background-color: inherit;
     }
 
     &__content {
@@ -81,6 +82,10 @@
       }
     }
   }
+}
+
+.ui5-panel::part(content) {
+  background-color: inherit;
 }
 
 .add-modules-form::part(layout) {

--- a/src/components/Modules/KymaModulesAddModule.scss
+++ b/src/components/Modules/KymaModulesAddModule.scss
@@ -13,6 +13,10 @@
     max-width: var(--card-width);
     height: fit-content;
 
+    .add-module-card-checked {
+      background-color: var(--sapList_SelectionBackgroundColor);
+    }
+
     .addModuleCard {
       --left-spacing: 45px;
 
@@ -44,7 +48,7 @@
       }
 
       .content {
-        margin-left: var(--left-spacing);
+        padding-left: var(--left-spacing);
       }
     }
   }

--- a/src/components/Modules/KymaModulesAddModule.scss
+++ b/src/components/Modules/KymaModulesAddModule.scss
@@ -19,6 +19,7 @@
 
     .addModuleCard {
       --left-spacing: 45px;
+      border-radius: 1rem;
 
       .moduleCardHeader {
         position: relative;
@@ -55,6 +56,7 @@
 
   .settings-panel {
     width: var(--card-width);
+    border-radius: 0 0 1rem 1rem;
 
     &::part(header) {
       font-family: var(--sapFontFamily);

--- a/src/components/Modules/community/components/CommunityModuleCard.tsx
+++ b/src/components/Modules/community/components/CommunityModuleCard.tsx
@@ -63,10 +63,10 @@ export default function CommunityModuleCard({
     <Card
       accessibleName={module.name}
       key={`card-${module.name}`}
-      className="addModuleCard"
+      className={`addModuleCard ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
     >
       <ListItemStandard
-        className="moduleCardHeader"
+        className={`moduleCardHeader ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
         key={`list-${module.name}`}
         onClick={() => {
           onChange(
@@ -80,7 +80,9 @@ export default function CommunityModuleCard({
           className="checkbox"
           checked={isChecked(module.name)}
         />
-        <div className="titles">
+        <div
+          className={`titles ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
+        >
           <Title level="H6" size="H6">
             {module.name}
           </Title>
@@ -98,7 +100,9 @@ export default function CommunityModuleCard({
           />
         )}
       </ListItemStandard>
-      <div className="content">
+      <div
+        className={`content ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
+      >
         {module.versions[0]?.docsURL && (
           <ExternalLink
             url={module.versions[0]?.docsURL}
@@ -109,7 +113,7 @@ export default function CommunityModuleCard({
         )}
       </div>
       <Panel
-        className="settings-panel"
+        className={`settings-panel ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
         collapsed
         headerText="Advanced"
         noAnimation

--- a/src/components/Modules/community/components/CommunityModuleCard.tsx
+++ b/src/components/Modules/community/components/CommunityModuleCard.tsx
@@ -120,7 +120,9 @@ export default function CommunityModuleCard({
         data-testid={`module-settings-panel-${module.name}`}
         accessibleName={t('modules.community.accessible-name.advanced')}
       >
-        <div className="settings-panel__content sap-margin-y-small">
+        <div
+          className={`settings-panel__content sap-margin-y-small ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
+        >
           <Label>{t('modules.community.origin') + ':'} </Label>
           <Select
             accessibleName={`${module.name} version select`}

--- a/src/components/Modules/components/ModulesCard.tsx
+++ b/src/components/Modules/components/ModulesCard.tsx
@@ -139,13 +139,13 @@ export default function ModulesCard({
     <Card
       accessibleName={module.name}
       key={module.name}
-      className="addModuleCard"
+      className={`addModuleCard ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
     >
       <ListItemStandard
-        className="moduleCardHeader"
+        className={`moduleCardHeader ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
         onClick={() => {
           setCheckbox(module, !isChecked(module.name), index);
-          checkIfVersionExistsAndSet();
+          if (!isChecked(module.name)) checkIfVersionExistsAndSet();
         }}
       >
         <CheckBox
@@ -185,7 +185,9 @@ export default function ModulesCard({
           />
         )}
       </ListItemStandard>
-      <div className="content">
+      <div
+        className={`content ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
+      >
         {module.docsUrl && (
           <ExternalLink
             url={module.docsUrl}
@@ -196,7 +198,7 @@ export default function ModulesCard({
         )}
       </div>
       <Panel
-        className="settings-panel"
+        className={`settings-panel ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
         collapsed
         headerText="Advanced"
         noAnimation

--- a/src/components/Modules/components/ModulesCard.tsx
+++ b/src/components/Modules/components/ModulesCard.tsx
@@ -205,7 +205,9 @@ export default function ModulesCard({
         data-testid={`module-settings-panel-${module.name}`}
         accessibleName={t('kyma-modules.accessible-name.advanced')}
       >
-        <div className="settings-panel__content sap-margin-y-small">
+        <div
+          className={`settings-panel__content sap-margin-y-small ${isChecked(module.name) ? 'add-module-card-checked' : ''}`}
+        >
           <Label>{t('kyma-modules.release-channel') + ':'} </Label>
           <Select
             onChange={(event) => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Applied background color to a module card in selected state
- Fixed bug in checking and unchecking module card multiple times (reproducible for `docker-registry` and `cfapi`, how to reproduce: in Add Modules view click `cfapi` card 4 times - the checkbox should be unchecked, then click 'Add' and see how `cfapi` is added to modules list) 

**Related issue(s)**
Resolves #4966
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
