### PR TITLE
fix(overview): Keep dismissed banners hidden after a reload

### DIFF
--- a/src/shared/components/FeatureCard/FeatureCard.test.tsx
+++ b/src/shared/components/FeatureCard/FeatureCard.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: () => new Promise(() => {}) },
+  }),
+}));
+
+vi.mock('jotai', () => ({
+  useAtomValue: () => 'sap_horizon',
+}));
+
+import { FeatureCardBanner } from './FeatureCard';
+
+const renderBanner = (id = 'test-banner') =>
+  render(
+    <FeatureCardBanner
+      id={id}
+      title="Banner title"
+      description="Banner description"
+      design="information-1"
+    />,
+  );
+
+describe('FeatureCardBanner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders the banner when it was never dismissed', () => {
+    renderBanner();
+
+    expect(screen.getByText('Banner title')).toBeInTheDocument();
+  });
+
+  it('stores the dismissal in local storage when closing the banner', () => {
+    const { container } = renderBanner();
+
+    const closeButton = container.querySelector('.decline-button');
+    expect(closeButton).not.toBeNull();
+    fireEvent.click(closeButton!);
+
+    expect(screen.queryByText('Banner title')).not.toBeInTheDocument();
+    expect(localStorage.getItem('hideBannertest-banner')).toEqual('true');
+  });
+
+  it('stays hidden on the next mount after being dismissed', () => {
+    localStorage.setItem('hideBannertest-banner', 'true');
+
+    renderBanner();
+
+    expect(screen.queryByText('Banner title')).not.toBeInTheDocument();
+  });
+
+  it('keeps the dismissed state per banner id', () => {
+    localStorage.setItem('hideBannerother-banner', 'true');
+
+    renderBanner();
+
+    expect(screen.getByText('Banner title')).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/FeatureCard/FeatureCard.tsx
+++ b/src/shared/components/FeatureCard/FeatureCard.tsx
@@ -61,6 +61,9 @@ const getIllustration = (
   }
 };
 
+const isBannerHidden = (hideBannerKey: string): boolean =>
+  localStorage.getItem(hideBannerKey) === 'true';
+
 export function FeatureCardBanner({
   id,
   title,
@@ -72,15 +75,16 @@ export function FeatureCardBanner({
   className = '',
 }: FeatureCardBannerProps) {
   const { t } = useTranslation();
-  const [hideBanner, setHideBanner] = useState(false);
   const hideBannerKey = `hideBanner${id}`;
+  const [hideBanner, setHideBanner] = useState(() =>
+    isBannerHidden(hideBannerKey),
+  );
   const theme = useAtomValue(themeAtom);
   const [prevId, setPrevId] = useState(id);
 
   if (id !== prevId) {
     setPrevId(id);
-    const storedHideValue = localStorage.getItem(hideBannerKey);
-    if (storedHideValue !== null) setHideBanner(storedHideValue === 'true');
+    setHideBanner(isBannerHidden(hideBannerKey));
   }
 
   if (!id || hideBanner) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Initialise `FeatureCardBanner`'s `hideBanner` state lazily from local storage, so a dismissed banner stays hidden after a reload.
- Add unit tests for the dismiss/persist behaviour of `FeatureCardBanner`.

`FeatureCardBanner` only read `hideBanner<id>` from local storage inside the `id !== prevId` branch:

```ts
const [hideBanner, setHideBanner] = useState(false);
const [prevId, setPrevId] = useState(id);

if (id !== prevId) {
  setPrevId(id);
  const storedHideValue = localStorage.getItem(hideBannerKey);
  if (storedHideValue !== null) setHideBanner(storedHideValue === 'true');
}
```

That branch never runs on the first render — `prevId` is initialised to `id`. So on every fresh mount the component starts with `hideBanner = false` and renders the banner, even though `'true'` was written under `hideBanner<id>` when the user closed it. Because the banners on the cluster overview (`AIBanner`, `KymaCLIBanner`) mount with a fixed `id`, the id-change path never fires for them at all and the stored value was effectively never read — the banner comes back on every page load.

The fix initialises the state from local storage directly:

```ts
const isBannerHidden = (hideBannerKey: string): boolean =>
  localStorage.getItem(hideBannerKey) === 'true';

const [hideBanner, setHideBanner] = useState(() => isBannerHidden(hideBannerKey));
```

The id-change branch keeps working and now shares the same helper. Writing the dismissal (`localStorage.setItem(hideBannerKey, 'true')`) is unchanged.

**Tests**

Added `src/shared/components/FeatureCard/FeatureCard.test.tsx` with four cases: renders when never dismissed, persists the dismissal to local storage on close, stays hidden on the next mount, and keeps the dismissed state scoped per banner id.

```
npx vitest run src/shared/components/FeatureCard/FeatureCard.test.tsx
Test Files  1 passed (1)
     Tests  4 passed (4)
```

Against the previous implementation, `stays hidden on the next mount after being dismissed` fails, so it pins the regression.

`npx eslint src/shared/components/FeatureCard/`, `npx prettier --check` on the touched files, and `npx tsc --noEmit` (no new errors in the touched files) are clean.

**Related issue(s)**

Closes #5102
