### PR TITLE
fix: Hide Joule iframe via DOM when webclient API is unresponsive

### DIFF
--- a/src/components/KymaCompanion/JouleChat.jsx
+++ b/src/components/KymaCompanion/JouleChat.jsx
@@ -153,14 +153,25 @@ export default function JouleChat() {
     const webclient = window.sap?.das?.webclient;
     if (!webclient) return;
 
+    // Direct DOM fallback: webclient API is unresponsive when auth fails and
+    // isOpen() returns false while the iframe container is still visible.
+    const getWebclientEl = () => document.getElementById('cai-webclient-main');
+
     if (
       showKymaCompanion.show &&
       showKymaCompanion.useJoule &&
       !webclient.isOpen()
     ) {
+      const el = getWebclientEl();
+      if (el) el.style.display = '';
       webclient.show();
-    } else if (!showKymaCompanion.show && webclient.isOpen()) {
-      webclient.hide();
+    } else if (!showKymaCompanion.show) {
+      if (webclient.isOpen()) {
+        webclient.hide();
+      } else {
+        const el = getWebclientEl();
+        if (el) el.style.display = 'none';
+      }
     }
   }, [isEnabled, showKymaCompanion]);
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fall back to direct DOM manipulation (`display: none`) to hide the Joule iframe when the `webclient` API is unresponsive 
- Expand the hide condition to no longer require `webclient.isOpen()` to return `true`, ensuring the iframe is always hidden when the companion should not be shown regardless of the webclient API state.
- Reset `display` to `''` before calling `webclient.show()` to restore visibility if it was previously force-hidden via the DOM fallback.

**Related issue(s)**

Resolves #4608

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintenance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked.
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
