### PR TITLE
feat: Sync Joule theme with Busola user theme selection

### DIFF
--- a/src/components/KymaCompanion/JouleChat.jsx
+++ b/src/components/KymaCompanion/JouleChat.jsx
@@ -34,7 +34,7 @@ export default function JouleChat() {
   const resourceRef = useRef(currentResource);
   const clusterRef = useRef(cluster);
   const authDataRef = useRef(authData);
-  const jouleThemeRef = useRef(null);
+  const resolveJouleThemeRef = useRef(null);
 
   useEffect(() => {
     resourceRef.current = currentResource;
@@ -142,8 +142,8 @@ export default function JouleChat() {
       };
 
       script.onload = () => {
-        if (jouleThemeRef.current) {
-          window.sap?.das?.webclient?.setTheme(jouleThemeRef.current());
+        if (resolveJouleThemeRef.current) {
+          window.sap?.das?.webclient?.setTheme(resolveJouleThemeRef.current());
         }
       };
 
@@ -181,7 +181,7 @@ export default function JouleChat() {
       window.sap?.das?.webclient?.setTheme(resolveJouleTheme());
     };
 
-    jouleThemeRef.current = resolveJouleTheme;
+    resolveJouleThemeRef.current = resolveJouleTheme;
     applyTheme();
     if (theme !== 'light_dark') return;
 

--- a/src/components/KymaCompanion/JouleChat.jsx
+++ b/src/components/KymaCompanion/JouleChat.jsx
@@ -34,6 +34,7 @@ export default function JouleChat() {
   const resourceRef = useRef(currentResource);
   const clusterRef = useRef(cluster);
   const authDataRef = useRef(authData);
+  const jouleThemeRef = useRef(null);
 
   useEffect(() => {
     resourceRef.current = currentResource;
@@ -140,6 +141,12 @@ export default function JouleChat() {
         console.error('Failed to load Joule Web Client');
       };
 
+      script.onload = () => {
+        if (jouleThemeRef.current) {
+          window.sap?.das?.webclient?.setTheme(jouleThemeRef.current());
+        }
+      };
+
       document.head.appendChild(script);
     }
 
@@ -174,8 +181,8 @@ export default function JouleChat() {
       window.sap?.das?.webclient?.setTheme(resolveJouleTheme());
     };
 
+    jouleThemeRef.current = resolveJouleTheme;
     applyTheme();
-
     if (theme !== 'light_dark') return;
 
     // When following system preference, update Joule if the OS theme changes

--- a/src/components/KymaCompanion/JouleChat.jsx
+++ b/src/components/KymaCompanion/JouleChat.jsx
@@ -3,6 +3,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import { showKymaCompanionAtom } from 'state/companion/showKymaCompanionAtom';
 import { clusterAtom } from 'state/clusterAtom';
 import { authDataAtom } from 'state/authDataAtom';
+import { themeAtom, isSystemThemeDark } from 'state/settings/themeAtom';
 
 import { useCurrentResource } from 'components/KymaCompanion/utils/useResource';
 import { useFeature } from 'hooks/useFeature';
@@ -22,6 +23,7 @@ export default function JouleChat() {
   );
   const cluster = useAtomValue(clusterAtom);
   const authData = useAtomValue(authDataAtom);
+  const theme = useAtomValue(themeAtom);
 
   const { isEnabled, jouleConfig } = useFeature(
     configFeaturesNames.KYMA_COMPANION,
@@ -156,6 +158,31 @@ export default function JouleChat() {
       }
     };
   }, [isEnabled, jouleConfig, setShowKymaCompanion]);
+
+  // Sync Busola theme to Joule
+  useEffect(() => {
+    if (!isEnabled) return;
+
+    const resolveJouleTheme = () =>
+      theme === 'light_dark'
+        ? isSystemThemeDark()
+          ? 'sap_horizon_dark'
+          : 'sap_horizon'
+        : theme;
+
+    const applyTheme = () => {
+      window.sap?.das?.webclient?.setTheme(resolveJouleTheme());
+    };
+
+    applyTheme();
+
+    if (theme !== 'light_dark') return;
+
+    // When following system preference, update Joule if the OS theme changes
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    mediaQuery.addEventListener('change', applyTheme);
+    return () => mediaQuery.removeEventListener('change', applyTheme);
+  }, [isEnabled, theme]);
 
   // Control visibility based on Jotai state
   useEffect(() => {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Sync the Joule Web Client theme with the user's active Busola theme on every theme change, covering all five options: Light, Dark, High-Contrast White, High-Contrast Black, and system-adaptive Light/Dark.
- Apply the correct theme on initial Joule script load by storing the resolved theme in a ref and calling `setTheme` inside `script.onload`, so the first render uses the user's selected theme rather than Joule's default.
- Listen for OS-level `prefers-color-scheme` changes when the "Automatically matches your system settings" option is active, so Joule updates without requiring a page reload.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintenance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked.
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
