### PR TITLE
fix: Use workflow_ref for concurrency group to prevent cross-workflow cancellation

### DIFF
--- a/.github/workflows/busola-backend-build.yml
+++ b/.github/workflows/busola-backend-build.yml
@@ -25,7 +25,7 @@ on:
       - 'package-lock.json'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event_name == 'workflow_call' && github.run_id || github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-build.yml
+++ b/.github/workflows/busola-build.yml
@@ -40,7 +40,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event_name == 'workflow_call' && github.run_id || github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-web-build.yml
+++ b/.github/workflows/busola-web-build.yml
@@ -34,7 +34,7 @@ on:
       - 'nginx/nginx.conf'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event_name == 'workflow_call' && github.run_id || github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace \`github.workflow\` with \`github.workflow_ref\` in the concurrency group key for all three build workflows (\`busola-build.yml\`, \`busola-web-build.yml\`, \`busola-backend-build.yml\`).
- The previous fix attempted to use \`github.event_name == 'workflow_call'\` to distinguish reusable workflow calls, but this does not work: when called from \`create-release.yml\` via \`workflow_dispatch\`, all sub-workflows inherit \`github.event_name == 'workflow_dispatch'\`, so the \`github.run_id\` branch never fires and all three workflows resolve to the same concurrency group (\`Create release-refs/heads/main\`), canceling each other.
- \`github.workflow_ref\` includes the file path (e.g. \`.github/workflows/busola-web-build.yml@refs/heads/main\`), which is unique per workflow file regardless of how it was triggered, permanently fixing the collision.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like \`backlog#4567\`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging