### PR TITLE
fix: Wait for Terminating pod before provisioning a new terminal session

### DIFF
--- a/src/components/App/BusolaTerminal/provisionPod.test.ts
+++ b/src/components/App/BusolaTerminal/provisionPod.test.ts
@@ -156,4 +156,92 @@ describe('provisionPod', () => {
       }),
     ).rejects.toThrow(/Failed/);
   });
+
+  it('waits for a Terminating pod to be deleted before provisioning a fresh one', async () => {
+    let getCallCount = 0;
+    const fetchFn = vi.fn(({ relativeUrl, init }: any) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'POST') return Promise.resolve(jsonResponse({}));
+      if (relativeUrl.includes(`/pods/${POD}`)) {
+        getCallCount++;
+        if (getCallCount === 1) {
+          // First check: pod exists but is Terminating
+          return Promise.resolve(
+            jsonResponse({
+              metadata: { deletionTimestamp: '2026-09-02T10:00:00Z' },
+              status: { phase: 'Running' },
+            }),
+          );
+        }
+        if (getCallCount === 2) {
+          // Second check: pod is fully gone
+          return Promise.reject(new HttpError('Not Found', 404, 404));
+        }
+        // Third check (pollPodReady): new pod is Running, no deletionTimestamp
+        return Promise.resolve(jsonResponse({ status: { phase: 'Running' } }));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    await expect(
+      provisionPod({
+        fetchFn: fetchFn as any,
+        podName: POD,
+        image: 'i',
+        abortController,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(getCallCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does not wait when no Terminating pod is present', async () => {
+    let getCallCount = 0;
+    const fetchFn = vi.fn(({ relativeUrl, init }: any) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'POST') return Promise.resolve(jsonResponse({}));
+      if (relativeUrl.includes(`/pods/${POD}`)) {
+        getCallCount++;
+        return Promise.resolve(jsonResponse({ status: { phase: 'Running' } }));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    await provisionPod({
+      fetchFn: fetchFn as any,
+      podName: POD,
+      image: 'i',
+      abortController,
+    });
+
+    // One pre-check GET + one pollPodReady GET — no deletion-wait loop
+    expect(getCallCount).toBe(2);
+  });
+
+  it('does not wait when no pod exists yet', async () => {
+    let getCallCount = 0;
+    const fetchFn = vi.fn(({ relativeUrl, init }: any) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'POST') return Promise.resolve(jsonResponse({}));
+      if (relativeUrl.includes(`/pods/${POD}`)) {
+        getCallCount++;
+        if (getCallCount === 1) {
+          // Pre-check: pod doesn't exist yet
+          return Promise.reject(new HttpError('Not Found', 404, 404));
+        }
+        // pollPodReady: new pod is Running
+        return Promise.resolve(jsonResponse({ status: { phase: 'Running' } }));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    await provisionPod({
+      fetchFn: fetchFn as any,
+      podName: POD,
+      image: 'i',
+      abortController,
+    });
+
+    expect(getCallCount).toBe(2);
+  });
 });

--- a/src/components/App/BusolaTerminal/provisionPod.test.ts
+++ b/src/components/App/BusolaTerminal/provisionPod.test.ts
@@ -244,4 +244,62 @@ describe('provisionPod', () => {
 
     expect(getCallCount).toBe(2);
   });
+
+  it('throws when the deadline expires while waiting for a Terminating pod', async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn(({ relativeUrl, init }: any) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'POST') return Promise.resolve(jsonResponse({}));
+      if (relativeUrl.includes(`/pods/${POD}`))
+        return Promise.resolve(
+          jsonResponse({
+            metadata: { deletionTimestamp: '2026-09-02T10:00:00Z' },
+          }),
+        );
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    const provision = provisionPod({
+      fetchFn: fetchFn as any,
+      podName: POD,
+      image: 'i',
+      abortController,
+    });
+    const assertion = expect(provision).rejects.toThrow(
+      'Timed out waiting for terminal pod to finish terminating.',
+    );
+    await vi.advanceTimersByTimeAsync(120_001);
+    await assertion;
+    vi.useRealTimers();
+  });
+
+  it('throws AbortError when aborted while waiting for a Terminating pod', async () => {
+    const aborted = new AbortController();
+    let initialCheckDone = false;
+    const fetchFn = vi.fn(({ relativeUrl, init }: any) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'POST') return Promise.resolve(jsonResponse({}));
+      if (relativeUrl.includes(`/pods/${POD}`)) {
+        if (!initialCheckDone) {
+          initialCheckDone = true;
+          aborted.abort();
+        }
+        return Promise.resolve(
+          jsonResponse({
+            metadata: { deletionTimestamp: '2026-09-02T10:00:00Z' },
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    await expect(
+      provisionPod({
+        fetchFn: fetchFn as any,
+        podName: POD,
+        image: 'i',
+        abortController: aborted,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
 });

--- a/src/components/App/BusolaTerminal/provisionPod.ts
+++ b/src/components/App/BusolaTerminal/provisionPod.ts
@@ -72,12 +72,49 @@ async function createIfMissing(
   }
 }
 
+// Waits until a pod that is currently Terminating (has deletionTimestamp) is
+// fully deleted. If the pod does not exist or is not terminating, returns
+// immediately. The caller should re-create the pod afterwards.
+async function waitIfTerminating(
+  fetchFn: FetchFn,
+  podName: string,
+  abortController: AbortController,
+  deadline: number,
+): Promise<void> {
+  const podUrl = `/api/v1/namespaces/${TERMINAL_NAMESPACE}/pods/${podName}`;
+  let isTerminating: boolean;
+  try {
+    const res = await fetchFn({ relativeUrl: podUrl, abortController });
+    const pod = await res.json();
+    isTerminating = Boolean(pod?.metadata?.deletionTimestamp);
+  } catch (err) {
+    if (err instanceof HttpError && err.code === 404) return;
+    throw err;
+  }
+  if (!isTerminating) return;
+
+  while (Date.now() < deadline) {
+    if (abortController.signal.aborted)
+      throw new DOMException('Aborted', 'AbortError');
+    await new Promise((resolve) => setTimeout(resolve, POD_POLL_INTERVAL_MS));
+    try {
+      const res = await fetchFn({ relativeUrl: podUrl, abortController });
+      const pod = await res.json();
+      if (!pod?.metadata?.deletionTimestamp) return;
+    } catch (err) {
+      if (err instanceof HttpError && err.code === 404) return;
+      throw err;
+    }
+  }
+  throw new Error('Timed out waiting for terminal pod to finish terminating.');
+}
+
 async function pollPodReady(
   fetchFn: FetchFn,
   podName: string,
   abortController: AbortController,
+  deadline: number,
 ): Promise<void> {
-  const deadline = Date.now() + POD_POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (abortController.signal.aborted)
       throw new DOMException('Aborted', 'AbortError');
@@ -107,6 +144,7 @@ export async function provisionPod({
   image: string;
   abortController: AbortController;
 }): Promise<void> {
+  const deadline = Date.now() + POD_POLL_TIMEOUT_MS;
   await createIfMissing(
     fetchFn,
     '/api/v1/namespaces',
@@ -117,11 +155,12 @@ export async function provisionPod({
     },
     abortController,
   );
+  await waitIfTerminating(fetchFn, podName, abortController, deadline);
   await createIfMissing(
     fetchFn,
     `/api/v1/namespaces/${TERMINAL_NAMESPACE}/pods`,
     buildPodManifest(podName, image),
     abortController,
   );
-  await pollPodReady(fetchFn, podName, abortController);
+  await pollPodReady(fetchFn, podName, abortController, deadline);
 }

--- a/src/components/App/BusolaTerminal/provisionPod.ts
+++ b/src/components/App/BusolaTerminal/provisionPod.ts
@@ -96,7 +96,6 @@ async function waitIfTerminating(
   while (Date.now() < deadline) {
     if (abortController.signal.aborted)
       throw new DOMException('Aborted', 'AbortError');
-    await new Promise((resolve) => setTimeout(resolve, POD_POLL_INTERVAL_MS));
     try {
       const res = await fetchFn({ relativeUrl: podUrl, abortController });
       const pod = await res.json();
@@ -105,6 +104,7 @@ async function waitIfTerminating(
       if (err instanceof HttpError && err.code === 404) return;
       throw err;
     }
+    await new Promise((resolve) => setTimeout(resolve, POD_POLL_INTERVAL_MS));
   }
   throw new Error('Timed out waiting for terminal pod to finish terminating.');
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added `waitIfTerminating()` helper in `provisionPod.ts` that checks whether an existing terminal pod has a `deletionTimestamp` (i.e. is Terminating) before attempting to create a new one
- If a Terminating pod is detected, the helper polls until the pod is fully deleted (404) before proceeding with pod creation, preventing a race condition where the attach WebSocket connects to a dying pod
- Shared the 120 s deadline across the new wait step and `pollPodReady` so the overall timeout budget is respected
- Added three new unit tests covering: waiting for a Terminating pod to be deleted, fast-path when no Terminating pod is present, and fast-path when no pod exists yet

**Related issue(s)**

Resolves #5229

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging