### PR TITLE
fix: Prevent radial chart container size console warning

### DIFF
--- a/src/shared/components/UI5RadialChart/UI5RadialChart.tsx
+++ b/src/shared/components/UI5RadialChart/UI5RadialChart.tsx
@@ -1,10 +1,11 @@
 import classNames from 'classnames';
 import { RadialChart } from '@ui5/webcomponents-react-charts';
 import { Card, Text, Title } from '@ui5/webcomponents-react';
+import { renderFinished } from '@ui5/webcomponents-base/dist/Render.js';
 
 import './UI5RadialChart.scss';
 import { HintButton } from '../HintButton/HintButton';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface UI5RadialChartProps {
   cardClassName?: string;
@@ -42,6 +43,19 @@ export const UI5RadialChart = ({
 
   const [showTitleDescription, setShowTitleDescription] = useState(false);
 
+  // Defer the chart until UI5's render queue has flushed, so its `Card` slot is
+  // laid out and Recharts measures a sized container instead of warning on 0×0.
+  const [isChartReady, setIsChartReady] = useState(false);
+  useEffect(() => {
+    let isMounted = true;
+    renderFinished().then(() => {
+      if (isMounted) setIsChartReady(true);
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <Card
       className={cardClassnames}
@@ -69,26 +83,28 @@ export const UI5RadialChart = ({
         aria-label={`${accessibleName}, radial chart, ${text}${additionalInfo ? `, ${additionalInfo}` : ''}`}
         role="img"
       >
-        <RadialChart
-          displayValue={text}
-          displayValueStyle={{
-            fontSize: textSize,
-            fill: color,
-          }}
-          value={value}
-          maxValue={max}
-          color={color}
-          className="sap-margin-y-tiny"
-          style={{
-            height: size + 'px',
-            width: size + 'px',
-          }}
-          chartConfig={{
-            innerRadius: '98%',
-            outerRadius: '98%',
-            barSize: 12,
-          }}
-        />
+        {isChartReady && (
+          <RadialChart
+            displayValue={text}
+            displayValueStyle={{
+              fontSize: textSize,
+              fill: color,
+            }}
+            value={value}
+            maxValue={max}
+            color={color}
+            className="sap-margin-y-tiny"
+            style={{
+              height: size + 'px',
+              width: size + 'px',
+            }}
+            chartConfig={{
+              innerRadius: '98%',
+              outerRadius: '98%',
+              barSize: 12,
+            }}
+          />
+        )}
         {additionalInfo && (
           <Text className="additional-info">{additionalInfo}</Text>
         )}

--- a/src/shared/components/UI5RadialChart/UI5RadialChart.tsx
+++ b/src/shared/components/UI5RadialChart/UI5RadialChart.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { RadialChart } from '@ui5/webcomponents-react-charts';
 import { Card, Text, Title } from '@ui5/webcomponents-react';
-import { renderFinished } from '@ui5/webcomponents-base/dist/Render.js';
+import { renderFinished } from '@ui5/webcomponents-base';
 
 import './UI5RadialChart.scss';
 import { HintButton } from '../HintButton/HintButton';


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Defer rendering the `RadialChart` in `UI5RadialChart` until UI5's render queue has flushed (`renderFinished()`), so the enclosing `Card` slot is laid out before Recharts measures its container.
- This removes the dev-console warning about the chart container width/height being 0 that appeared on the cluster overview.

**Related issue(s)**

Fixes #5139

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging