### PR TITLE
fix: Hardcode unique concurrency group prefix per workflow file

### DIFF
--- a/.github/workflows/busola-backend-build.yml
+++ b/.github/workflows/busola-backend-build.yml
@@ -25,7 +25,7 @@ on:
       - 'package-lock.json'
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
+  group: busola-backend-build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-backend-build.yml
+++ b/.github/workflows/busola-backend-build.yml
@@ -25,7 +25,7 @@ on:
       - 'package-lock.json'
 
 concurrency:
-  group: busola-backend-build-${{ github.event.pull_request.number || github.ref }}
+  group: busola-backend-build-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-build.yml
+++ b/.github/workflows/busola-build.yml
@@ -40,7 +40,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
+  group: busola-build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-build.yml
+++ b/.github/workflows/busola-build.yml
@@ -40,7 +40,7 @@ on:
   merge_group:
 
 concurrency:
-  group: busola-build-${{ github.event.pull_request.number || github.ref }}
+  group: busola-build-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-web-build.yml
+++ b/.github/workflows/busola-web-build.yml
@@ -34,7 +34,7 @@ on:
       - 'nginx/nginx.conf'
 
 concurrency:
-  group: busola-web-build-${{ github.event.pull_request.number || github.ref }}
+  group: busola-web-build-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/busola-web-build.yml
+++ b/.github/workflows/busola-web-build.yml
@@ -34,7 +34,7 @@ on:
       - 'nginx/nginx.conf'
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
+  group: busola-web-build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a hardcoded unique prefix per workflow file to the concurrency group key in \`busola-build.yml\`, \`busola-web-build.yml\`, and \`busola-backend-build.yml\`.
- \`github.workflow_ref\` resolves to the **caller's** workflow ref when invoked via \`workflow_call\`, so all three sub-workflows end up with the same concurrency group when triggered from \`create-release.yml\`, causing them to cancel each other.
- Prefixing each group with a hardcoded string unique to the file (\`busola-build-\`, \`busola-web-build-\`, \`busola-backend-build-\`) guarantees uniqueness regardless of what \`github.workflow_ref\` resolves to.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like \`backlog#4567\`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging