### PR TITLE
fix: Flakiness in accessibility flows

### DIFF
--- a/src/state/extensibilitySchemasAtom.ts
+++ b/src/state/extensibilitySchemasAtom.ts
@@ -9,9 +9,17 @@ interface ExtensiblitySchemas {
   [key: string]: ExtensibilitySchema;
 }
 
-const getSchema = async (schema: string): Promise<ExtensibilitySchema> => {
+const getSchema = async (
+  schema: string,
+  signal?: AbortSignal,
+): Promise<ExtensibilitySchema> => {
   const cacheBuster = 'cache-buster=' + Date.now();
-  const response = await fetch(`/schemas/schema-${schema}.yaml?${cacheBuster}`);
+  const response = await fetch(
+    `/schemas/schema-${schema}.yaml?${cacheBuster}`,
+    {
+      signal,
+    },
+  );
   const text = await response.text();
   return jsyaml.load(text);
 };
@@ -22,15 +30,20 @@ export const useGetExtensibilitySchemas = () => {
   const auth = useAtomValue(authDataAtom);
 
   useEffect(() => {
+    if (!cluster) {
+      setSchemas(null);
+      return;
+    }
+
+    const controller = new AbortController();
     const setExtensionsSchema = async () => {
-      if (!cluster) {
-        setSchemas(null);
-      } else {
-        const details = await getSchema('details');
-        const list = await getSchema('list');
-        const general = await getSchema('general');
-        const form = await getSchema('form');
-        // const dataSources = await getSchema('dataSources');
+      try {
+        const { signal } = controller;
+        const details = await getSchema('details', signal);
+        const list = await getSchema('list', signal);
+        const general = await getSchema('general', signal);
+        const form = await getSchema('form', signal);
+        // const dataSources = await getSchema('dataSources', signal);
 
         setSchemas({
           details,
@@ -39,9 +52,16 @@ export const useGetExtensibilitySchemas = () => {
           form,
           // dataSources,
         });
+      } catch (e) {
+        // abort is fine, this happens when cluster/auth changes or we clean up mid-fetch
+        if ((e as Error)?.name === 'AbortError') return;
+        // a failed fetch shouldn't bubble up as an unhandled rejection, just warn and move on
+        console.warn('Cannot load extensibility schemas', e);
       }
     };
     setExtensionsSchema();
+
+    return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cluster, auth]);
 };

--- a/tests/integration/continuum/cypress.js
+++ b/tests/integration/continuum/cypress.js
@@ -13,13 +13,29 @@ const accessEngineFilePath =
     '',
   ); // versions of Cypress prior to 5 include a leading forward slash in __dirname
 
-const setUpContinuum = (configFilePath) =>
+const setUpContinuum = (configFilePath) => {
   // Using the Continuum JavaScript SDK requires us to load the following files before invoking `Continuum.setUp`:
   // * the Continuum configuration file (continuum.conf.js) specified by `configFilePath`
   // * Access Engine (AccessEngine.professional.js), the underlying accessibility testing engine Continuum uses
   // Normally code outside the Continuum JavaScript SDK is not required to do this, but Cypress' design essentially forces our hand
 
-  cy
+  // Reuse the catalog we already fetched once in plugins/index.js. If we don't stub it here,
+  // the SDK fetches it again for every spec and setUp times out whenever CI egress is slow.
+  // The 60s is needed because taskTimeout is only 10s globally. If the prefetch returned null
+  // we let the stub fail right away, otherwise setUp would sit on the SDK's own 60s timeout.
+  cy.task('getBestPracticeCatalog', null, { timeout: 60000 }).then(
+    (catalog) => {
+      cy.intercept(
+        'GET',
+        '**/api/cont/bestpractices*',
+        catalog
+          ? { statusCode: 200, body: catalog }
+          : { forceNetworkError: true },
+      );
+    },
+  );
+
+  return cy
     .readFile(configFilePath)
     .then((configFileContents) => window.eval(configFileContents))
     .window()
@@ -35,6 +51,7 @@ const setUpContinuum = (configFilePath) =>
         )
         .then(() => Continuum.setUp(null, configFilePath, windowUnderTest)),
     );
+};
 
 const runAllAccessibilityTests = () =>
   // We verify Access Engine is loaded, loading it again only if necessary, before running our accessibility tests using `Continuum.runAllTests`

--- a/tests/integration/plugins/index.js
+++ b/tests/integration/plugins/index.js
@@ -1,5 +1,35 @@
 const fs = require('fs');
 
+// Continuum fetches this catalog from the browser during every spec's setUp. On CI that
+// call is often slow enough to time out, so we fetch it once here and replay it per spec.
+const BESTPRACTICES_URL = 'https://sap.levelaccess.net/api/cont/bestpractices';
+const FETCH_TIMEOUT_MS = 20000;
+let bestPracticeCatalogPromise = null;
+
+async function fetchBestPracticeCatalog() {
+  const attempt = async () => {
+    const res = await fetch(BESTPRACTICES_URL, {
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  };
+  try {
+    return await attempt();
+  } catch (first) {
+    try {
+      return await attempt(); // try again, the first call sometimes just fails
+    } catch (second) {
+      console.log(
+        `[a11y] Failed to prefetch best-practice catalog (${second}); ` +
+          `Continuum will run in degraded (unfiltered) mode for this run.`,
+      );
+      return null;
+    }
+  }
+}
+
 module.exports = (on, config) => {
   let namespaceName = process.env.NAMESPACE_NAME || null;
   // generate random namespace name if it wasn't provided as env
@@ -47,6 +77,13 @@ module.exports = (on, config) => {
       } else {
         return dynamicSharedStore[property.name];
       }
+    },
+    // fetch only once and reuse the promise for the other specs; null if it failed
+    getBestPracticeCatalog() {
+      if (!bestPracticeCatalogPromise) {
+        bestPracticeCatalogPromise = fetchBestPracticeCatalog();
+      }
+      return bestPracticeCatalogPromise;
     },
   });
   return config;

--- a/tests/integration/support/login-commands.js
+++ b/tests/integration/support/login-commands.js
@@ -109,7 +109,8 @@ Cypress.Commands.add('loginAndSelectCluster', function (params) {
     }
 
     cy.visit(`${config.clusterAddress}/clusters`)
-      .get('ui5-button:visible')
+      // the first cold boot under load can take longer than the default 10s
+      .get('ui5-button:visible', { timeout: 20000 })
       .contains('Connect')
       .click();
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR's template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Pre-fetch the Continuum best-practice catalog once in Node and stub it per spec, so slow network or CI egress can't time out anymore
- Add AbortController + error handling to extensibility schema fetches so interrupted loads don't cause unhandled rejections
- Give the first ui5-button:visible query in loginAndSelectCluster a longer timeout to handle slow cold boots

**Related issue(s)**
#---
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
