### PR TITLE
fix: Wrongly rendered required field indicator in service instances

### DIFF
--- a/src/components/Extensibility/components-form/FormGroup.tsx
+++ b/src/components/Extensibility/components-form/FormGroup.tsx
@@ -2,6 +2,7 @@ import { ResourceForm } from 'shared/ResourceForm';
 import { useGetTranslation } from 'components/Extensibility/helpers';
 import { SomeSchema, StoreKeys } from '@ui-schema/ui-schema';
 import './FormGroup.scss';
+import { List } from 'immutable';
 
 type FormGroupProps = {
   schema: SomeSchema;
@@ -28,7 +29,15 @@ export function FormGroup({
 
   const defaultOpen = schema.get('defaultExpanded') ?? false;
   const schemaReq = schema.get('required');
-  const schemaRequired = typeof schemaReq === 'boolean' ? schemaReq : required;
+  let schemaRequired = required;
+  if (typeof schemaReq === 'boolean') {
+    schemaRequired = schemaReq;
+  } else if (schemaReq === undefined) {
+    const parentRequired = props.parentSchema?.get('required');
+    if (List.isList(parentRequired)) {
+      schemaRequired = parentRequired.includes(props.storeKeys?.last());
+    }
+  }
   const tooltipContent = schema.get('description');
 
   return (

--- a/src/components/Extensibility/components-form/FormGroup.tsx
+++ b/src/components/Extensibility/components-form/FormGroup.tsx
@@ -27,7 +27,8 @@ export function FormGroup({
   const gridTemplateColumns = `repeat(${columns}, 1fr)`;
 
   const defaultOpen = schema.get('defaultExpanded') ?? false;
-  const schemaRequired = schema.get('required') ?? required;
+  const schemaReq = schema.get('required');
+  const schemaRequired = typeof schemaReq === 'boolean' ? schemaReq : required;
   const tooltipContent = schema.get('description');
 
   return (

--- a/src/components/Extensibility/components-form/FormGroup.tsx
+++ b/src/components/Extensibility/components-form/FormGroup.tsx
@@ -1,8 +1,10 @@
 import { ResourceForm } from 'shared/ResourceForm';
-import { useGetTranslation } from 'components/Extensibility/helpers';
+import {
+  checkRequiredType,
+  useGetTranslation,
+} from 'components/Extensibility/helpers';
 import { SomeSchema, StoreKeys } from '@ui-schema/ui-schema';
 import './FormGroup.scss';
-import { List } from 'immutable';
 
 type FormGroupProps = {
   schema: SomeSchema;
@@ -30,14 +32,12 @@ export function FormGroup({
   const defaultOpen = schema.get('defaultExpanded') ?? false;
   const schemaReq = schema.get('required');
   let schemaRequired = required;
-  if (typeof schemaReq === 'boolean') {
-    schemaRequired = schemaReq;
-  } else if (schemaReq === undefined) {
-    const parentRequired = props.parentSchema?.get('required');
-    if (List.isList(parentRequired)) {
-      schemaRequired = parentRequired.includes(props.storeKeys?.last());
-    }
-  }
+  schemaRequired = checkRequiredType(
+    schemaReq,
+    required,
+    props?.parentSchema,
+    storeKeys,
+  );
   const tooltipContent = schema.get('description');
 
   return (

--- a/src/components/Extensibility/components-form/index.tsx
+++ b/src/components/Extensibility/components-form/index.tsx
@@ -5,7 +5,6 @@ import {
   FunctionComponent,
   ReactNode,
 } from 'react';
-import { List } from 'immutable';
 import { WidgetRenderer } from '@ui-schema/react/WidgetRenderer';
 
 import { DefaultHandler } from '@ui-schema/react/DefaultHandler';
@@ -45,6 +44,7 @@ import { MultiType } from './MultiType';
 import { Modules } from './Modules/Modules';
 import { BindingTypeGeneric } from '@ui-schema/react';
 import { SomeSchema } from '@ui-schema/ui-schema';
+import { checkRequiredType } from '../helpers';
 
 const SchemaPluginsAdapter = schemaPluginsAdapterBuilder([validatorPlugin]);
 
@@ -85,14 +85,12 @@ export const widgets: BindingTypeGeneric = {
     required: boolean;
   } & Record<string, any>) => {
     const schemaReq = schema.get('required');
-    if (typeof schemaReq === 'boolean') {
-      required = schemaReq;
-    } else if (schemaReq === undefined) {
-      const parentRequired = props.parentSchema?.get('required');
-      if (List.isList(parentRequired)) {
-        required = parentRequired.includes(props.storeKeys?.last());
-      }
-    }
+    required = checkRequiredType(
+      schemaReq,
+      required,
+      props?.parentSchema,
+      props?.storeKeys,
+    );
     return (WidgetRenderer as FunctionComponent<any>)({
       schema,
       required,

--- a/src/components/Extensibility/components-form/index.tsx
+++ b/src/components/Extensibility/components-form/index.tsx
@@ -83,7 +83,8 @@ export const widgets: BindingTypeGeneric = {
     schema: SomeSchema;
     required: boolean;
   } & Record<string, any>) => {
-    required = schema.get('required') ?? required;
+    const schemaReq = schema.get('required');
+    required = typeof schemaReq === 'boolean' ? schemaReq : required;
     return (WidgetRenderer as FunctionComponent<any>)({
       schema,
       required,

--- a/src/components/Extensibility/components-form/index.tsx
+++ b/src/components/Extensibility/components-form/index.tsx
@@ -5,6 +5,7 @@ import {
   FunctionComponent,
   ReactNode,
 } from 'react';
+import { List } from 'immutable';
 import { WidgetRenderer } from '@ui-schema/react/WidgetRenderer';
 
 import { DefaultHandler } from '@ui-schema/react/DefaultHandler';
@@ -84,7 +85,14 @@ export const widgets: BindingTypeGeneric = {
     required: boolean;
   } & Record<string, any>) => {
     const schemaReq = schema.get('required');
-    required = typeof schemaReq === 'boolean' ? schemaReq : required;
+    if (typeof schemaReq === 'boolean') {
+      required = schemaReq;
+    } else if (schemaReq === undefined) {
+      const parentRequired = props.parentSchema?.get('required');
+      if (List.isList(parentRequired)) {
+        required = parentRequired.includes(props.storeKeys?.last());
+      }
+    }
     return (WidgetRenderer as FunctionComponent<any>)({
       schema,
       required,

--- a/src/components/Extensibility/helpers/index.js
+++ b/src/components/Extensibility/helpers/index.js
@@ -195,7 +195,8 @@ export const throwConfigError = (message, code) => {
 };
 
 export const getPropsFromSchema = (schema, required, t) => {
-  const schemaRequired = schema.get('required');
+  const schemaReq = schema.get('required');
+  const schemaRequired = typeof schemaReq === 'boolean' ? schemaReq : undefined;
   const inputInfo = schema.get('inputInfo');
   const tooltipContent = schema.get('description');
 

--- a/src/components/Extensibility/helpers/index.js
+++ b/src/components/Extensibility/helpers/index.js
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { OrderedMap } from 'immutable';
+import { OrderedMap, List } from 'immutable';
 import { last, merge } from 'lodash';
 
 import { EMPTY_TEXT_PLACEHOLDER } from 'shared/constants';
@@ -304,4 +304,22 @@ export const getBadgeType = async (highlights, value, jsonata, t) => {
   type = TYPE_FALLBACK.get(type) || type;
 
   return type;
+};
+
+export const checkRequiredType = (
+  schemaRequired,
+  required,
+  parentSchema,
+  storeKeys,
+) => {
+  let newRequired = required;
+  if (typeof schemaRequired === 'boolean') {
+    newRequired = schemaRequired;
+  } else if (schemaRequired === undefined) {
+    const parentRequired = parentSchema?.get('required');
+    if (List.isList(parentRequired)) {
+      newRequired = parentRequired.includes(storeKeys?.last());
+    }
+  }
+  return newRequired;
 };

--- a/src/components/Extensibility/helpers/index.js
+++ b/src/components/Extensibility/helpers/index.js
@@ -195,8 +195,7 @@ export const throwConfigError = (message, code) => {
 };
 
 export const getPropsFromSchema = (schema, required, t) => {
-  const schemaReq = schema.get('required');
-  const schemaRequired = typeof schemaReq === 'boolean' ? schemaReq : undefined;
+  const schemaRequired = schema.get('required');
   const inputInfo = schema.get('inputInfo');
   const tooltipContent = schema.get('description');
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fixed wrongly rendered required field indicator for fields spec.btpAccessCredentialsSecret and spec.servicePlanID in Service Instance Create view

**Related issue(s)**
Resolves #5147
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
