### PR TITLE
feat: Changes for GDC-a isolated environments

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <meta
       http-equiv="Content-Security-Policy"
       content="
-        font-src 'self' https://sdk.openui5.org/ https://cdn.jsdelivr.net data:;
+        font-src 'self' https://sdk.openui5.org/ data:;
         script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https://*.sapdas.cloud.sap;
         frame-src 'self' https://*.sapdas.cloud.sap https://*.ondemand.com https://*.sap.com https://*.accounts.cloud.sap;
         object-src 'self';

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <meta
       http-equiv="Content-Security-Policy"
       content="
-        font-src 'self' https://sdk.openui5.org/ data:;
+        font-src 'self' data:;
         script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https://*.sapdas.cloud.sap;
         frame-src 'self' https://*.sapdas.cloud.sap https://*.ondemand.com https://*.sap.com https://*.accounts.cloud.sap;
         object-src 'self';

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -33,8 +33,18 @@ function sapui5LocalFonts() {
           next();
           return;
         }
-        if (fs.existsSync(file)) {
-          res.setHeader('Content-Type', 'font/woff2');
+        if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+          const mimeTypes: Record<string, string> = {
+            '.woff2': 'font/woff2',
+            '.woff': 'font/woff',
+            '.ttf': 'font/ttf',
+            '.otf': 'font/otf',
+          };
+          const ext = path.extname(file);
+          res.setHeader(
+            'Content-Type',
+            mimeTypes[ext] ?? 'application/octet-stream',
+          );
           fs.createReadStream(file).pipe(res);
         } else {
           next();

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -28,7 +28,7 @@ function sapui5LocalFonts() {
     },
     configureServer(server: import('vite').ViteDevServer) {
       server.middlewares.use(`/${FONTS_DEST}`, (req, res, next) => {
-        const file = path.join(fontsDir, req.url ?? '');
+        const file = path.join(fontsDir, (req.url ?? '').split('?')[0]);
         if (!file.startsWith(fontsDir + path.sep) && file !== fontsDir) {
           next();
           return;
@@ -98,7 +98,7 @@ export default defineConfig({
           },
         },
         {
-          src: 'node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/*.woff2',
+          src: 'node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/*.{woff2,woff}',
           dest: FONTS_DEST,
         },
       ],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -24,11 +24,15 @@ function sapui5LocalFonts() {
     name: 'sapui5-local-fonts',
     transform(code: string, id: string) {
       if (!id.includes('FontFace.css.js')) return;
-      return code.replace(FONT_CDN_RE, `/${FONTS_DEST}/`);
+      return { code: code.replace(FONT_CDN_RE, `/${FONTS_DEST}/`), map: null };
     },
     configureServer(server: import('vite').ViteDevServer) {
       server.middlewares.use(`/${FONTS_DEST}`, (req, res, next) => {
         const file = path.join(fontsDir, req.url ?? '');
+        if (!file.startsWith(fontsDir + path.sep) && file !== fontsDir) {
+          next();
+          return;
+        }
         if (fs.existsSync(file)) {
           res.setHeader('Content-Type', 'font/woff2');
           fs.createReadStream(file).pipe(res);
@@ -103,7 +107,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     force: true,
-    exclude: ['@ui5/webcomponents-base'],
+    exclude: ['@ui5/webcomponents-base'], // pre-bundled deps bypass the transform hook, so FontFace.css.js URL rewriting would be silently skipped without this exclusion
     include: [
       '@openapi-contrib/openapi-schema-to-json-schema',
       '@stoplight/json-ref-resolver',

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,7 +7,38 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import eslint from '@nabla/vite-plugin-eslint';
 import istanbul from 'vite-plugin-istanbul';
 import fs from 'fs';
+import path from 'path';
 import { glob } from 'glob';
+
+const FONTS_DEST = 'fonts/72';
+const FONT_CDN_RE =
+  /https:\/\/cdn\.jsdelivr\.net\/npm\/@sap-theming\/theming-base-content@[^/]+\/content\/Base\/baseLib\/baseTheme\/fonts\//g;
+
+// Rewrites CDN font URLs in UI5's generated FontFace.css.js to local paths,
+// and serves the font files from node_modules during dev.
+function sapui5LocalFonts() {
+  const fontsDir = path.resolve(
+    'node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts',
+  );
+  return {
+    name: 'sapui5-local-fonts',
+    transform(code: string, id: string) {
+      if (!id.includes('FontFace.css.js')) return;
+      return code.replace(FONT_CDN_RE, `/${FONTS_DEST}/`);
+    },
+    configureServer(server: import('vite').ViteDevServer) {
+      server.middlewares.use(`/${FONTS_DEST}`, (req, res, next) => {
+        const file = path.join(fontsDir, req.url ?? '');
+        if (fs.existsSync(file)) {
+          res.setHeader('Content-Type', 'font/woff2');
+          fs.createReadStream(file).pipe(res);
+        } else {
+          next();
+        }
+      });
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -41,6 +72,7 @@ export default defineConfig({
     svgr({
       include: '**/*.svg?react',
     }),
+    sapui5LocalFonts(),
     viteStaticCopy({
       targets: [
         {
@@ -50,6 +82,10 @@ export default defineConfig({
           transform() {
             return mergeYamlFiles('resource-validation/rule-sets/**/*.yaml');
           },
+        },
+        {
+          src: 'node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/*.woff2',
+          dest: FONTS_DEST,
         },
       ],
     }),
@@ -67,6 +103,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     force: true,
+    exclude: ['@ui5/webcomponents-base'],
     include: [
       '@openapi-contrib/openapi-schema-to-json-schema',
       '@stoplight/json-ref-resolver',


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
GDC-A environments require special handling for SAPUI5 framework provisioning. The Busola and other components that use SAPUI5 must load the framework via a Bootstrap URL that points to the SAPUI5 Cloud Service instance installed within the GDC-A environment. Unlike standard deployments, this URL contains a customer-specific domain name that must be configured during product installation and updates.

- Identify whether Kyma uses SAPUI5 for its user interfaces
- Ensure awareness of the configuration requirements for GDC-A deployments
- Track progress toward implementing the necessary installation/update enhancements

Changes proposed in this pull request:

- Preparing the configuration to load fonts from modules instead of an external network.
- Removing font downloads from index.html.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
