### PR TITLE
fix: Hardcode unique concurrency group prefix per test workflow file

### DIFF
--- a/.github/workflows/lint-check-pr.yml
+++ b/.github/workflows/lint-check-pr.yml
@@ -10,7 +10,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: lint-check-pr-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-integration-cluster-k3d.yml
+++ b/.github/workflows/pull-integration-cluster-k3d.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-integration-cluster-k3d-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-integration-namespace-k3d.yml
+++ b/.github/workflows/pull-integration-namespace-k3d.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-integration-namespace-k3d-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-k8s-chart-smoke-tests.yml
+++ b/.github/workflows/pull-k8s-chart-smoke-tests.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-k8s-chart-smoke-tests-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-kyma-integration-tests-dev.yml
+++ b/.github/workflows/pull-kyma-integration-tests-dev.yml
@@ -24,7 +24,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-kyma-integration-tests-dev-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-lighthouse.yml
+++ b/.github/workflows/pull-lighthouse.yml
@@ -17,7 +17,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-lighthouse-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-smoke-test-prod.yml
+++ b/.github/workflows/pull-smoke-test-prod.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-smoke-test-prod-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-smoke-test-stage.yml
+++ b/.github/workflows/pull-smoke-test-stage.yml
@@ -20,7 +20,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-smoke-test-stage-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-unit-tests.yml
+++ b/.github/workflows/pull-unit-tests.yml
@@ -19,7 +19,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pull-unit-tests-${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a hardcoded unique prefix per workflow file to the concurrency group key in all 9 reusable test workflows (`pull-integration-cluster-k3d`, `pull-integration-namespace-k3d`, `lint-check-pr`, `pull-smoke-test-prod`, `pull-smoke-test-stage`, `pull-kyma-integration-tests-dev`, `pull-k8s-chart-smoke-tests`, `pull-lighthouse`, `pull-unit-tests`).
- `github.workflow` resolves to the **caller's** workflow name when invoked via `workflow_call`, so all reusable test workflows end up sharing the same concurrency group when triggered from `create-release.yml`, causing them to cancel each other.
- Prefixing each group with a hardcoded string unique to the file (e.g. `pull-integration-cluster-k3d-`) plus `github.workflow_ref` guarantees uniqueness regardless of the caller, following the same pattern introduced for build workflows in #5056.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintenance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked.
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging