### PR TITLE
test: Stabilize integration tests against merge-queue flakiness

### DIFF
--- a/tests/integration/cypress.config.js
+++ b/tests/integration/cypress.config.js
@@ -24,10 +24,6 @@ module.exports = defineConfig({
   experimentalInteractiveRunEvents: true,
   experimentalMemoryManagement: true,
   numTestsKeptInMemory: 0,
-  retries: {
-    runMode: 2,
-    openMode: 0,
-  },
   e2e: {
     includeShadowDom: true,
     testIsolation: false,

--- a/tests/integration/cypress.config.js
+++ b/tests/integration/cypress.config.js
@@ -22,7 +22,12 @@ module.exports = defineConfig({
     ? `${process.env?.ARTIFACTS}/videos`
     : 'cypress/videos',
   experimentalInteractiveRunEvents: true,
+  experimentalMemoryManagement: true,
   numTestsKeptInMemory: 0,
+  retries: {
+    runMode: 2,
+    openMode: 0,
+  },
   e2e: {
     includeShadowDom: true,
     testIsolation: false,

--- a/tests/integration/support/navigate-to.js
+++ b/tests/integration/support/navigate-to.js
@@ -1,15 +1,22 @@
 Cypress.Commands.add('navigateTo', (leftNav, resource) => {
+  // Alias the query before clicking. UI5 side-navigation re-renders
+  // asynchronously (React), so a direct `.should('be.visible').click()` can
+  // hit an element that detaches between the actionability check and the click
+  // ("element detached from the DOM"). Accessing an alias re-runs the query,
+  // so Cypress clicks a fresh, attached node instead of a stale reference.
   cy.wait(1500)
     .getLeftNav()
     .get(`ui5-side-navigation-item[text="${leftNav}"]`)
     .should('be.visible')
-    .click();
+    .as('leftNavItem');
+  cy.get('@leftNavItem').click();
 
   if (resource) {
     cy.getLeftNav()
       .get(`ui5-side-navigation-sub-item[text="${resource}"]`)
       .should('be.visible')
-      .click();
+      .as('leftNavSubItem');
+    cy.get('@leftNavSubItem').click();
   }
   cy.wait(1500);
 });


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable `experimentalMemoryManagement` in the Cypress integration config so Chrome manages renderer memory across the single long `cypress run`, preventing the "The Chrome Renderer process just crashed" out-of-memory failures observed mid-suite.
- Add `retries: { runMode: 2, openMode: 0 }` so a single transient failure no longer fails the whole required check. This is essential in the GitHub merge queue, which runs each required check exactly once — one flake currently dequeues an otherwise-green PR.
- Harden the `navigateTo` command by aliasing the side-navigation item/sub-item queries before clicking. UI5/React re-render the navigation asynchronously, so a direct `.should('be.visible').click()` could hit an element that detached between the actionability check and the click ("element detached from the DOM"); accessing an alias re-runs the query and clicks a fresh node.

**Related issue(s)**

N/A — addresses recurring merge-queue dequeues of the "PR Integration Cluster Tests" check caused by test-infrastructure flakiness (renderer OOM crashes and detached-element navigation races) rather than a tracked issue.

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging