### PR TITLE
feat: Add Markdown display widget to extensibility

### DIFF
--- a/docs/contributor/extensibility/50-list-and-details-widgets.md
+++ b/docs/contributor/extensibility/50-list-and-details-widgets.md
@@ -22,6 +22,7 @@ You can distinguish the following widget types:
   - [`Columns`](#columns)
   - [`EventList`](#eventlist)
   - [`FeatureCard`](#featuredcard)
+  - [`Markdown`](#markdown)
   - [`Panel`](#panel)
   - [`Plain`](#plain)
   - [`Section`](#section)
@@ -557,6 +558,28 @@ injections: |-
 ```
 
 <img src="./assets/display-widgets/FeaturedCard.png" alt="Example of a FeaturedCard widget">
+
+### `Markdown`
+
+The `Markdown` widget renders a string value as formatted Markdown. It is useful for displaying human-readable, richly formatted text stored as a plain string (for example, a `ConfigMap` **data** entry), instead of showing it in a read-only code editor.
+
+The Markdown source is sanitized: any embedded raw HTML is rendered as escaped text and is never executed.
+
+These are the available `Markdown` widget parameters:
+
+| Parameter       | Required | Type   | Description                                                                                                                                                                                                       |
+| --------------- | -------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **placeholder** | No       | string | Changes the default empty text placeholder `-` with a custom string. If the **translations** section has a translation entry with the ID that is the same as the **placeholder** string, the translation is used. |
+
+See the following example:
+
+```yaml
+- widget: Panel
+  name: Notes
+  children:
+    - source: spec.description
+      widget: Markdown
+```
 
 ### `Panel`
 

--- a/examples/pizzas/configuration/pizzas-configmap.yaml
+++ b/examples/pizzas/configuration/pizzas-configmap.yaml
@@ -87,6 +87,11 @@ data:
             sort:
               - source: type
                 default: true
+      - name: Baking Instructions
+        widget: Panel
+        children:
+          - widget: Markdown
+            source: spec.recipe
     resourceGraph:
       colorVariant: 2
       dataSources:

--- a/examples/pizzas/configuration/pizzas-crd.yaml
+++ b/examples/pizzas/configuration/pizzas-crd.yaml
@@ -29,6 +29,9 @@ spec:
                 description:
                   description: Pizza description
                   type: string
+                recipe:
+                  description: Markdown-formatted recipe with baking instructions
+                  type: string
                 sauce:
                   description: The name of the sauce to use on our pizza
                   type: string

--- a/examples/pizzas/samples/pizzas-samples.yaml
+++ b/examples/pizzas/samples/pizzas-samples.yaml
@@ -16,6 +16,19 @@ spec:
     - 'Please, make my pizza quickly.'
     - Margherita is a delicious pizza!
   description: 'Margherita is a simple, vegetarian pizza.'
+  recipe: |-
+    ## How to bake a Margherita
+
+    1. **Preheat** the oven to 250°C (480°F) with a pizza stone inside.
+    2. Roll out the dough into a thin, round base.
+    3. Spread a thin layer of **garlic sauce**.
+    4. Add the toppings:
+       - Tomato sauce
+       - Cheese
+       - Fresh basil
+    5. Bake for *8–10 minutes* until the crust is golden.
+
+    > Tip: finish with a drizzle of olive oil before serving.
   sauce: GARLIC
   toppings:
     - name: Tomato sauce
@@ -47,6 +60,19 @@ spec:
     - I would like the spiciest pizza.
     - I would like to ask for a discount for students.
   description: 'Diavola is such a spicy pizza, it includes hot salami and pickled jalapeños!'
+  recipe: |-
+    ## How to bake a Diavola
+
+    1. **Preheat** the oven to 250°C (480°F).
+    2. Stretch the dough into a thin base.
+    3. Spread the **tomato sauce** evenly, leaving a border for the crust.
+    4. Add the toppings:
+       - Hot salami
+       - Pickled jalapeños
+       - Cheese
+    5. Bake for *8–10 minutes* until bubbling.
+
+    > Tip: a splash of chili oil before serving makes it extra spicy!
   toppings:
     - name: Hot salami
       price: 10

--- a/src/components/Extensibility/components/Markdown.scss
+++ b/src/components/Extensibility/components/Markdown.scss
@@ -1,0 +1,130 @@
+.extensibility-markdown {
+  color: var(--sapTextColor);
+  font-family: var(--sapFontFamily);
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+
+  > *:first-child {
+    margin-top: 0;
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: var(--sapTextColor);
+    font-weight: 700;
+    margin: 0.8em 0 0.4em;
+  }
+
+  h1 {
+    font-size: 1.5rem;
+  }
+
+  h2 {
+    font-size: 1.3rem;
+  }
+
+  h3 {
+    font-size: 1.15rem;
+  }
+
+  h4 {
+    font-size: 1rem;
+  }
+
+  h5 {
+    font-size: 0.9rem;
+  }
+
+  h6 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+
+  p {
+    margin: 0.5em 0;
+  }
+
+  a {
+    color: var(--sapLinkColor);
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  ul,
+  ol {
+    padding-left: 1.5em;
+    margin: 0.5em 0;
+  }
+
+  li {
+    margin: 0.15em 0;
+  }
+
+  code {
+    font-family: var(--sapCodeFontFamily, monospace);
+    background: var(--sapList_Background, rgba(128, 128, 128, 0.15));
+    padding: 0.1em 0.3em;
+    border-radius: 0.25em;
+    font-size: 0.9em;
+  }
+
+  pre {
+    background: var(--sapList_Background, rgba(128, 128, 128, 0.15));
+    padding: 0.75em 1em;
+    border-radius: 0.375rem;
+    overflow: auto;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: 1em;
+  }
+
+  blockquote {
+    border-left: 3px solid var(--sapList_BorderColor, #ccc);
+    padding-left: 1em;
+    margin: 0.5em 0;
+    color: var(--sapContent_LabelColor);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5em 0;
+  }
+
+  th,
+  td {
+    border: 1px solid var(--sapList_BorderColor, #ccc);
+    padding: 0.5em 0.75em;
+    text-align: left;
+  }
+
+  th {
+    background: var(--sapList_HeaderBackground, rgba(128, 128, 128, 0.1));
+    font-weight: 600;
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--sapList_BorderColor, #ccc);
+    margin: 1em 0;
+  }
+}

--- a/src/components/Extensibility/components/Markdown.scss
+++ b/src/components/Extensibility/components/Markdown.scss
@@ -1,52 +1,9 @@
 .extensibility-markdown {
-  color: var(--sapTextColor);
-  font-family: var(--sapFontFamily);
-  line-height: 1.5;
-  overflow-wrap: anywhere;
-
-  > *:first-child {
-    margin-top: 0;
-  }
-
-  > *:last-child {
-    margin-bottom: 0;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    color: var(--sapTextColor);
-    font-weight: 700;
-    margin: 0.8em 0 0.4em;
-  }
-
-  h1 {
-    font-size: 1.5rem;
-  }
-
-  h2 {
-    font-size: 1.3rem;
-  }
-
-  h3 {
-    font-size: 1.15rem;
-  }
-
-  h4 {
-    font-size: 1rem;
-  }
-
-  h5 {
-    font-size: 0.9rem;
-  }
-
-  h6 {
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
+  // Global reset.css strips <ul> bullets/indent and <p> margins app-wide.
+  // Restore just those; everything else uses browser defaults + inherited SAP font.
+  ul {
+    list-style: disc;
+    padding-left: 1.5em;
   }
 
   p {
@@ -55,76 +12,11 @@
 
   a {
     color: var(--sapLinkColor);
-    text-decoration: none;
-  }
-
-  a:hover {
-    text-decoration: underline;
-  }
-
-  ul,
-  ol {
-    padding-left: 1.5em;
-    margin: 0.5em 0;
-  }
-
-  li {
-    margin: 0.15em 0;
-  }
-
-  code {
-    font-family: var(--sapCodeFontFamily, monospace);
-    background: var(--sapList_Background, rgba(128, 128, 128, 0.15));
-    padding: 0.1em 0.3em;
-    border-radius: 0.25em;
-    font-size: 0.9em;
-  }
-
-  pre {
-    background: var(--sapList_Background, rgba(128, 128, 128, 0.15));
-    padding: 0.75em 1em;
-    border-radius: 0.375rem;
-    overflow: auto;
-  }
-
-  pre code {
-    background: none;
-    padding: 0;
-    font-size: 1em;
-  }
-
-  blockquote {
-    border-left: 3px solid var(--sapList_BorderColor, #ccc);
-    padding-left: 1em;
-    margin: 0.5em 0;
-    color: var(--sapContent_LabelColor);
-  }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 0.5em 0;
   }
 
   th,
   td {
-    border: 1px solid var(--sapList_BorderColor, #ccc);
-    padding: 0.5em 0.75em;
-    text-align: left;
-  }
-
-  th {
-    background: var(--sapList_HeaderBackground, rgba(128, 128, 128, 0.1));
-    font-weight: 600;
-  }
-
-  img {
-    max-width: 100%;
-  }
-
-  hr {
-    border: none;
-    border-top: 1px solid var(--sapList_BorderColor, #ccc);
-    margin: 1em 0;
+    border: 1px solid var(--sapList_BorderColor);
+    padding: 0.5rem;
   }
 }

--- a/src/components/Extensibility/components/Markdown.tsx
+++ b/src/components/Extensibility/components/Markdown.tsx
@@ -24,7 +24,7 @@ export function Markdown({ value, structure }: MarkdownProps) {
 
   return (
     <div
-      className="extensibility-markdown"
+      className="extensibility-markdown sap-margin-small"
       data-testid="extensibility-markdown"
     >
       <ReactMarkdown>{text}</ReactMarkdown>

--- a/src/components/Extensibility/components/Markdown.tsx
+++ b/src/components/Extensibility/components/Markdown.tsx
@@ -1,0 +1,33 @@
+import ReactMarkdown from 'marked-react';
+import { isNil } from 'lodash';
+
+import { useGetPlaceholder } from 'components/Extensibility/helpers';
+
+import './Markdown.scss';
+
+interface MarkdownProps {
+  value: any;
+  structure: any;
+}
+
+export function Markdown({ value, structure }: MarkdownProps) {
+  const { emptyLeafPlaceholder } = useGetPlaceholder(structure);
+
+  if (isNil(value) || value === '') {
+    return emptyLeafPlaceholder;
+  }
+
+  // marked-react throws when given a non-string, so coerce defensively.
+  // The expected input is a plain string (e.g. a ConfigMap data value).
+  const text =
+    typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+
+  return (
+    <div
+      className="extensibility-markdown"
+      data-testid="extensibility-markdown"
+    >
+      <ReactMarkdown>{text}</ReactMarkdown>
+    </div>
+  );
+}

--- a/src/components/Extensibility/components/index.tsx
+++ b/src/components/Extensibility/components/index.tsx
@@ -1,6 +1,7 @@
 import { Text } from './Text';
 import { Plain } from './Plain';
 import { Columns } from './Columns';
+import { Markdown } from './Markdown';
 import { Panel } from './Panel';
 import { Section } from './Section';
 import { CodeViewer } from './CodeViewer';
@@ -43,6 +44,7 @@ export const widgets = {
   ExternalLink,
   JoinedArray,
   Labels,
+  Markdown,
   Panel,
   Plain,
   ResourceButton,

--- a/src/components/Extensibility/components/tests/Markdown.cy.jsx
+++ b/src/components/Extensibility/components/tests/Markdown.cy.jsx
@@ -1,0 +1,47 @@
+/* global cy, describe, it */
+import { Markdown } from '../Markdown';
+
+describe('Markdown Component', () => {
+  it('renders markdown headings and inline formatting', () => {
+    const value = '# Title\n\nSome **bold** text.';
+
+    cy.mount(<Markdown value={value} structure={{}} />);
+
+    cy.get('[data-testid="extensibility-markdown"] h1').should(
+      'contain.text',
+      'Title',
+    );
+    cy.get('[data-testid="extensibility-markdown"] strong').should(
+      'contain.text',
+      'bold',
+    );
+  });
+
+  it('renders lists', () => {
+    const value = '- one\n- two\n- three';
+
+    cy.mount(<Markdown value={value} structure={{}} />);
+
+    cy.get('[data-testid="extensibility-markdown"] li').should(
+      'have.length',
+      3,
+    );
+  });
+
+  it('renders the placeholder for an empty value', () => {
+    cy.mount(<Markdown value={null} structure={{}} />);
+
+    cy.contains('-').should('be.visible');
+  });
+
+  it('escapes embedded HTML instead of executing it', () => {
+    const value = 'text <img src=x onerror="window.__xss = true"> more';
+
+    cy.mount(<Markdown value={value} structure={{}} />);
+
+    cy.get('[data-testid="extensibility-markdown"]').should('exist');
+    // Raw HTML is rendered as escaped text, so no real element is created.
+    cy.get('[data-testid="extensibility-markdown"] img').should('not.exist');
+    cy.window().its('__xss').should('be.undefined');
+  });
+});

--- a/tests/integration/tests/extensibility/ext-test-pizzas.spec.js
+++ b/tests/integration/tests/extensibility/ext-test-pizzas.spec.js
@@ -144,6 +144,17 @@ context('Test Pizzas', () => {
       .contains('Diavola is such a spicy pizza')
       .should('be.visible');
 
+    // The Markdown widget renders spec.recipe as formatted HTML, not raw text.
+    cy.getMidColumn().contains('Baking Instructions').scrollIntoView();
+
+    cy.getMidColumn()
+      .find('[data-testid="extensibility-markdown"] h2')
+      .should('contain.text', 'How to bake a Diavola');
+
+    cy.getMidColumn()
+      .find('[data-testid="extensibility-markdown"] li')
+      .should('have.length.at.least', 5);
+
     cy.getLeftNav()
       .contains(/^Pizzas$/)
       .click();


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a new `Markdown` extensibility display widget that renders a string value (for example, a ConfigMap `data` entry) as formatted Markdown, instead of showing it in a read-only code editor.
- Render Markdown through the existing `marked-react` dependency. Any embedded raw HTML is rendered as escaped text and never executed (XSS-safe).
- Add theme-aware styles using SAP CSS variables, so the widget looks correct in both light and dark themes.
- Register the widget in the extensibility widget map and document it in the list-and-details widgets guide with a usage example.
- Add a Cypress component test covering headings, lists, the empty-value placeholder, and HTML escaping.

**Related issue(s)**

No tracking issue — small, self-contained widget addition.

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- Related issues: not applicable — there is no tracking issue for this change.
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging