### PR TITLE
chore: Add script to approve pending PR deployments

### DIFF
--- a/.github/scripts/approve-deployments.sh
+++ b/.github/scripts/approve-deployments.sh
@@ -35,7 +35,7 @@ for run_id in $run_ids; do
     --jq ".[] | select(.databaseId == $run_id) | .name")
 
   gh api "repos/$REPO/actions/runs/$run_id/pending_deployments" \
-    -X POST --input - <<EOF
+    -X POST --input - <<EOF > /dev/null
 {"environment_ids":$env_ids,"state":"approved","comment":""}
 EOF
   echo "Approved: $name (run $run_id)"

--- a/.github/scripts/approve-deployments.sh
+++ b/.github/scripts/approve-deployments.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <pr-number> [repo]"
+  echo "  repo defaults to kyma-project/busola"
+  exit 1
+fi
+
+PR=$1
+REPO=${2:-kyma-project/busola}
+
+branch=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq '.headRefName')
+echo "Branch: $branch"
+
+run_ids=$(gh run list --repo "$REPO" --branch "$branch" --json databaseId,status \
+  --jq '[.[] | select(.status == "waiting") | .databaseId] | .[]')
+
+if [[ -z "$run_ids" ]]; then
+  echo "No waiting runs found."
+  exit 0
+fi
+
+for run_id in $run_ids; do
+  env_ids=$(gh api "repos/$REPO/actions/runs/$run_id/pending_deployments" \
+    --jq '[.[].environment.id]')
+
+  if [[ "$env_ids" == "[]" ]]; then
+    continue
+  fi
+
+  name=$(gh run list --repo "$REPO" --json databaseId,name \
+    --jq ".[] | select(.databaseId == $run_id) | .name")
+
+  gh api "repos/$REPO/actions/runs/$run_id/pending_deployments" \
+    -X POST --input - <<EOF
+{"environment_ids":$env_ids,"state":"approved","comment":""}
+EOF
+  echo "Approved: $name (run $run_id)"
+done

--- a/.github/scripts/approve-deployments.sh
+++ b/.github/scripts/approve-deployments.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export GH_PAGER=cat
+
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <pr-number> [repo]"
   echo "  repo defaults to kyma-project/busola"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `.github/scripts/approve-deployments.sh` — a helper script that approves all pending deployments for a given PR number using the GitHub CLI

Usage:
\`\`\`bash
.github/scripts/approve-deployments.sh 5152
\`\`\`

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging