### PR TITLE
fix: Terminal doesn't append newline

### DIFF
--- a/backend/src/terminal/connection.js
+++ b/backend/src/terminal/connection.js
@@ -81,6 +81,7 @@ class ExponentialBackoff {
 export class WebSocketConnection {
   #backoff;
   #reconnectTimeout = null;
+  #pendingMessages = [];
 
   constructor(remoteURL, frontWS, authHeaders, logger, backoffConfig) {
     this.remoteURL = remoteURL;
@@ -124,6 +125,11 @@ export class WebSocketConnection {
       opts,
     );
     this.k8sWS.addEventListener('open', () => {
+      for (const msg of this.#pendingMessages) {
+        this.k8sWS.send(msg);
+      }
+      this.#pendingMessages = [];
+
       if (this.#backoff.hasLaunched()) {
         this.#sendMsg(
           this.frontWS,
@@ -182,7 +188,11 @@ export class WebSocketConnection {
     });
 
     this.frontWS.addEventListener('message', (event) => {
-      this.#sendMsg(this.k8sWS, event.data, 'K8s WebSocket');
+      if (this.k8sWS?.readyState !== WebSocket.OPEN) {
+        this.#pendingMessages.push(event.data);
+      } else {
+        this.#sendMsg(this.k8sWS, event.data, 'K8s WebSocket');
+      }
     });
 
     this.frontWS.addEventListener('close', () => {

--- a/src/components/App/BusolaTerminal/connectTerminal.test.ts
+++ b/src/components/App/BusolaTerminal/connectTerminal.test.ts
@@ -11,10 +11,17 @@ const AUTH_HEADERS = new Headers({
   'X-K8s-Authorization': 'Bearer tok123',
 });
 
-function makeTerm() {
+function makeTerm(cols = 80, rows = 24) {
   return {
     write: vi.fn(),
+    cols,
+    rows,
     onData: vi.fn((_handler: (data: string) => void) => ({ dispose: vi.fn() })),
+    onResize: vi.fn(
+      (_handler: (size: { cols: number; rows: number }) => void) => ({
+        dispose: vi.fn(),
+      }),
+    ),
   };
 }
 
@@ -112,6 +119,30 @@ describe('connectTerminal', () => {
     expect(Array.from(frame.slice(1))).toEqual(
       Array.from(new TextEncoder().encode('x')),
     );
+  });
+
+  it('sends a resize frame (channel 4) on open with current terminal dimensions', async () => {
+    const { ws, term } = await attach();
+    ws.onopen();
+
+    const resizeFrame = ws.sent.find((f: Uint8Array) => f[0] === 4);
+    expect(resizeFrame).toBeDefined();
+    const payload = JSON.parse(new TextDecoder().decode(resizeFrame.slice(1)));
+    expect(payload).toEqual({ Width: term.cols, Height: term.rows });
+  });
+
+  it('sends a resize frame (channel 4) when the terminal is resized', async () => {
+    const { ws, term } = await attach();
+    ws.onopen();
+    ws.sent.length = 0; // clear the initial resize frame
+
+    const resizeHandler = term.onResize.mock.calls[0][0];
+    resizeHandler({ cols: 120, rows: 40 });
+
+    const frame = ws.sent.find((f: Uint8Array) => f[0] === 4);
+    expect(frame).toBeDefined();
+    const payload = JSON.parse(new TextDecoder().decode(frame.slice(1)));
+    expect(payload).toEqual({ Width: 120, Height: 40 });
   });
 
   it('ignores socket callbacks once the signal is aborted', async () => {

--- a/src/components/App/BusolaTerminal/connectTerminal.ts
+++ b/src/components/App/BusolaTerminal/connectTerminal.ts
@@ -9,6 +9,7 @@ import { TFunction } from 'i18next';
 const STDIN_CHANNEL = 0;
 const STDOUT_CHANNEL = 1;
 const STDERR_CHANNEL = 2;
+const RESIZE_CHANNEL = 4;
 
 const ANSI_RESET = '\x1b[0m';
 export const COLOR_SUCCESS = '\x1b[32m';
@@ -20,6 +21,16 @@ export const LINE_BREAK = '\r\n';
 
 export function terminalMessage(color: string, text: string) {
   return `${LINE_BREAK}${color}${text}${ANSI_RESET}${LINE_BREAK}`;
+}
+
+export function sendResize(ws: WebSocket, cols: number, rows: number): void {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  const message = JSON.stringify({ Width: cols, Height: rows });
+  const bytes = new TextEncoder().encode(message);
+  const frame = new Uint8Array(bytes.length + 1);
+  frame[0] = RESIZE_CHANNEL;
+  frame.set(bytes, 1);
+  ws.send(frame);
 }
 
 function buildProtocols(authHeaders: Headers): string[] {
@@ -76,6 +87,7 @@ export async function connectTerminal({
 
   ws.onopen = () => {
     if (signal.aborted) return;
+    sendResize(ws, term.cols, term.rows);
     setSession((prev) => ({ ...prev, status: 'connected' }));
     term.write(
       terminalMessage(COLOR_SUCCESS, t('terminal.messages.connected')),
@@ -118,7 +130,7 @@ export async function connectTerminal({
     }));
   };
 
-  const disposable = term.onData((input) => {
+  const dataDisposable = term.onData((input) => {
     if (ws.readyState !== WebSocket.OPEN) return;
     const bytes = new TextEncoder().encode(input);
     const frame = new Uint8Array(bytes.length + 1);
@@ -127,5 +139,17 @@ export async function connectTerminal({
     ws.send(frame);
   });
 
-  return { ws, disposable };
+  const resizeDisposable = term.onResize(({ cols, rows }) => {
+    sendResize(ws, cols, rows);
+  });
+
+  return {
+    ws,
+    disposable: {
+      dispose: () => {
+        dataDisposable.dispose();
+        resizeDisposable.dispose();
+      },
+    },
+  };
 }

--- a/src/components/App/BusolaTerminal/provisionPod.test.ts
+++ b/src/components/App/BusolaTerminal/provisionPod.test.ts
@@ -116,6 +116,25 @@ describe('provisionPod', () => {
     expect(podCall?.[0].init.body).toContain('my-registry/dev:1.2.3');
   });
 
+  it('sets PROMPT_COMMAND so the prompt never appears on the same line as partial output', async () => {
+    const fetchFn = podFetch('Running');
+    await provisionPod({
+      fetchFn: fetchFn as any,
+      podName: POD,
+      image: 'i',
+      abortController,
+    });
+    const podCall = fetchFn.mock.calls.find(([arg]: any) =>
+      arg.relativeUrl.endsWith('/pods'),
+    );
+    const body = JSON.parse(podCall?.[0].init.body);
+    const env: { name: string; value: string }[] =
+      body.spec.containers[0].env ?? [];
+    const promptCommand = env.find((e) => e.name === 'PROMPT_COMMAND');
+    expect(promptCommand).toBeDefined();
+    expect(promptCommand?.value).toContain('\\r');
+  });
+
   it('tolerates a 409 when the namespace or pod already exists', async () => {
     const conflict = new HttpError('Conflict', 409, 409);
     const fetchFn = vi.fn(({ init }: any) => {

--- a/src/components/App/BusolaTerminal/provisionPod.ts
+++ b/src/components/App/BusolaTerminal/provisionPod.ts
@@ -43,6 +43,15 @@ function buildPodManifest(podName: string, image: string) {
           command: ['/bin/bash'],
           stdin: true,
           tty: true,
+          // Prints COLUMNS spaces + \r before each prompt: if the cursor is
+          // mid-line (e.g. curl output without a trailing newline) the spaces
+          // wrap to the next line so the prompt never shares a line with output.
+          env: [
+            {
+              name: 'PROMPT_COMMAND',
+              value: 'printf "%*s\\r" "${COLUMNS:-80}" ""',
+            },
+          ],
         },
       ],
       restartPolicy: 'Never',

--- a/src/components/App/BusolaTerminal/useTerminalSession.test.ts
+++ b/src/components/App/BusolaTerminal/useTerminalSession.test.ts
@@ -47,7 +47,14 @@ const jsonResponse = (data: any) => ({ json: () => Promise.resolve(data) });
 function makeTerm() {
   return {
     write: vi.fn(),
+    cols: 80,
+    rows: 24,
     onData: vi.fn((_handler: (data: string) => void) => ({ dispose: vi.fn() })),
+    onResize: vi.fn(
+      (_handler: (size: { cols: number; rows: number }) => void) => ({
+        dispose: vi.fn(),
+      }),
+    ),
   };
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Buffer messages from the browser WebSocket until the backend's Kubernetes WebSocket is open, preventing the initial PTY resize frame from being silently dropped
- Send a PTY resize frame on WebSocket connect so the terminal dimensions are applied to the PTY immediately; resend on every `term.onResize` event 
- Set `PROMPT_COMMAND` in the terminal pod so the bash prompt always starts on a new line, even when the previous command produced no trailing newline (e.g. `curl`)


**Related issue(s)**
Closes #5231 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
