### PR TITLE
fix: Display terminal button label in overflow menu

### DIFF
--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -78,7 +78,7 @@ export function Header() {
   );
 
   const [showCompanion, setShowCompanion] = useAtom(showKymaCompanionAtom);
-  const [showTerminal, setShowTerminal] = useAtom(showTerminalAtom);
+  const [, setShowTerminal] = useAtom(showTerminalAtom);
 
   // Close the panel on cluster switch instead of swapping modes mid-conversation.
   useEffect(() => {
@@ -174,10 +174,10 @@ export function Header() {
           </>
         )}
         {isTerminalEnabled && !isOnClustersPage && (
-          <ToggleButton
+          <ShellBarItem
             icon="command-line-interfaces"
-            accessibleName={t('terminal.name')}
-            pressed={showTerminal.isOpen}
+            text={t('terminal.name')}
+            title={t('terminal.name')}
             onClick={() =>
               setShowTerminal((prev) => ({ ...prev, isOpen: !prev.isOpen }))
             }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Replaced terminal button's `ToggleButton` with `ShellBarItem` in the header, so ShellBar renders its text label ("Busola Terminal") in overflow menu on narrow viewports, same as Feedback and Get Help buttons behave.
- Added `title` attribute so icon shows tooltip on hover in wide header.
- Removed `showTerminal` value from `useAtom` destructuring since it's now unused.

The button previously used `accessibleName` and no visible label appeared once the button collapsed into the overflow menu. `ShellBarItem`'s `text` prop is rendered as the visible overflow label. The trade off is that the button no longer shows a "pressed" highlight while terminal is open.

While working on this, I noticed the Get Help button also lacks a hover tooltip. I'd be happy to address in a follow-up if applicable.

**Related issue(s)**

Fixes #5153

**Definition of done**

- [x] The PR's title starts with one of the allowed prefixes (`fix:`)
- [x] Related issues are linked
- [x] Explains clearly why the PR was created and what changes it introduces
- [x] All necessary steps are delivered (no tests or documentation changes are required for this UI label fix)


**Testing**

I tested locally against a k3d cluster. As the terminal feature is disabled by default (`TERMINAL.isEnabled: false` in `public/defaultConfig.yaml`) I temporarily enabled it locally to render the button. This allowed to verify that:

- On a narrow viewport, terminal entry in header overflow menu now shows "Busola Terminal" label.
- On a wide viewport, the button stays icon only with a hover tooltip, and clicking it still opens the terminal.

| Before | After |
| --- | --- |
|<img width="625" height="484" alt="image" src="https://github.com/user-attachments/assets/071b133e-14f0-4649-b8d7-aa5f00e0eac6" />|<img width="625" height="484" alt="image" src="https://github.com/user-attachments/assets/c36c1e9d-bdc3-4ee1-bd83-f02ee1560cd9" />|

I also attach a small video showing the change.

[test-terminal-button.webm](https://github.com/user-attachments/assets/409e1a08-a4fb-48e8-a53c-136c5f7ca58e)


