### PR TITLE
feat: Add reconnection mechamism for busola backend web sockets

### DIFF
--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -112,9 +112,9 @@ export class WebSocketConnection {
         key: this.authHeaders.clientKey,
       };
     }
-    if (this.frontWS.readyState === WebSocket.OPEN) {
+    if (this.frontWS.readyState !== WebSocket.OPEN) {
       this.logger.info(
-        'Reconnection aborted because Frontend Websocket closed.',
+        'Reconnection aborted because Frontend WebSocket closed.',
       );
       return;
     }
@@ -131,7 +131,6 @@ export class WebSocketConnection {
         );
         this.#backoff.reset();
       }
-      this.#sendMsg(this.k8sWS, encodeMsg('date'), 'K8s WebSocket');
     });
 
     this.k8sWS.addEventListener('message', (event) => {
@@ -163,7 +162,15 @@ export class WebSocketConnection {
 
   close(errMsg) {
     if (errMsg) {
-      this.frontWS.close(WS_CODE.INTERNAL_ERROR, errMsg);
+      this.#sendMsg(
+        this.frontWS,
+        encodeMsg(errMsg, Stream.STDOUT, Colors.ERROR),
+        'Busola WebSocket',
+      );
+      this.frontWS.close(
+        WS_CODE.INTERNAL_ERROR,
+        'Closing because of internal error',
+      );
     } else {
       this.frontWS.close();
     }
@@ -180,7 +187,7 @@ export class WebSocketConnection {
 
     this.frontWS.addEventListener('close', () => {
       clearTimeout(this.#reconnectTimeout);
-      this.k8sWS.close();
+      this.k8sWS?.close();
     });
   }
 
@@ -199,7 +206,7 @@ export class WebSocketConnection {
         Stream.STDOUT,
         Colors.WARNING,
       ),
-      'Busola Websocket',
+      'Busola WebSocket',
     );
     this.#reconnectTimeout = setTimeout(() => {
       this.#connectToK8s();

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -1,6 +1,19 @@
 /* global Buffer */
 import { WebSocket } from 'ws';
 
+const ANSI_RESET = '\x1b[0m';
+
+const COLOR_SUCCESS = '\x1b[32m';
+const COLOR_WARNING = '\x1b[33m';
+const COLOR_ERROR = '\x1b[31m';
+
+// \r returns the cursor to column 0 — xterm is in raw mode, so a lone \n staircases.
+const LINE_BREAK = '\n\r';
+
+function terminalMessage(text, color) {
+  return `${LINE_BREAK}${color}${text}${ANSI_RESET}${LINE_BREAK}`;
+}
+
 const Stream = Object.freeze({
   STDIN: 0,
   STDOUT: 1,
@@ -20,8 +33,13 @@ const WS_CODE = Object.freeze({
   INTERNAL_ERROR: 1011,
 });
 
-function encodeMsg(input, std = Stream.STDIN) {
-  const msgEncoded = Buffer.from(input + '\n', 'utf-8');
+function encodeMsg(input, std = Stream.STDIN, color = '') {
+  let msgEncoded = '';
+  if (std === Stream.STDIN) {
+    msgEncoded = Buffer.from(input + '\n', 'utf-8');
+  } else {
+    msgEncoded = Buffer.from(terminalMessage(input, color), 'utf-8');
+  }
   const encodedMsgForK8s = new Uint8Array(msgEncoded.length + 1);
   encodedMsgForK8s[0] = std; // set STD[IN,OUT,ERR]
   encodedMsgForK8s.set(msgEncoded, 1);
@@ -31,7 +49,11 @@ function encodeMsg(input, std = Stream.STDIN) {
 class ExponentialBackoff {
   #attempts = 0;
 
-  constructor({ maxAttempts = 3, baseDelay = 1_000, maxDelay = 10_000 } = {}) {
+  constructor({
+    maxAttempts = 3,
+    baseDelay = 10_000,
+    maxDelay = 100_000,
+  } = {}) {
     this.maxAttempts = maxAttempts;
     this.baseDelay = baseDelay;
     this.maxDelay = maxDelay;
@@ -41,6 +63,9 @@ class ExponentialBackoff {
     this.#attempts = 0;
   }
 
+  isFresh() {
+    return this.#attempts !== 0;
+  }
   exhausted() {
     return this.#attempts >= this.maxAttempts;
   }
@@ -96,7 +121,13 @@ export class WebSocketConnection {
       opts,
     );
     this.k8sWS.addEventListener('open', () => {
-      this.#backoff.reset();
+      if (!this.#backoff.isFresh) {
+        this.#sendMsg(
+          this.frontWS,
+          encodeMsg('Reconnection succeeded', Stream.STDOUT, COLOR_SUCCESS),
+        );
+        this.#backoff.reset();
+      }
       this.#sendMsg(this.k8sWS, encodeMsg('date'), 'K8s WebSocket');
     });
 
@@ -105,7 +136,7 @@ export class WebSocketConnection {
     });
 
     this.k8sWS.addEventListener('error', (event) => {
-      this.logger.error({ err: event }, 'K8s WebSocket error: ');
+      this.logger.error({ err: event }, 'K8s WebSocket error');
     });
 
     this.k8sWS.addEventListener('close', (event) => {
@@ -131,7 +162,7 @@ export class WebSocketConnection {
     if (errMsg) {
       this.frontWS.close(
         WS_CODE.INTERNAL_ERROR,
-        encodeMsg(errMsg, Stream.STDOUT),
+        encodeMsg(errMsg, Stream.STDOUT, COLOR_ERROR),
       );
     } else {
       this.frontWS.close();
@@ -164,7 +195,9 @@ export class WebSocketConnection {
     this.#sendMsg(
       this.frontWS,
       encodeMsg(
-        'Trying to reconnect to backend in ' + delay.toFixed(0) + '....',
+        'Trying to reconnect to K8s in ' + delay.toFixed(0) + ' [ms]....',
+        Stream.STDOUT,
+        COLOR_WARNING,
       ),
       'Busola Websocket',
     );

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -1,17 +1,18 @@
 /* global Buffer */
 import { WebSocket } from 'ws';
 
-const ANSI_RESET = '\x1b[0m';
+const Colors = Object.freeze({
+  SUCCESS: '\x1b[32m',
+  WARNING: '\x1b[33m',
+  ERROR: '\x1b[31m',
+});
 
-const COLOR_SUCCESS = '\x1b[32m';
-const COLOR_WARNING = '\x1b[33m';
-const COLOR_ERROR = '\x1b[31m';
-
-// \r returns the cursor to column 0 — xterm is in raw mode, so a lone \n staircases.
+// a lone \n in termianl raw mode only move cursor down, the \r makes it to return to the begging.
 const LINE_BREAK = '\n\r';
 
 function terminalMessage(text, color) {
-  return `${LINE_BREAK}${color}${text}${ANSI_RESET}${LINE_BREAK}`;
+  const colorReset = '\x1b[0m';
+  return `${LINE_BREAK}${color}${text}${colorReset}${LINE_BREAK}`;
 }
 
 const Stream = Object.freeze({
@@ -49,11 +50,7 @@ function encodeMsg(input, std = Stream.STDIN, color = '') {
 class ExponentialBackoff {
   #attempts = 0;
 
-  constructor({
-    maxAttempts = 3,
-    baseDelay = 10_000,
-    maxDelay = 100_000,
-  } = {}) {
+  constructor({ maxAttempts = 3, baseDelay = 1_000, maxDelay = 10_000 } = {}) {
     this.maxAttempts = maxAttempts;
     this.baseDelay = baseDelay;
     this.maxDelay = maxDelay;
@@ -124,7 +121,7 @@ export class WebSocketConnection {
       if (!this.#backoff.isFresh) {
         this.#sendMsg(
           this.frontWS,
-          encodeMsg('Reconnection succeeded', Stream.STDOUT, COLOR_SUCCESS),
+          encodeMsg('Reconnection succeeded', Stream.STDOUT, Colors.SUCCESS),
         );
         this.#backoff.reset();
       }
@@ -162,7 +159,7 @@ export class WebSocketConnection {
     if (errMsg) {
       this.frontWS.close(
         WS_CODE.INTERNAL_ERROR,
-        encodeMsg(errMsg, Stream.STDOUT, COLOR_ERROR),
+        encodeMsg(errMsg, Stream.STDOUT, Colors.ERROR),
       );
     } else {
       this.frontWS.close();
@@ -197,7 +194,7 @@ export class WebSocketConnection {
       encodeMsg(
         'Trying to reconnect to K8s in ' + delay.toFixed(0) + ' [ms]....',
         Stream.STDOUT,
-        COLOR_WARNING,
+        Colors.WARNING,
       ),
       'Busola Websocket',
     );

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -97,7 +97,7 @@ export class WebSocketConnection {
     );
     this.k8sWS.addEventListener('open', () => {
       this.#backoff.reset();
-      this.#sendMsg(this.frontWS, encodeMsg('date'), 'Busola WebSocket');
+      this.#sendMsg(this.k8sWS, encodeMsg('date'), 'Busola WebSocket');
     });
 
     this.k8sWS.addEventListener('message', (event) => {
@@ -155,9 +155,7 @@ export class WebSocketConnection {
 
   #reconnect() {
     if (this.#backoff.exhausted()) {
-      this.logger.info(
-        'Max reconnection attempts reached for: ' + this.remoteURL,
-      );
+      this.logger.info('Max reconnection attempts reached');
       this.close('Max reconnection attempts reached, closing');
       return;
     }

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -112,6 +112,12 @@ export class WebSocketConnection {
         key: this.authHeaders.clientKey,
       };
     }
+    if (this.frontWS.readyState === WebSocket.OPEN) {
+      this.logger.info(
+        'Reconnection aborted because Frontend Websocket closed.',
+      );
+      return;
+    }
     this.k8sWS = new WebSocket(
       this.remoteURL,
       [this.authHeaders.protocol],
@@ -157,10 +163,7 @@ export class WebSocketConnection {
 
   close(errMsg) {
     if (errMsg) {
-      this.frontWS.close(
-        WS_CODE.INTERNAL_ERROR,
-        encodeMsg(errMsg, Stream.STDOUT, Colors.ERROR),
-      );
+      this.frontWS.close(WS_CODE.INTERNAL_ERROR, errMsg);
     } else {
       this.frontWS.close();
     }
@@ -198,7 +201,6 @@ export class WebSocketConnection {
       ),
       'Busola Websocket',
     );
-
     this.#reconnectTimeout = setTimeout(() => {
       this.#connectToK8s();
     }, delay);

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -97,7 +97,7 @@ export class WebSocketConnection {
     );
     this.k8sWS.addEventListener('open', () => {
       this.#backoff.reset();
-      this.#sendMsg(this.k8sWS, encodeMsg('date'), 'Busola WebSocket');
+      this.#sendMsg(this.k8sWS, encodeMsg('date'), 'K8s WebSocket');
     });
 
     this.k8sWS.addEventListener('message', (event) => {

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -1,0 +1,152 @@
+/* global Math */
+
+import { WebSocket } from 'ws';
+
+const Stream = Object.freeze({
+  STDIN: 0,
+  STDOUT: 1,
+  STDERR: 2,
+});
+
+export class WebSocketConnection {
+  #reconnectionAttempts = 0;
+  #maxReconnectionAttemps = 3;
+  #baseDelay = 1_000;
+  #maxDelay = 10_000;
+
+  constructor(remoteURL, frontWS, authHeaders, logger) {
+    this.remoteURL = remoteURL;
+    this.frontWS = frontWS;
+    this.k8sWS = null;
+    this.logger = logger;
+    this.authHeaders = authHeaders;
+  }
+
+  #nextDelay() {
+    const delay = Math.min(
+      this.#baseDelay * Math.pow(2, this.#reconnectionAttempts),
+      this.#maxDelay,
+    );
+    const jitter = delay * 0.2 * Math.random();
+    return delay + jitter;
+  }
+
+  #reconnect() {
+    if (this.#reconnectionAttempts > this.#maxReconnectionAttemps) {
+      this.logger.info(
+        'Max reconnection attempts reached for: ' + this.remoteURL,
+      );
+      return;
+    }
+    const delay = this.#nextDelay();
+    this.logger.info('reconnection in: ' + delay.toFixed(4) + '[ms]');
+    this.frontWS.send(
+      this.#encodeMsg(
+        'Trying to reconnect to backend in ' + delay.toFixed(4) + '....',
+      ),
+    );
+
+    setTimeout(() => {
+      this.#reconnectionAttempts++;
+      this.connect();
+    }, delay);
+  }
+
+  connect() {
+    let opts;
+    if (this.authHeaders.token) {
+      opts = {
+        ca: this.authHeaders.ca,
+        headers: {
+          Authorization: this.authHeaders.token,
+        },
+      };
+    } else {
+      opts = {
+        ca: this.authHeaders.ca,
+        cert: this.authHeaders.clientCert,
+        key: this.authHeaders.clientKey,
+      };
+    }
+    this.k8sWS = new WebSocket(
+      this.remoteURL,
+      [this.authHeaders.protocol],
+      opts,
+    );
+    this.#startMessageProxy();
+  }
+
+  #startMessageProxy() {
+    this.k8sWS.addEventListener('open', () => {
+      // TODO: Currently the busola terminal uses default service account which has 0 permissions to access k8s api.
+      // We can try to build kubeconfig and add it to env
+      // TODO: This is a help command executed at the begining of connection, we can change or remove it completely.
+      this.#reconnectionAttempts = 0;
+      this.k8sWS.send(this.#encodeMsg('date'));
+    });
+
+    this.k8sWS.addEventListener('message', (event) => {
+      if (this.frontWS.readyState === WebSocket.OPEN) {
+        const data = event.data;
+        this.frontWS.send(data);
+      } else {
+        this.logger.info(
+          'Front WS is not open, cannot send message, status: ' +
+            this.frontWS.readyState,
+        );
+      }
+    });
+
+    this.k8sWS.addEventListener('error', (event) => {
+      this.logger.error({ err: event }, 'K8s WebSocket error: ');
+    });
+
+    this.k8sWS.addEventListener('close', (event) => {
+      // Abnormal closure || Internal Server Error
+      if (event.code === 1006 || event.code === 1011) {
+        this.k8sWS.close();
+        this.#reconnect();
+        return;
+      }
+      this.logger.info('K8s WebSocket closed, reason:' + event.code);
+      const closingMsg = 'Remote connection closed';
+      this.frontWS.send(this.#encodeMsg(closingMsg, Stream.STDOUT));
+      this.frontWS.close();
+    });
+
+    this.frontWS.addEventListener('error', (event) => {
+      this.logger.error({ err: event }, 'Front WebSocket error: ');
+    });
+
+    this.frontWS.addEventListener('message', (event) => {
+      if (this.k8sWS.readyState === WebSocket.OPEN) {
+        const data = event.data;
+        this.k8sWS.send(data);
+      } else {
+        this.logger.info(
+          'K8s WS is not open, cannot send message, status: ' +
+            this.k8sWS.readyState,
+        );
+      }
+    });
+
+    this.frontWS.addEventListener('close', () => this.k8sWS.close());
+  }
+
+  #encodeMsg(input, std = Stream.STDIN) {
+    const msgEncoded = Buffer.from(input + '\n', 'utf-8');
+    const encodedMsgForK8s = new Uint8Array(msgEncoded.length + 1);
+    encodedMsgForK8s[0] = std; // set STD[IN,OUT,ERR]
+    encodedMsgForK8s.set(msgEncoded, 1);
+    return encodedMsgForK8s;
+  }
+
+  close(msg) {
+    if (msg) {
+      this.frontWS.close(
+        1011,
+        encodeMsg('Internal Server Error', Stream.STDOUT),
+      );
+    }
+  }
+}

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -7,7 +7,7 @@ const Colors = Object.freeze({
   ERROR: '\x1b[31m',
 });
 
-// a lone \n in termianl raw mode only move cursor down, the \r makes it to return to the begging.
+// a lone \n in terminal raw mode only move cursor down, the \r makes it return to the beginning.
 const LINE_BREAK = '\n\r';
 
 function terminalMessage(text, color) {
@@ -60,7 +60,7 @@ class ExponentialBackoff {
     this.#attempts = 0;
   }
 
-  isFresh() {
+  hasLaunched() {
     return this.#attempts !== 0;
   }
   exhausted() {
@@ -118,7 +118,7 @@ export class WebSocketConnection {
       opts,
     );
     this.k8sWS.addEventListener('open', () => {
-      if (!this.#backoff.isFresh) {
+      if (!this.#backoff.hasLaunched()) {
         this.#sendMsg(
           this.frontWS,
           encodeMsg('Reconnection succeeded', Stream.STDOUT, Colors.SUCCESS),

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -118,7 +118,7 @@ export class WebSocketConnection {
       opts,
     );
     this.k8sWS.addEventListener('open', () => {
-      if (!this.#backoff.hasLaunched()) {
+      if (this.#backoff.hasLaunched()) {
         this.#sendMsg(
           this.frontWS,
           encodeMsg('Reconnection succeeded', Stream.STDOUT, Colors.SUCCESS),

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -1,3 +1,4 @@
+/* global Buffer */
 import { WebSocket } from 'ws';
 
 const Stream = Object.freeze({

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -10,35 +10,35 @@ const Stream = Object.freeze({
 
 export class WebSocketConnection {
   #reconnectionAttempts = 0;
-  #maxReconnectionAttemps = 3;
-  #baseDelay = 1_000;
-  #maxDelay = 10_000;
 
-  constructor(remoteURL, frontWS, authHeaders, logger) {
+  constructor(remoteURL, frontWS, authHeaders, logger, backoffConfig) {
     this.remoteURL = remoteURL;
     this.frontWS = frontWS;
     this.k8sWS = null;
     this.logger = logger;
     this.authHeaders = authHeaders;
+    this.maxReconnectionAttemps = backoffConfig?.maxReconnectionAttemps || 3;
+    this.baseDelay = backoffConfig?.baseDelay || 1_000;
+    this.maxDelay = backoffConfig?.maxDelay || 10_000;
   }
 
-  #nextDelay() {
+  #nextExponentialDelay() {
     const delay = Math.min(
-      this.#baseDelay * Math.pow(2, this.#reconnectionAttempts),
-      this.#maxDelay,
+      this.baseDelay * Math.pow(2, this.#reconnectionAttempts),
+      this.maxDelay,
     );
     const jitter = delay * 0.2 * Math.random();
     return delay + jitter;
   }
 
   #reconnect() {
-    if (this.#reconnectionAttempts > this.#maxReconnectionAttemps) {
+    if (this.#reconnectionAttempts >= this.maxReconnectionAttemps) {
       this.logger.info(
         'Max reconnection attempts reached for: ' + this.remoteURL,
       );
       return;
     }
-    const delay = this.#nextDelay();
+    const delay = this.#nextExponentialDelay();
     this.logger.info('reconnection in: ' + delay.toFixed(4) + '[ms]');
     this.frontWS.send(
       this.#encodeMsg(

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -58,6 +58,7 @@ class ExponentialBackoff {
 
 export class WebSocketConnection {
   #backoff;
+  #reconnectTimeout = null;
 
   constructor(remoteURL, frontWS, authHeaders, logger, backoffConfig) {
     this.remoteURL = remoteURL;
@@ -69,6 +70,11 @@ export class WebSocketConnection {
   }
 
   connect() {
+    this.#connectToK8s();
+    this.#startProxyingMsgToBusola();
+  }
+
+  #connectToK8s() {
     let opts;
     if (this.authHeaders.token) {
       opts = {
@@ -89,21 +95,6 @@ export class WebSocketConnection {
       [this.authHeaders.protocol],
       opts,
     );
-    this.#startMessageProxy();
-  }
-
-  close(errMsg) {
-    if (errMsg) {
-      this.frontWS.close(
-        WS_CODE.INTERNAL_ERROR,
-        encodeMsg(errMsg, Stream.STDOUT),
-      );
-    } else {
-      this.frontWS.close();
-    }
-  }
-
-  #startMessageProxy() {
     this.k8sWS.addEventListener('open', () => {
       this.#backoff.reset();
       this.#sendMsg(this.frontWS, encodeMsg('date'), 'Busola WebSocket');
@@ -134,7 +125,20 @@ export class WebSocketConnection {
       );
       this.frontWS.close();
     });
+  }
 
+  close(errMsg) {
+    if (errMsg) {
+      this.frontWS.close(
+        WS_CODE.INTERNAL_ERROR,
+        encodeMsg(errMsg, Stream.STDOUT),
+      );
+    } else {
+      this.frontWS.close();
+    }
+  }
+
+  #startProxyingMsgToBusola() {
     this.frontWS.addEventListener('error', (event) => {
       this.logger.error({ err: event }, 'Front WebSocket error: ');
     });
@@ -143,7 +147,10 @@ export class WebSocketConnection {
       this.#sendMsg(this.k8sWS, event.data, 'K8s WebSocket');
     });
 
-    this.frontWS.addEventListener('close', () => this.k8sWS.close());
+    this.frontWS.addEventListener('close', () => {
+      clearTimeout(this.#reconnectTimeout);
+      this.k8sWS.close();
+    });
   }
 
   #reconnect() {
@@ -164,8 +171,8 @@ export class WebSocketConnection {
       'Busola Websocket',
     );
 
-    setTimeout(() => {
-      this.connect();
+    this.#reconnectTimeout = setTimeout(() => {
+      this.#connectToK8s();
     }, delay);
   }
 

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -27,8 +27,36 @@ function encodeMsg(input, std = Stream.STDIN) {
   return encodedMsgForK8s;
 }
 
+class ExponentialBackoff {
+  #attempts = 0;
+
+  constructor({ maxAttempts = 3, baseDelay = 1_000, maxDelay = 10_000 } = {}) {
+    this.maxAttempts = maxAttempts;
+    this.baseDelay = baseDelay;
+    this.maxDelay = maxDelay;
+  }
+
+  reset() {
+    this.#attempts = 0;
+  }
+
+  exhausted() {
+    return this.#attempts >= this.maxAttempts;
+  }
+
+  next() {
+    const delay = Math.min(
+      this.baseDelay * Math.pow(2, this.#attempts),
+      this.maxDelay,
+    );
+    const jitter = delay * 0.2 * Math.random();
+    this.#attempts++;
+    return delay + jitter;
+  }
+}
+
 export class WebSocketConnection {
-  #reconnectionAttempts = 0;
+  #backoff;
 
   constructor(remoteURL, frontWS, authHeaders, logger, backoffConfig) {
     this.remoteURL = remoteURL;
@@ -36,9 +64,7 @@ export class WebSocketConnection {
     this.k8sWS = null;
     this.logger = logger;
     this.authHeaders = authHeaders;
-    this.maxReconnectionAttempts = backoffConfig?.maxReconnectionAttempts || 3;
-    this.baseDelay = backoffConfig?.baseDelay || 1_000;
-    this.maxDelay = backoffConfig?.maxDelay || 10_000;
+    this.#backoff = new ExponentialBackoff(backoffConfig);
   }
 
   connect() {
@@ -78,7 +104,7 @@ export class WebSocketConnection {
 
   #startMessageProxy() {
     this.k8sWS.addEventListener('open', () => {
-      this.#reconnectionAttempts = 0;
+      this.#backoff.reset();
       this.#sendMsg(this.frontWS, encodeMsg('date'), 'Busola WebSocket');
     });
 
@@ -120,14 +146,14 @@ export class WebSocketConnection {
   }
 
   #reconnect() {
-    if (this.#reconnectionAttempts >= this.maxReconnectionAttempts) {
+    if (this.#backoff.exhausted()) {
       this.logger.info(
         'Max reconnection attempts reached for: ' + this.remoteURL,
       );
       this.close('Max reconnection attempts reached, closing');
       return;
     }
-    const delay = this.#nextExponentialDelay();
+    const delay = this.#backoff.next();
     this.logger.info('reconnection in: ' + delay.toFixed(0) + '[ms]');
     this.#sendMsg(
       this.frontWS,
@@ -138,18 +164,8 @@ export class WebSocketConnection {
     );
 
     setTimeout(() => {
-      this.#reconnectionAttempts++;
       this.connect();
     }, delay);
-  }
-
-  #nextExponentialDelay() {
-    const delay = Math.min(
-      this.baseDelay * Math.pow(2, this.#reconnectionAttempts),
-      this.maxDelay,
-    );
-    const jitter = delay * 0.2 * Math.random();
-    return delay + jitter;
   }
 
   #sendMsg(webSocket, data, webSocketName) {

--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -1,5 +1,3 @@
-/* global Math */
-
 import { WebSocket } from 'ws';
 
 const Stream = Object.freeze({
@@ -7,6 +5,27 @@ const Stream = Object.freeze({
   STDOUT: 1,
   STDERR: 2,
 });
+
+const WS_CODE = Object.freeze({
+  NORMAL_CLOSURE: 1000,
+  GOING_AWAY: 1001,
+  PROTOCOL_ERROR: 1002,
+  UNSUPPORTED_DATA: 1003,
+  NO_STATUS: 1005,
+  ABNORMAL_CLOSURE: 1006,
+  INVALID_PAYLOAD: 1007,
+  POLICY_VIOLATION: 1008,
+  MESSAGE_TOO_BIG: 1009,
+  INTERNAL_ERROR: 1011,
+});
+
+function encodeMsg(input, std = Stream.STDIN) {
+  const msgEncoded = Buffer.from(input + '\n', 'utf-8');
+  const encodedMsgForK8s = new Uint8Array(msgEncoded.length + 1);
+  encodedMsgForK8s[0] = std; // set STD[IN,OUT,ERR]
+  encodedMsgForK8s.set(msgEncoded, 1);
+  return encodedMsgForK8s;
+}
 
 export class WebSocketConnection {
   #reconnectionAttempts = 0;
@@ -17,39 +36,9 @@ export class WebSocketConnection {
     this.k8sWS = null;
     this.logger = logger;
     this.authHeaders = authHeaders;
-    this.maxReconnectionAttemps = backoffConfig?.maxReconnectionAttemps || 3;
+    this.maxReconnectionAttempts = backoffConfig?.maxReconnectionAttempts || 3;
     this.baseDelay = backoffConfig?.baseDelay || 1_000;
     this.maxDelay = backoffConfig?.maxDelay || 10_000;
-  }
-
-  #nextExponentialDelay() {
-    const delay = Math.min(
-      this.baseDelay * Math.pow(2, this.#reconnectionAttempts),
-      this.maxDelay,
-    );
-    const jitter = delay * 0.2 * Math.random();
-    return delay + jitter;
-  }
-
-  #reconnect() {
-    if (this.#reconnectionAttempts >= this.maxReconnectionAttemps) {
-      this.logger.info(
-        'Max reconnection attempts reached for: ' + this.remoteURL,
-      );
-      return;
-    }
-    const delay = this.#nextExponentialDelay();
-    this.logger.info('reconnection in: ' + delay.toFixed(4) + '[ms]');
-    this.frontWS.send(
-      this.#encodeMsg(
-        'Trying to reconnect to backend in ' + delay.toFixed(4) + '....',
-      ),
-    );
-
-    setTimeout(() => {
-      this.#reconnectionAttempts++;
-      this.connect();
-    }, delay);
   }
 
   connect() {
@@ -76,25 +65,25 @@ export class WebSocketConnection {
     this.#startMessageProxy();
   }
 
+  close(errMsg) {
+    if (errMsg) {
+      this.frontWS.close(
+        WS_CODE.INTERNAL_ERROR,
+        encodeMsg(errMsg, Stream.STDOUT),
+      );
+    } else {
+      this.frontWS.close();
+    }
+  }
+
   #startMessageProxy() {
     this.k8sWS.addEventListener('open', () => {
-      // TODO: Currently the busola terminal uses default service account which has 0 permissions to access k8s api.
-      // We can try to build kubeconfig and add it to env
-      // TODO: This is a help command executed at the begining of connection, we can change or remove it completely.
       this.#reconnectionAttempts = 0;
-      this.k8sWS.send(this.#encodeMsg('date'));
+      this.#sendMsg(this.frontWS, encodeMsg('date'), 'Busola WebSocket');
     });
 
     this.k8sWS.addEventListener('message', (event) => {
-      if (this.frontWS.readyState === WebSocket.OPEN) {
-        const data = event.data;
-        this.frontWS.send(data);
-      } else {
-        this.logger.info(
-          'Front WS is not open, cannot send message, status: ' +
-            this.frontWS.readyState,
-        );
-      }
+      this.#sendMsg(this.frontWS, event.data, 'Busola WebSocket');
     });
 
     this.k8sWS.addEventListener('error', (event) => {
@@ -102,15 +91,20 @@ export class WebSocketConnection {
     });
 
     this.k8sWS.addEventListener('close', (event) => {
-      // Abnormal closure || Internal Server Error
-      if (event.code === 1006 || event.code === 1011) {
-        this.k8sWS.close();
+      if (
+        event.code === WS_CODE.ABNORMAL_CLOSURE ||
+        event.code === WS_CODE.INTERNAL_ERROR
+      ) {
         this.#reconnect();
         return;
       }
       this.logger.info('K8s WebSocket closed, reason:' + event.code);
       const closingMsg = 'Remote connection closed';
-      this.frontWS.send(this.#encodeMsg(closingMsg, Stream.STDOUT));
+      this.#sendMsg(
+        this.frontWS,
+        encodeMsg(closingMsg, Stream.STDOUT),
+        'Busola WebSocket',
+      );
       this.frontWS.close();
     });
 
@@ -119,33 +113,53 @@ export class WebSocketConnection {
     });
 
     this.frontWS.addEventListener('message', (event) => {
-      if (this.k8sWS.readyState === WebSocket.OPEN) {
-        const data = event.data;
-        this.k8sWS.send(data);
-      } else {
-        this.logger.info(
-          'K8s WS is not open, cannot send message, status: ' +
-            this.k8sWS.readyState,
-        );
-      }
+      this.#sendMsg(this.k8sWS, event.data, 'K8s WebSocket');
     });
 
     this.frontWS.addEventListener('close', () => this.k8sWS.close());
   }
 
-  #encodeMsg(input, std = Stream.STDIN) {
-    const msgEncoded = Buffer.from(input + '\n', 'utf-8');
-    const encodedMsgForK8s = new Uint8Array(msgEncoded.length + 1);
-    encodedMsgForK8s[0] = std; // set STD[IN,OUT,ERR]
-    encodedMsgForK8s.set(msgEncoded, 1);
-    return encodedMsgForK8s;
+  #reconnect() {
+    if (this.#reconnectionAttempts >= this.maxReconnectionAttempts) {
+      this.logger.info(
+        'Max reconnection attempts reached for: ' + this.remoteURL,
+      );
+      this.close('Max reconnection attempts reached, closing');
+      return;
+    }
+    const delay = this.#nextExponentialDelay();
+    this.logger.info('reconnection in: ' + delay.toFixed(0) + '[ms]');
+    this.#sendMsg(
+      this.frontWS,
+      encodeMsg(
+        'Trying to reconnect to backend in ' + delay.toFixed(0) + '....',
+      ),
+      'Busola Websocket',
+    );
+
+    setTimeout(() => {
+      this.#reconnectionAttempts++;
+      this.connect();
+    }, delay);
   }
 
-  close(msg) {
-    if (msg) {
-      this.frontWS.close(
-        1011,
-        encodeMsg('Internal Server Error', Stream.STDOUT),
+  #nextExponentialDelay() {
+    const delay = Math.min(
+      this.baseDelay * Math.pow(2, this.#reconnectionAttempts),
+      this.maxDelay,
+    );
+    const jitter = delay * 0.2 * Math.random();
+    return delay + jitter;
+  }
+
+  #sendMsg(webSocket, data, webSocketName) {
+    if (webSocket.readyState === WebSocket.OPEN) {
+      webSocket.send(data);
+    } else {
+      this.logger.info(
+        webSocketName +
+          ' is not open, cannot send message, status: ' +
+          webSocket.readyState,
       );
     }
   }

--- a/backend/src/terminal/handler.js
+++ b/backend/src/terminal/handler.js
@@ -3,6 +3,7 @@ import { WebSocket, WebSocketServer } from 'ws';
 import parseProtocolHeaders from './protocolHeaderParser';
 import { pinoWebSocketLogger } from '../../logging/';
 import { InvalidInputError } from '../errors/errors';
+import { WebSocketConnection } from './connection';
 
 function buildRemoteURL(url, remoteURL) {
   const remoteServerAddress = remoteURL.replace('https://', '');
@@ -14,20 +15,6 @@ function buildRemoteURL(url, remoteURL) {
 const baseURLStub = 'https://localhost';
 
 const webSocketPath = '/backend/ws/';
-
-const Stream = Object.freeze({
-  STDIN: 0,
-  STDOUT: 1,
-  STDERR: 2,
-});
-
-function encodeMsg(input, std = Stream.STDIN) {
-  const msgEncoded = Buffer.from(input + '\n', 'utf-8');
-  const encodedMsgForK8s = new Uint8Array(msgEncoded.length + 1);
-  encodedMsgForK8s[0] = std; // set STD[IN,OUT,ERR]
-  encodedMsgForK8s.set(msgEncoded, 1);
-  return encodedMsgForK8s;
-}
 
 const handleUpgrade = (webSocketServer) => {
   return function (req, socket, head) {
@@ -82,6 +69,7 @@ export default function registerWebSocket(server) {
   const webSocketServer = new WebSocketServer({ noServer: true });
   server.on('upgrade', handleUpgrade(webSocketServer));
 
+  let connection = null;
   webSocketServer.on('connection', (frontWS, req) => {
     req.logger.info('Starting WebSocket connection proxy');
     try {
@@ -89,73 +77,18 @@ export default function registerWebSocket(server) {
       const remoteURL = buildRemoteURL(url, req.authHeaders.clusterURL);
       req.logger.info('Connecting to:' + remoteURL);
 
-      let opts;
-      if (req.authHeaders.token) {
-        opts = {
-          ca: req.authHeaders.ca,
-          headers: {
-            Authorization: req.authHeaders.token,
-          },
-        };
-      } else {
-        opts = {
-          ca: req.authHeaders.ca,
-          cert: req.authHeaders.clientCert,
-          key: req.authHeaders.clientKey,
-        };
-      }
-      const k8sWS = new WebSocket(remoteURL, [req.authHeaders.protocol], opts);
+      connection = new WebSocketConnection(
+        remoteURL,
+        frontWS,
+        req.authHeaders,
+        req.logger,
+      );
 
-      k8sWS.addEventListener('open', () => {
-        // TODO: Currently the busola terminal uses default service account which has 0 permissions to access k8s api.
-        // We can try to build kubeconfig and add it to env
-        // TODO: This is a help command executed at the begining of connection, we can change or remove it completely.
-        k8sWS.send(encodeMsg('kubectl'));
-      });
-
-      k8sWS.addEventListener('message', (event) => {
-        if (frontWS.readyState === WebSocket.OPEN) {
-          const data = event.data;
-          frontWS.send(data);
-        } else {
-          req.logger.info(
-            'Front WS is not open, cannot send message, status: ' +
-              frontWS.readyState,
-          );
-        }
-      });
-
-      k8sWS.addEventListener('error', (event) => {
-        req.logger.error({ err: event }, 'K8s WebSocket error: ');
-      });
-
-      k8sWS.addEventListener('close', () => {
-        req.logger.info('K8s WebSocket closed');
-        const closingMsg = 'Remote connection closed';
-        frontWS.send(encodeMsg(closingMsg, Stream.STDOUT));
-        frontWS.close();
-      });
-
-      frontWS.addEventListener('error', (event) => {
-        req.logger.error({ err: event }, 'Front WebSocket error: ');
-      });
-
-      frontWS.addEventListener('message', (event) => {
-        if (k8sWS.readyState === WebSocket.OPEN) {
-          const data = event.data;
-          k8sWS.send(data);
-        } else {
-          req.logger.info(
-            'K8s WS is not open, cannot send message, status: ' +
-              k8sWS.readyState,
-          );
-        }
-      });
-
-      frontWS.addEventListener('close', () => k8sWS.close());
+      connection.connect();
     } catch (e) {
-      frontWS.close(1011, encodeMsg('Internal Server Error', Stream.STDOUT));
       req.logger.error({ err: e }, 'Error during WebSocket proxy connections');
+    } finally {
+      connection?.close();
     }
   });
 }

--- a/backend/src/terminal/handler.js
+++ b/backend/src/terminal/handler.js
@@ -1,5 +1,4 @@
-/* global Buffer */
-import { WebSocket, WebSocketServer } from 'ws';
+import { WebSocketServer } from 'ws';
 import parseProtocolHeaders from './protocolHeaderParser';
 import { pinoWebSocketLogger } from '../../logging/';
 import { InvalidInputError } from '../errors/errors';

--- a/backend/src/terminal/handler.js
+++ b/backend/src/terminal/handler.js
@@ -69,8 +69,8 @@ export default function registerWebSocket(server) {
   const webSocketServer = new WebSocketServer({ noServer: true });
   server.on('upgrade', handleUpgrade(webSocketServer));
 
-  let connection = null;
   webSocketServer.on('connection', (frontWS, req) => {
+    let connection = null;
     req.logger.info('Starting WebSocket connection proxy');
     try {
       const url = new URL(req.url, 'http://' + req.socket.remoteAddress);
@@ -87,8 +87,7 @@ export default function registerWebSocket(server) {
       connection.connect();
     } catch (e) {
       req.logger.error({ err: e }, 'Error during WebSocket proxy connections');
-    } finally {
-      connection?.close();
+      connection?.close('Internal Server Error');
     }
   });
 }

--- a/src/components/App/BusolaTerminal/connectTerminal.test.ts
+++ b/src/components/App/BusolaTerminal/connectTerminal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { connectTerminal } from './connectTerminal';
 import { encodeBase64Url } from 'shared/utils/base64url';
 
@@ -132,6 +132,8 @@ describe('connectTerminal', () => {
       closed: 'translated-closed',
       connectionError: 'translated-error',
     };
+    const expectedReason = 'Closing because I can';
+
     const { ws, term } = await attach(new AbortController().signal, messages);
 
     ws.onopen();
@@ -139,7 +141,10 @@ describe('connectTerminal', () => {
       expect.stringContaining('translated-connected'),
     );
 
-    ws.onclose();
+    ws.onclose({ reason: expectedReason });
+    expect(term.write).toHaveBeenCalledWith(
+      expect.stringContaining(expectedReason),
+    );
     expect(term.write).toHaveBeenCalledWith(
       expect.stringContaining('translated-closed'),
     );

--- a/src/components/App/BusolaTerminal/connectTerminal.ts
+++ b/src/components/App/BusolaTerminal/connectTerminal.ts
@@ -91,7 +91,9 @@ export async function connectTerminal({
   ws.onclose = (event) => {
     if (signal.aborted) return;
     setSession((prev) => ({ ...prev, status: 'idle' }));
-    term.write(terminalMessage(COLOR_ERROR, event.reason));
+    if (event.reason) {
+      term.write(terminalMessage(COLOR_ERROR, event.reason));
+    }
     term.write(terminalMessage(COLOR_WARNING, messages.closed));
   };
 

--- a/src/components/App/BusolaTerminal/connectTerminal.ts
+++ b/src/components/App/BusolaTerminal/connectTerminal.ts
@@ -88,9 +88,10 @@ export async function connectTerminal({
     }
   };
 
-  ws.onclose = () => {
+  ws.onclose = (event) => {
     if (signal.aborted) return;
     setSession((prev) => ({ ...prev, status: 'idle' }));
+    term.write(terminalMessage(COLOR_ERROR, event.reason));
     term.write(terminalMessage(COLOR_WARNING, messages.closed));
   };
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add re connection mechanism for backend connecting to k8s

Example log of reconnection:
```
{"level":30,"time":1784014737196,"pid":452398,"hostname":"damian-praca-thinkpad","req":{"method":"GET","url":"/backend/ws/api/v1/namespaces/busola-terminal/pods/busola-terminal-12c4dd29e3eeb16c/attach?container=dev-toolbox&stdin=true&stdout=true&stderr=true&tty=true"},"msg":"reconnection in: 1147.8507[ms]"}
{"level":30,"time":1784014738347,"pid":452398,"hostname":"damian-praca-thinkpad","req":{"method":"GET","url":"/backend/ws/api/v1/namespaces/busola-terminal/pods/busola-terminal-12c4dd29e3eeb16c/attach?container=dev-toolbox&stdin=true&stdout=true&stderr=true&tty=true"},"msg":"reconnection in: 2104.8767[ms]"}
{"level":30,"time":1784014740453,"pid":452398,"hostname":"damian-praca-thinkpad","req":{"method":"GET","url":"/backend/ws/api/v1/namespaces/busola-terminal/pods/busola-terminal-12c4dd29e3eeb16c/attach?container=dev-toolbox&stdin=true&stdout=true&stderr=true&tty=true"},"msg":"reconnection in: 4765.2917[ms]"}
{"level":30,"time":1784014745219,"pid":452398,"hostname":"damian-praca-thinkpad","req":{"method":"GET","url":"/backend/ws/api/v1/namespaces/busola-terminal/pods/busola-terminal-12c4dd29e3eeb16c/attach?container=dev-toolbox&stdin=true&stdout=true&stderr=true&tty=true"},"msg":"reconnection in: 8218.2630[ms]"}
{"level":30,"time":1784014753441,"pid":452398,"hostname":"damian-praca-thinkpad","req":{"method":"GET","url":"/backend/ws/api/v1/namespaces/busola-terminal/pods/busola-terminal-12c4dd29e3eeb16c/attach?container=dev-toolbox&stdin=true&stdout=true&stderr=true&tty=true"},"msg":"Max reconnection attempts reached for: wss://0.0.0.0:46595/api/v1/namespaces/busola-terminal/pods/busola-terminal-12c4dd29e3eeb16c/attach?container=dev-toolbox&stdin=true&stdout=true&stderr=true&tty=true"}
```
**Related issue(s)**
#4923 

** How to test it:
I used k3d
- increase baseDelay and maxDelay to something much bigger. I used 10s and 100s values. But you can invent your own.
- connect to terminal
- stop and start k3d cluster to shutdown the connection between backend and k8s `k3d cluster stop kyma && k3d cluster start kyma`
- when k3d is up, please apply manually busola terminal pod, because the previosu one is terminated because there are no connection to it.
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: busola-terminal-12c4dd29e3eeb16c
  namespace: busola-terminal
  labels:
    run: busola-terminal
  annotations:
    busola.io/time-to-live: '2026-07-15T11:07:59.833Z'
spec:
  containers:
    - image: ubuntu
      name: dev-toolbox
      resources:
        requests:
          cpu: 100m
          memory: 128Mi
        limits:
          cpu: 500m
          memory: 256Mi
      command:
        - /bin/bash
      stdin: true
      tty: true
  restartPolicy: Never


```

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
