### PR TITLE
fix: Handle shell bar overflow actions once

### DIFF
--- a/src/header/Feedback/FeedbackPopover.tsx
+++ b/src/header/Feedback/FeedbackPopover.tsx
@@ -3,7 +3,6 @@ import {
   FlexBox,
   ObjectStatus,
   Popover,
-  ShellBarItem,
   Text,
   Title,
 } from '@ui5/webcomponents-react';
@@ -18,6 +17,7 @@ import {
   getShowFeedbackStorageKey,
   setNoFeedbackShowNextTime,
 } from 'components/KymaCompanion/components/JouleFeedbackDialog/helpers/feedbackViewHelpers';
+import { ShellBarAction } from '../ShellBarAction';
 
 export default function FeedbackPopover() {
   const { isEnabled: isFeedbackEnabled, config: kymaFeedbackConfig } =
@@ -69,7 +69,7 @@ export default function FeedbackPopover() {
 
   return (
     <>
-      <ShellBarItem
+      <ShellBarAction
         id="feedbackOpener"
         onClick={() => setFeedbackOpen(true)}
         icon="feedback"

--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -4,7 +4,6 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import {
   Avatar,
   ShellBar,
-  ShellBarItem,
   type ShellBarDomRef,
 } from '@ui5/webcomponents-react';
 
@@ -30,6 +29,7 @@ import FeedbackPopover from './Feedback/FeedbackPopover';
 import { TerminalFeature } from './TerminalFeature';
 import { AIAssistantFeature } from './AIAssistantFeature';
 import { GetHelpMenu } from './GetHelpMenu';
+import { ShellBarAction } from './ShellBarAction';
 import './Header.scss';
 
 export function Header() {
@@ -135,7 +135,7 @@ export function Header() {
         <FeedbackPopover />
         <AIAssistantFeature />
         <TerminalFeature />
-        <ShellBarItem
+        <ShellBarAction
           onClick={() => setIsGetHelpOpen(true)}
           id="openGetHelpMenu"
           icon="sys-help"

--- a/src/header/ShellBarAction.tsx
+++ b/src/header/ShellBarAction.tsx
@@ -1,0 +1,14 @@
+import {
+  ShellBarItem,
+  type ShellBarItemPropTypes,
+} from '@ui5/webcomponents-react';
+
+export function ShellBarAction({ onClick, ...props }: ShellBarItemPropTypes) {
+  const handleClick: ShellBarItemPropTypes['onClick'] = (event) => {
+    // Overflow items also bubble their underlying MouseEvent in UI5 2.24.
+    if (!(event instanceof CustomEvent)) return;
+    onClick?.(event);
+  };
+
+  return <ShellBarItem {...props} onClick={handleClick} />;
+}

--- a/src/header/ShellBarOverflow.cy.tsx
+++ b/src/header/ShellBarOverflow.cy.tsx
@@ -1,0 +1,59 @@
+/* global cy, describe, it */
+import { ShellBar } from '@ui5/webcomponents-react';
+import { ShellBarAction } from './ShellBarAction';
+
+function TestShellBar({
+  onAction,
+  extraActions = 0,
+  width,
+}: {
+  onAction: () => void;
+  extraActions?: number;
+  width?: string;
+}) {
+  return (
+    <ShellBar primaryTitle="Busola" style={{ width }}>
+      <ShellBarAction icon="sys-help" text="Target action" onClick={onAction} />
+      {Array.from({ length: extraActions }, (_, index) => (
+        <ShellBarAction
+          key={index}
+          icon="sys-help"
+          text={`Extra action ${index + 1}`}
+        />
+      ))}
+    </ShellBar>
+  );
+}
+
+describe('ShellBar overflow actions', () => {
+  it('calls a visible ShellBarItem handler once', () => {
+    const onAction = cy.stub().as('onAction');
+
+    cy.mount(<TestShellBar onAction={onAction} />);
+
+    cy.get('ui5-shellbar-item[text="Target action"]')
+      .shadow()
+      .find('ui5-button')
+      .click();
+
+    cy.get('@onAction').should('have.been.calledOnce');
+  });
+
+  it('calls a ShellBarItem handler from the overflow menu', () => {
+    cy.viewport(320, 600);
+    const onAction = cy.stub().as('onAction');
+
+    cy.mount(
+      <TestShellBar onAction={onAction} extraActions={12} width="280px" />,
+    );
+
+    cy.get('ui5-shellbar')
+      .shadow()
+      .find('#ui5-shellbar-overflow-button')
+      .should('be.visible')
+      .click();
+    cy.contains('ui5-li', 'Target action').click();
+
+    cy.get('@onAction').should('have.been.calledOnce');
+  });
+});

--- a/src/header/SnowFeature.tsx
+++ b/src/header/SnowFeature.tsx
@@ -1,4 +1,3 @@
-import { ShellBarItem } from '@ui5/webcomponents-react';
 import { useFeature } from 'hooks/useFeature';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -6,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useAtom } from 'jotai';
 import { themeAtom } from 'state/settings/themeAtom';
 import { configFeaturesNames } from 'state/types';
+import { ShellBarAction } from './ShellBarAction';
 import './SnowFeature.scss';
 
 const SNOW_STORAGE_KEY = 'snow-animation';
@@ -60,7 +60,7 @@ export function SnowFeature() {
           document.body,
         )}
       {isSnowEnabled && (
-        <ShellBarItem
+        <ShellBarAction
           onClick={handleSnowButtonClick}
           icon={isSnowOpen ? 'heating-cooling' : 'activate'}
           text={isSnowOpen ? t('navigation.snow-stop') : t('navigation.snow')}

--- a/src/header/TerminalFeature.tsx
+++ b/src/header/TerminalFeature.tsx
@@ -1,10 +1,10 @@
-import { ShellBarItem } from '@ui5/webcomponents-react';
 import { useTranslation } from 'react-i18next';
 import { useSetAtom } from 'jotai';
 import { useLocation } from 'react-router';
 import { useFeature } from 'hooks/useFeature';
 import { showTerminalAtom } from 'state/showTerminalAtom';
 import { configFeaturesNames } from 'state/types';
+import { ShellBarAction } from './ShellBarAction';
 
 export function TerminalFeature() {
   const { t } = useTranslation();
@@ -18,7 +18,7 @@ export function TerminalFeature() {
   if (!isTerminalEnabled || isOnClustersPage) return null;
 
   return (
-    <ShellBarItem
+    <ShellBarAction
       icon="command-line-interfaces"
       text={t('terminal.name')}
       title={t('terminal.name')}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

UI5's overflow rendering sends two click events to React for a `ShellBarItem`: the item's custom event and the underlying mouse event. That makes toggle actions such as Terminal and Snow change state twice and appear not to respond.

This change:

- routes the header items through a small shared `ShellBarAction` wrapper that handles only UI5's intended custom event;
- applies it to Snow, Feedback, Terminal, and Help; and
- adds component coverage for both visible and overflowed actions.

The test verifies that the same handler is called exactly once in either layout.

**Related issue(s)**

Fixes #5099

**Definition of done**

- [x] The PR's title starts with `fix:`
- [x] Related issues are linked
- [x] The reason and behavior change are described
- [x] All necessary steps are delivered; focused Cypress component tests pass (2/2)
