### PR TITLE
fix: Remove pull-requests write permission from unit tests workflow

### DIFF
--- a/.github/workflows/pull-unit-tests.yml
+++ b/.github/workflows/pull-unit-tests.yml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     if: github.event.pull_request.draft == false
     steps:
       - uses: gardenlinux/workflow-telemetry-action@v2


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove \`pull-requests: write\` permission from the \`run-unit-and-component-test\` job in \`pull-unit-tests.yml\` so it can be called from \`create-release.yml\` without a permission conflict — the parent workflow only grants \`pull-requests: none\` and nested jobs cannot exceed the caller's permissions.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like \`backlog#4567\`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging