### PR TITLE
fix: Use localStorage for pending kubeconfigID across SSO redirect

### DIFF
--- a/src/state/intendedPathAtom.ts
+++ b/src/state/intendedPathAtom.ts
@@ -2,12 +2,12 @@ const INTENDED_PATH_KEY = 'busola.intended-path';
 const PENDING_KUBECONFIG_ID_KEY = 'busola.pending-kubeconfig-id';
 
 export function savePendingKubeconfigId(kubeconfigId: string): void {
-  sessionStorage.setItem(PENDING_KUBECONFIG_ID_KEY, kubeconfigId);
+  localStorage.setItem(PENDING_KUBECONFIG_ID_KEY, kubeconfigId);
 }
 
 export function consumePendingKubeconfigId(): string | null {
-  const value = sessionStorage.getItem(PENDING_KUBECONFIG_ID_KEY);
-  if (value) sessionStorage.removeItem(PENDING_KUBECONFIG_ID_KEY);
+  const value = localStorage.getItem(PENDING_KUBECONFIG_ID_KEY);
+  if (value) localStorage.removeItem(PENDING_KUBECONFIG_ID_KEY);
   return value;
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Switch `savePendingKubeconfigId` and `consumePendingKubeconfigId` from `sessionStorage` to `localStorage` so the `kubeconfigID` is preserved when the browser navigates away to IAS (the SSO identity provider) and returns — `sessionStorage` can be cleared during cross-origin redirects in restricted/isolated environments.

**Related issue(s)**

See also #5199

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - fix: A bug fix
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging