### PR TITLE
fix: Close and fulll screen buttons wrongly rendered in a popover

### DIFF
--- a/src/shared/components/DynamicPageComponent/DynamicPageComponent.tsx
+++ b/src/shared/components/DynamicPageComponent/DynamicPageComponent.tsx
@@ -278,6 +278,7 @@ export const DynamicPageComponent = ({
             layoutNumber !== 'midColumn')) && (
           <ToolbarButton
             accessibleName="enter-full-screen"
+            overflowPriority="NeverOverflow"
             design="Transparent"
             icon="full-screen"
             onClick={() => {
@@ -306,6 +307,7 @@ export const DynamicPageComponent = ({
           layoutColumn.layout === 'EndColumnFullScreen') && (
           <ToolbarButton
             accessibleName="close-full-screen"
+            overflowPriority="NeverOverflow"
             design="Transparent"
             icon="exit-full-screen"
             onClick={() => {
@@ -334,6 +336,7 @@ export const DynamicPageComponent = ({
         )}
         <ToolbarButton
           accessibleName="close-column"
+          overflowPriority="NeverOverflow"
           design="Transparent"
           icon="decline"
           onClick={() => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fixed close and enter full screen buttons wrongly rendered in a popover when there is enough space for them to be rendered in the toolbar next to each other

**Related issue(s)**
Resolves #5166
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
