### PR TITLE
fix: Emit empty statics.yaml and wizards.yaml when no sources exist

### DIFF
--- a/kyma/gulpfile.js
+++ b/kyma/gulpfile.js
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
 import { URL } from 'url';
-import { lstatSync, readdirSync, readFile, mkdirSync } from 'fs';
+import { lstatSync, readdirSync, readFile, mkdirSync, writeFileSync } from 'fs';
 import { dump, load } from 'js-yaml';
 
 import { dest, src, task } from 'gulp';
@@ -143,6 +143,9 @@ task('get-statics', () => {
 
 task('pack-statics', () => {
   const env = process.env.ENV;
+  const outDir = `build/${env}/extensions`;
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(`${outDir}/statics.yaml`, '[]');
   return src(`temp/${env}/statics-local/**/*.yaml`, { allowEmpty: true })
     .pipe(loadPreparedExtensions)
     .pipe(
@@ -150,7 +153,7 @@ task('pack-statics', () => {
         newLine: '---\n',
       }),
     )
-    .pipe(dest(`build/${env}/extensions`));
+    .pipe(dest(outDir));
 });
 
 task('clean-wizards', () => {
@@ -170,12 +173,15 @@ task('get-wizards', () => {
 
 task('pack-wizards', () => {
   const env = process.env.ENV;
-  return src(`temp/${env}/wizards-local/**/*.yaml`)
+  const outDir = `build/${env}/extensions`;
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(`${outDir}/wizards.yaml`, '[]');
+  return src(`temp/${env}/wizards-local/**/*.yaml`, { allowEmpty: true })
     .pipe(loadPreparedExtensions)
     .pipe(
       concat('wizards.yaml', {
         newLine: '---\n',
       }),
     )
-    .pipe(dest(`build/${env}/extensions`));
+    .pipe(dest(outDir));
 });

--- a/kyma/gulpfile.js
+++ b/kyma/gulpfile.js
@@ -114,14 +114,17 @@ task('get-extensions', () => {
 
 task('pack-extensions', () => {
   const env = process.env.ENV;
-  return src(`temp/${env}/extensions-local/**/*.yaml`)
+  const outDir = `build/${env}/extensions`;
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(`${outDir}/extensions.yaml`, '[]');
+  return src(`temp/${env}/extensions-local/**/*.yaml`, { allowEmpty: true })
     .pipe(loadPreparedExtensions)
     .pipe(
       concat('extensions.yaml', {
         newLine: '---\n',
       }),
     )
-    .pipe(dest(`build/${env}/extensions`));
+    .pipe(dest(outDir));
 });
 
 task('clean-statics', () => {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- `pack-statics`, `pack-wizards`, and `pack-extensions` gulp tasks now write a fallback `[]` to the output YAML file before running the concat pipeline, so `statics.yaml`, `wizards.yaml`, and `extensions.yaml` always exist in the build output even when there are no source files to pack.
- Added `{ allowEmpty: true }` to the `pack-wizards` and `pack-extensions` source globs to prevent gulp from erroring when the source directory is empty.
- Imported `writeFileSync` from `fs` to support the above.

**Related issue(s)**

See also #5096

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging