### PR TITLE
chore: Disable /proxy endpoint and EXTENSIBILITY_CUSTOM_COMPONENTS

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4,7 +4,8 @@ import {
   k8sRateLimiter,
   requireK8sCredential,
 } from './kubernetes/handler';
-import { proxyHandler } from './proxy.js';
+// Enable after: https://github.com/kyma-project/busola/issues/5299
+// import { proxyHandler } from './proxy.js';
 import { setupJWTCheck } from './jwtCheck';
 import companionRouter from './companion/companionRouter';
 import communityRouter from './modules/communityRouter';
@@ -68,7 +69,8 @@ const SLOW_REQUEST_THRESHOLD_MS = parseInt(
 );
 app.use(createSlowRequestLogger(SLOW_REQUEST_THRESHOLD_MS));
 
-app.use('/proxy', proxyHandler);
+// Enable after: https://github.com/kyma-project/busola/issues/5299
+// app.use('/proxy', proxyHandler);
 
 app.get('/backend/kubeconfig', (req, res) => {
   const kubeconfigDir = path.join(

--- a/kyma/environments/dev/config.yaml
+++ b/kyma/environments/dev/config.yaml
@@ -54,7 +54,7 @@ config:
     EXTENSIBILITY_INJECTIONS:
       isEnabled: true
     EXTENSIBILITY_CUSTOM_COMPONENTS:
-      isEnabled: true
+      isEnabled: false
     EXTENSIBILITY_WIZARD:
       isEnabled: false
     KYMA_COMPANION:

--- a/kyma/environments/stage/config.yaml
+++ b/kyma/environments/stage/config.yaml
@@ -53,7 +53,7 @@ config:
     EXTENSIBILITY_INJECTIONS:
       isEnabled: true
     EXTENSIBILITY_CUSTOM_COMPONENTS:
-      isEnabled: true
+      isEnabled: false
     EXTENSIBILITY_WIZARD:
       isEnabled: false
     KYMA_COMPANION:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- chore: Disable the `/proxy` CORS endpoint again — it can be abused for Server-Side Request Forgery (SSRF), so it stays off until it is properly secured (`backend/index.js`, import and route commented out).
- chore: Disable `EXTENSIBILITY_CUSTOM_COMPONENTS` on `dev` and `stage`, since that feature relies on the `/proxy` endpoint.

**Related issue(s)**

Re-enabling the endpoint (with SSRF protection) is tracked in #5299

**Definition of done**

- [x] The PR's title starts with one of the following prefixes:
  - feat: A new feature
  - fix: A bug fix
  - docs: Documentation only changes
  - refactor: A code change that neither fixes a bug nor adds a feature
  - test: Adding tests
  - revert: Revert commit
  - chore: Maintainance changes to the build process or auxiliary tools, libraries, workflows, etc.
- [x] Related issues are linked. To link internal trackers, use the issue IDs like `backlog#4567`
- [x] Explain clearly why you created the PR and what changes it introduces
- [x] All necessary steps are delivered, for example, tests, documentation, merging
