### PR TITLE
fix: Ignore coveralls.io URLs in markdown link checker

### DIFF
--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -12,6 +12,9 @@
   "ignorePatterns": [
     {
       "pattern": "^http://localhost"
+    },
+    {
+      "pattern": "^https://coveralls.io"
     }
   ]
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `https://coveralls.io` to the markdown link checker ignore list in `.mlc.config.json` to fix the daily lint workflow failing with a 403 on the Coveralls badge link. Coveralls blocks automated/bot requests with 403, even though the badge and coverage page work correctly in a browser.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintenance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked.
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging