### PR TITLE
fix: Upgrade ECDH curve from P-256 to P-521 for stronger key exchange

### DIFF
--- a/src/components/KymaCompanion/utils/encryption.ts
+++ b/src/components/KymaCompanion/utils/encryption.ts
@@ -65,7 +65,7 @@ function concatBuffers(
 
 async function performKeyExchange(): Promise<SessionKeys> {
   const clientKeys = await window.crypto.subtle.generateKey(
-    { name: 'ECDH', namedCurve: 'P-256' },
+    { name: 'ECDH', namedCurve: 'P-521' },
     false,
     ['deriveBits'],
   );
@@ -98,7 +98,7 @@ async function performKeyExchange(): Promise<SessionKeys> {
   const serverPublicKey = await window.crypto.subtle.importKey(
     'raw',
     fromBase64(companionPublicKeyB64),
-    { name: 'ECDH', namedCurve: 'P-256' },
+    { name: 'ECDH', namedCurve: 'P-521' },
     false,
     [],
   );
@@ -106,7 +106,7 @@ async function performKeyExchange(): Promise<SessionKeys> {
   const sharedSecret = await window.crypto.subtle.deriveBits(
     { name: 'ECDH', public: serverPublicKey },
     clientKeys.privateKey,
-    256,
+    528, // P-521 shared secret is 66 bytes = 528 bits
   );
 
   const hkdfBaseKey = await window.crypto.subtle.importKey(
@@ -120,8 +120,9 @@ async function performKeyExchange(): Promise<SessionKeys> {
   const sharedKeyBytes = await window.crypto.subtle.deriveBits(
     {
       name: 'HKDF',
-      hash: 'SHA-256',
-      salt: new Uint8Array(0) as Uint8Array<ArrayBuffer>,
+      hash: 'SHA-384',
+      // Python's HKDF(salt=None) uses hash-length zero salt (48 bytes for SHA-384)
+      salt: new Uint8Array(48) as Uint8Array<ArrayBuffer>,
       info: textEncoder.encode('ecdh-key-exchange'),
     },
     hkdfBaseKey,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Upgrade the ECDH key exchange curve from P-256 to P-521 for stronger cryptographic security
- Adjust derived bits length from 256 to 528 to match P-521's 66-byte shared secret
- Switch HKDF hash from SHA-256 to SHA-384 and set the salt to a 48-byte zero array to align with Python's `HKDF(salt=None)` convention on the backend

**Related issue(s)**

Resolves https://github.com/kyma-project/kyma-companion/pull/1206

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintenance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked.
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging