### PR TITLE
fix: Center protected resources icon horizontally

### DIFF
--- a/src/shared/components/ProtectedResourcesButton.tsx
+++ b/src/shared/components/ProtectedResourcesButton.tsx
@@ -7,6 +7,7 @@ import {
 } from '@ui5/webcomponents-react';
 import { useFeature } from 'hooks/useFeature';
 import { useId, useState } from 'react';
+import type React from 'react';
 import { createPortal } from 'react-dom';
 import { configFeaturesNames } from 'state/types';
 import jp from 'jsonpath';
@@ -100,7 +101,7 @@ export const ProtectedResourceWarning = ({
             ? ({
                 '--sapButton_Lite_TextColor': 'var(--sapCriticalColor)',
                 '--sapButton_Lite_Hover_TextColor': 'var(--sapCriticalColor)',
-              } as never)
+              } as React.CSSProperties)
             : undefined
         }
       >

--- a/src/shared/components/ProtectedResourcesButton.tsx
+++ b/src/shared/components/ProtectedResourcesButton.tsx
@@ -93,7 +93,16 @@ export const ProtectedResourceWarning = ({
           setPopoverMessage(message);
         }}
         design="Transparent"
+        icon={withText ? undefined : 'locked'}
         accessibleName={t('common.protected-resource')}
+        style={
+          !withText
+            ? ({
+                '--sapButton_Lite_TextColor': 'var(--sapCriticalColor)',
+                '--sapButton_Lite_Hover_TextColor': 'var(--sapCriticalColor)',
+              } as never)
+            : undefined
+        }
       >
         {withText ? (
           <ObjectStatus
@@ -104,13 +113,7 @@ export const ProtectedResourceWarning = ({
           >
             {t('common.protected-resource')}
           </ObjectStatus>
-        ) : (
-          <Icon
-            design="Critical"
-            name="locked"
-            style={{ marginTop: '0.125rem' }}
-          />
-        )}
+        ) : null}
       </Button>
       {createPortal(
         <Popover

--- a/src/shared/components/ProtectedResourcesButton.tsx
+++ b/src/shared/components/ProtectedResourcesButton.tsx
@@ -6,8 +6,7 @@ import {
   Text,
 } from '@ui5/webcomponents-react';
 import { useFeature } from 'hooks/useFeature';
-import { useId, useState } from 'react';
-import type React from 'react';
+import { type CSSProperties, useId, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { configFeaturesNames } from 'state/types';
 import jp from 'jsonpath';
@@ -101,7 +100,7 @@ export const ProtectedResourceWarning = ({
             ? ({
                 '--sapButton_Lite_TextColor': 'var(--sapCriticalColor)',
                 '--sapButton_Lite_Hover_TextColor': 'var(--sapCriticalColor)',
-              } as React.CSSProperties)
+              } as CSSProperties)
             : undefined
         }
       >


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace `<Icon>` rendered as Button children with the `icon` prop on `Button` for the icon-only variant of `ProtectedResourceWarning`. Using the `icon` prop triggers UI5's icon-only button mode, which centers the icon horizontally — placing an `Icon` component as children renders it in the text slot and left-aligns it.
- Remove the previous `marginTop` workaround that was patching vertical misalignment.
- Override `--sapButton_Lite_TextColor` and `--sapButton_Lite_Hover_TextColor` CSS custom properties inline to keep the icon orange (`--sapCriticalColor`), since the `icon` prop does not accept a `design` attribute.

**Related issue(s)**

N/A

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging