### PR TITLE
fix: Strip browser headers before forwarding to K8s API server

### DIFF
--- a/backend/kubernetes/handler.js
+++ b/backend/kubernetes/handler.js
@@ -75,10 +75,6 @@ export async function handleK8sRequests(req, res) {
   const { targetApiServer, ca, cert, key, authorization } = headersData;
 
   // Forward only the headers the Kubernetes API server needs.
-  // Passing all browser headers (user-agent, cookie, sec-fetch-*, etc.) can
-  // cause 431 errors when OIDC tokens with large group claim sets push the
-  // total header block past the API server's limit (common with custom IDPs
-  // such as GitHub Enterprise that embed many group memberships in the JWT).
   const K8S_FORWARDED_HEADERS = new Set([
     'accept',
     'content-type',

--- a/backend/kubernetes/handler.js
+++ b/backend/kubernetes/handler.js
@@ -74,9 +74,23 @@ export async function handleK8sRequests(req, res) {
 
   const { targetApiServer, ca, cert, key, authorization } = headersData;
 
+  // Forward only the headers the Kubernetes API server needs.
+  // Passing all browser headers (user-agent, cookie, sec-fetch-*, etc.) can
+  // cause 431 errors when OIDC tokens with large group claim sets push the
+  // total header block past the API server's limit (common with custom IDPs
+  // such as GitHub Enterprise that embed many group memberships in the JWT).
+  const K8S_FORWARDED_HEADERS = new Set([
+    'accept',
+    'content-type',
+    'content-length',
+    'transfer-encoding',
+  ]);
+  const filteredHeaders = Object.fromEntries(
+    Object.entries(req.headers).filter(([k]) => K8S_FORWARDED_HEADERS.has(k)),
+  );
   const headers = authorization
-    ? { ...req.headers, authorization }
-    : req.headers;
+    ? { ...filteredHeaders, authorization }
+    : filteredHeaders;
 
   // Use keep-alive agent for token auth only (skip for cert auth)
   const useAgent = authorization && !cert && !key;


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Strip unnecessary browser headers (e.g. `user-agent`, `cookie`, `sec-fetch-*`, `accept-encoding`) before forwarding requests to the Kubernetes API server, forwarding only `accept`, `content-type`, `content-length`, `transfer-encoding`, and `authorization`.
- Fixes 431 Request Header Fields Too Large errors caused by large OIDC tokens from custom IDPs (e.g. GitHub Enterprise with many group memberships) pushing the total header block past the upstream API server's limit.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging