### PR TITLE
fix: Add pull-requests write permission to create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,6 +16,7 @@ permissions: # used by build images steps
   id-token: write # This is required for requesting the JWT token
   contents: write # This is required for actions/checkout and builds
   actions: read # This is required for using actions in the workflow
+  pull-requests: write # This is required for coverage reporting in unit tests
 
 jobs:
   build-busola-web:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add \`pull-requests: write\` permission to \`create-release.yml\` so the nested \`pull-unit-tests\` workflow can post coverage reports without a permission error.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like \`backlog#4567\`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging