### PR TITLE
fix: show terminal button label on narrow viewports

### DIFF
--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -181,7 +181,10 @@ export function Header() {
             onClick={() =>
               setShowTerminal((prev) => ({ ...prev, isOpen: !prev.isOpen }))
             }
-          />
+          >
+            {/* Show label on small screens */}
+            {!isLargeScreen && t('terminal.name')}
+          </ToggleButton>
         )}
         <ShellBarItem
           onClick={() => setIsGetHelpOpen(true)}


### PR DESCRIPTION
Updated the header's terminal `ToggleButton` to render the localized `terminal.name label when `isLargeScreen` is false. Ensures the text label remains visible alongside the icon on small viewports so the button's action is clear.