### PR TITLE
fix: Approval run canceled because of the same group

### DIFF
--- a/.github/workflows/busola-backend-build.yml
+++ b/.github/workflows/busola-backend-build.yml
@@ -25,7 +25,7 @@ on:
       - 'package-lock.json'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event_name == 'workflow_call' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-build.yml
+++ b/.github/workflows/busola-build.yml
@@ -40,7 +40,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event_name == 'workflow_call' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-web-build.yml
+++ b/.github/workflows/busola-web-build.yml
@@ -34,7 +34,7 @@ on:
       - 'nginx/nginx.conf'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event_name == 'workflow_call' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix concurrency group expression in all three build workflows (`busola-build`, `busola-web-build`, `busola-backend-build`) so that when they are called as `workflow_call` from `create-release`, each run gets a unique concurrency group instead of all sharing the same `refs/heads/main`-based key.
- Previously, all three sub-workflows resolved to the same concurrency group during a release run, causing GitHub Actions to cancel earlier runs in favor of a "higher priority" request — breaking the release pipeline.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
